### PR TITLE
fix: use node18 target for pkg binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
         run: pnpm build
 
       - name: Build standalone binary
-        run: npx pkg dist/index.js --target node20-${{ matrix.target }} --output ${{ matrix.artifact }}
+        run: npx pkg dist/index.js --target node18-${{ matrix.target }} --output ${{ matrix.artifact }}
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the binary build failure in the release workflow by changing the pkg target from `node20` to `node18`.

## Problem

The release workflow was failing with:
```
Error! No available node version satisfies 'node20'
```

This is because `pkg@5.8.1` does not support `node20` as a target version.

## Solution

Changed the pkg target from `node20-${target}` to `node18-${target}` in the release workflow. Node.js 20 is still used as the build environment (which is fine), but pkg must use node18 targets.

## Changes

- Updated `.github/workflows/release.yml` to use `node18` instead of `node20` for pkg targets

## Testing

- Verified locally that `node18-linux-x64` is a valid pkg target
- All matrix targets (linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64) will now use node18

Fixes the binary build failures in the release workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release workflow adjustment**
> 
> - Updates `Build standalone binary` step in `.github/workflows/release.yml` to use `pkg` target `node18-${{ matrix.target }}` instead of `node20-${{ matrix.target }}` for all matrix builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea0ce161994978fc99d43ee38ec8f558b79b50bb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->