### PR TITLE
fix: close tracking and security fidelity gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ tuck restore --all
 | `tuck config remote` | Configure git provider (GitHub/GitLab/local) |
 | `tuck config wizard` | Interactive configuration setup              |
 
+### Diagnostics
+
+| Command         | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `tuck doctor`   | Run repository health and safety diagnostics         |
+
+`tuck doctor` flags:
+- `--json`: Machine-readable output for CI
+- `--strict`: Treat warnings as non-zero exit
+- `--category <env|repo|manifest|security|hooks>`: Run one check group
+
 ## How It Works
 
 tuck stores your dotfiles in `~/.tuck`, organized by category:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Configure tuck via `~/.tuck/.tuckrc.json` or `tuck config wizard`:
 ### File Strategies
 
 - **copy** (default) — Files are copied. Run `tuck sync` to update the repo.
-- **symlink** — Files are symlinked. Changes are instant but require more care.
+- **symlink** — tuck copies the file into the repo, then replaces the original path with a symlink to the repo file. Changes are instant, but this modifies your home dotfile paths.
 
 ## Windows Support
 

--- a/docs/TUCK_DOCTOR_PLAN.md
+++ b/docs/TUCK_DOCTOR_PLAN.md
@@ -1,0 +1,100 @@
+# Tuck Doctor Plan
+
+## Summary
+`tuck doctor` will be a read-only diagnostics command that validates installation health, repository integrity, and safety posture. It should produce human-friendly output by default and machine-readable JSON for CI.
+
+## Goals
+- Detect common setup and runtime issues before `add`, `sync`, `apply`, and `restore` fail.
+- Catch risky states early (unsafe manifest entries, missing backups/secrets config, git misconfiguration).
+- Provide concrete, fix-oriented guidance for each failing check.
+- Stay non-destructive by default.
+
+## Non-Goals
+- Automatic repair in v1 (`--fix` deferred to later release).
+- Network-heavy remote diagnostics beyond lightweight `git remote` validation.
+
+## Command Contract
+- Command: `tuck doctor`
+- Flags:
+  - `--json`: Emit structured JSON report.
+  - `--strict`: Exit non-zero on warnings (default: non-zero only for failures).
+  - `--category <name>`: Run only one category (`env|repo|manifest|security|hooks`).
+- Exit codes:
+  - `0`: All checks pass.
+  - `1`: At least one failure.
+  - `2`: Warnings only with `--strict`.
+
+## Check Categories
+
+### 1) Environment
+- Node version is supported.
+- `pnpm` available when project scripts require it.
+- TTY capability and fallback behavior are sane.
+
+### 2) Repository
+- `~/.tuck` exists and contains `.git`.
+- Manifest and config files are present and parseable.
+- Working tree sanity (`git status`) and branch tracking.
+
+### 3) Manifest Integrity
+- Validate with `tuckManifestSchema`.
+- Validate each `source` with `validateSafeSourcePath`.
+- Validate each `destination` with `validateSafeManifestDestination`.
+- Ensure destination resolves within tuck root (`validatePathWithinRoot`).
+- Detect duplicate normalized `source` or destination collisions.
+
+### 4) Security Posture
+- Secret scanning config is enabled/reasonable.
+- Hooks trust model warnings (`trustHooks` usage).
+- Backup/snapshot settings present for destructive flows.
+
+### 5) Hooks and Integrations
+- Hook command strings are syntactically valid and executable context is clear.
+- Optional check: GH CLI availability when configured workflows depend on it.
+
+## Output Shape (JSON)
+```json
+{
+  "summary": {
+    "passed": 0,
+    "warnings": 0,
+    "failed": 0
+  },
+  "checks": [
+    {
+      "id": "manifest.safe-destination",
+      "category": "manifest",
+      "status": "pass|warn|fail",
+      "message": "...",
+      "details": "...",
+      "fix": "..."
+    }
+  ]
+}
+```
+
+## Implementation Plan
+1. Add `src/commands/doctor.ts` and register in `src/index.ts`.
+2. Add typed check runner framework in `src/lib/doctor.ts`:
+   - `DoctorCheck`, `DoctorResult`, `DoctorReport`.
+   - Category filtering and strict-mode exit mapping.
+3. Implement read-only checks by category using existing path/schema/security utilities.
+4. Add UI formatter:
+   - Default: grouped table + concise fix hints.
+   - `--json`: deterministic object output.
+5. Add tests:
+   - Unit tests for check runner and each check.
+   - Command tests for exit behavior and JSON format.
+   - Security regression tests for malicious manifest inputs.
+6. Add docs updates in `docs/TESTING.md` and README command list.
+
+## Acceptance Criteria
+- `tuck doctor` returns actionable output in <2s on normal repos.
+- Fails on unsafe manifest entries and clearly identifies offending keys.
+- JSON output is stable and CI-consumable.
+- Tests cover pass/warn/fail/strict paths and malformed manifest cases.
+
+## Assumptions and Defaults
+- Best-practice default: non-destructive diagnostics only.
+- Best-practice default: warnings do not fail unless `--strict`.
+- Best-practice default: local checks first; avoid network dependence.

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { prompts, logger } from '../ui/index.js';
-import { getTuckDir, getDestinationPathFromSource } from '../lib/paths.js';
+import { getTuckDir } from '../lib/paths.js';
 import { loadManifest } from '../lib/manifest.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
 import { NotInitializedError } from '../errors.js';
@@ -19,10 +19,18 @@ const addFiles = async (
   tuckDir: string,
   options: AddOptions
 ): Promise<void> => {
-  const filesToTrack: FileToTrack[] = filesToAdd.map((f) => ({
-    path: f.source,
-    category: f.category,
-  }));
+  const filesToTrack: FileToTrack[] = filesToAdd.map((f) => {
+    const trackedFile: FileToTrack = {
+      path: f.source,
+      category: f.category,
+    };
+
+    if (f.nameOverride) {
+      trackedFile.name = f.nameOverride;
+    }
+
+    return trackedFile;
+  });
 
   await trackFilesWithProgress(filesToTrack, tuckDir, {
     showCategory: true,
@@ -81,7 +89,6 @@ const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
 
     const selectedCategory = await prompts.select('Category:', categoryOptions);
     file.category = selectedCategory as string;
-    file.destination = getDestinationPathFromSource(tuckDir, file.category, file.source);
   }
 
   const confirm = await prompts.confirm(

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -10,6 +10,7 @@ import {
   detectCategory,
   sanitizeFilename,
   getDestinationPath,
+  validateSafeSourcePath,
 } from '../lib/paths.js';
 import { isFileTracked, loadManifest } from '../lib/manifest.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
@@ -125,6 +126,7 @@ const validateAndPrepareFiles = async (
   for (const path of paths) {
     const expandedPath = expandPath(path);
     const collapsedPath = collapsePath(expandedPath);
+    validateSafeSourcePath(collapsedPath);
 
     // SECURITY: Block private keys
     if (isPrivateKey(collapsedPath)) {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,252 +1,29 @@
 import { Command } from 'commander';
-import { basename } from 'path';
-import { prompts, logger, colors as c } from '../ui/index.js';
-import {
-  getTuckDir,
-  expandPath,
-  collapsePath,
-  pathExists,
-  isDirectory,
-  detectCategory,
-  sanitizeFilename,
-  getDestinationPath,
-  validateSafeSourcePath,
-} from '../lib/paths.js';
-import { isFileTracked, loadManifest } from '../lib/manifest.js';
+import { prompts, logger } from '../ui/index.js';
+import { getTuckDir, getDestinationPathFromSource } from '../lib/paths.js';
+import { loadManifest } from '../lib/manifest.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
-import {
-  NotInitializedError,
-  FileNotFoundError,
-  FileAlreadyTrackedError,
-  SecretsDetectedError,
-  PrivateKeyError,
-  OperationCancelledError,
-} from '../errors.js';
+import { NotInitializedError } from '../errors.js';
 import { CATEGORIES } from '../constants.js';
 import type { AddOptions } from '../types.js';
-import { getDirectoryFileCount, checkFileSizeThreshold, formatFileSize } from '../lib/files.js';
-import { shouldExcludeFromBin } from '../lib/binary.js';
-import { addToTuckignore, isIgnored } from '../lib/tuckignore.js';
-import { loadConfig } from '../lib/config.js';
-import { logForceSecretBypass } from '../lib/audit.js';
 import {
-  scanForSecrets,
-  shouldBlockOnSecrets,
-  processSecretsForRedaction,
-  redactFile,
-  getSecretsPath,
-  type ScanSummary,
-} from '../lib/secrets/index.js';
+  preparePathsForTracking,
+  type PreparedTrackFile,
+  type TrackPathCandidate,
+} from '../lib/trackPipeline.js';
 
-// SSH private key patterns - NEVER allow these
-const PRIVATE_KEY_PATTERNS = [
-  /^id_rsa$/,
-  /^id_dsa$/,
-  /^id_ecdsa$/,
-  /^id_ed25519$/,
-  /^id_.*$/, // Any id_ file without .pub
-  /\.pem$/,
-  /\.key$/,
-  /^.*_key$/, // aws_key, github_key, etc.
-];
-
-// Files that should trigger a warning
-const SENSITIVE_FILE_PATTERNS = [
-  /^\.netrc$/,
-  /^\.aws\/credentials$/,
-  /^\.docker\/config\.json$/,
-  /^\.npmrc$/, // May contain tokens
-  /^\.pypirc$/,
-  /^\.kube\/config$/,
-  /^\.ssh\/config$/,
-  /^\.gnupg\//,
-  /credentials/i,
-  /secrets?/i,
-  /tokens?\.json$/i,
-  /\.env$/,
-  /\.env\./,
-];
-
-/**
- * Check if a path is a private key (should never be tracked)
- */
-const isPrivateKey = (path: string): boolean => {
-  const name = basename(path);
-
-  // SSH private keys (without .pub extension)
-  if (path.includes('.ssh/') && !name.endsWith('.pub')) {
-    for (const pattern of PRIVATE_KEY_PATTERNS) {
-      if (pattern.test(name)) {
-        return true;
-      }
-    }
-  }
-
-  // Other private key patterns
-  if (name.endsWith('.pem') || name.endsWith('.key')) {
-    return true;
-  }
-
-  return false;
-};
-
-/**
- * Check if a path contains potentially sensitive data
- */
-const isSensitiveFile = (path: string): boolean => {
-  // Strip ~/ prefix if present, since patterns with ^ anchor expect paths without it
-  // e.g., ~/.netrc should match /^\.netrc$/ pattern
-  const pathToTest = path.startsWith('~/') ? path.slice(2) : path;
-
-  for (const pattern of SENSITIVE_FILE_PATTERNS) {
-    if (pattern.test(pathToTest)) {
-      return true;
-    }
-  }
-  return false;
-};
-
-interface FileToAdd {
-  source: string;
-  destination: string;
-  category: string;
-  filename: string;
-  isDir: boolean;
-  fileCount: number;
-  sensitive: boolean;
-}
-
-const validateAndPrepareFiles = async (
-  paths: string[],
-  tuckDir: string,
-  options: AddOptions
-): Promise<FileToAdd[]> => {
-  const filesToAdd: FileToAdd[] = [];
-
-  for (const path of paths) {
-    const expandedPath = expandPath(path);
-    const collapsedPath = collapsePath(expandedPath);
-    validateSafeSourcePath(collapsedPath);
-
-    // SECURITY: Block private keys
-    if (isPrivateKey(collapsedPath)) {
-      throw new PrivateKeyError(path);
-    }
-
-    // Check if file exists
-    if (!(await pathExists(expandedPath))) {
-      throw new FileNotFoundError(path);
-    }
-
-    // Check if already tracked
-    if (await isFileTracked(tuckDir, collapsedPath)) {
-      throw new FileAlreadyTrackedError(path);
-    }
-
-    // Check if in .tuckignore
-    if (await isIgnored(tuckDir, collapsedPath)) {
-      logger.info(`Skipping ${path} (in .tuckignore)`);
-      continue;
-    }
-
-    // Check if binary executable in bin directory
-    if (await shouldExcludeFromBin(expandedPath)) {
-      const sizeCheck = await checkFileSizeThreshold(expandedPath);
-      logger.info(
-        `Skipping binary executable: ${path}${sizeCheck.size > 0 ? ` (${formatFileSize(sizeCheck.size)})` : ''}` +
-          ` - Add to .tuckignore to customize`
-      );
-      continue;
-    }
-
-    // Check file size
-    const sizeCheck = await checkFileSizeThreshold(expandedPath);
-
-    if (sizeCheck.block) {
-      // >= 100MB: Block and offer to ignore
-      logger.warning(
-        `File ${path} is ${formatFileSize(sizeCheck.size)} (exceeds GitHub's 100MB limit)`
-      );
-
-      const action = await prompts.select('How would you like to proceed?', [
-        { value: 'ignore', label: 'Add to .tuckignore and skip' },
-        { value: 'cancel', label: 'Cancel operation' },
-      ]);
-
-      if (action === 'ignore') {
-        await addToTuckignore(tuckDir, collapsedPath);
-        logger.success(`Added ${path} to .tuckignore`);
-        continue; // Skip this file
-      } else {
-        throw new OperationCancelledError('file size exceeds GitHub limit');
-      }
-    }
-
-    if (sizeCheck.warn) {
-      // 50-100MB: Warn and confirm
-      logger.warning(
-        `File ${path} is ${formatFileSize(sizeCheck.size)}. ` +
-          `GitHub recommends files under 50MB.`
-      );
-
-      const action = await prompts.select('How would you like to proceed?', [
-        { value: 'continue', label: 'Track it anyway' },
-        { value: 'ignore', label: 'Add to .tuckignore and skip' },
-        { value: 'cancel', label: 'Cancel operation' },
-      ]);
-
-      if (action === 'ignore') {
-        await addToTuckignore(tuckDir, collapsedPath);
-        logger.success(`Added ${path} to .tuckignore`);
-        continue;
-      } else if (action === 'cancel') {
-        throw new OperationCancelledError('file size warning');
-      }
-      // 'continue' falls through to track the file
-    }
-
-    // Determine if it's a directory
-    const isDir = await isDirectory(expandedPath);
-    const fileCount = isDir ? await getDirectoryFileCount(expandedPath) : 1;
-
-    // Determine category
-    const category = options.category || detectCategory(expandedPath);
-
-    // Generate filename for storage
-    const filename = options.name || sanitizeFilename(expandedPath);
-
-    // Determine destination path
-    const destination = getDestinationPath(tuckDir, category, filename);
-
-    // Check if sensitive
-    const sensitive = isSensitiveFile(collapsedPath);
-
-    filesToAdd.push({
-      source: collapsedPath,
-      destination,
-      category,
-      filename,
-      isDir,
-      fileCount,
-      sensitive,
-    });
-  }
-
-  return filesToAdd;
-};
+type FileToAdd = PreparedTrackFile;
 
 const addFiles = async (
   filesToAdd: FileToAdd[],
   tuckDir: string,
   options: AddOptions
 ): Promise<void> => {
-  // Convert FileToAdd to FileToTrack
   const filesToTrack: FileToTrack[] = filesToAdd.map((f) => ({
     path: f.source,
     category: f.category,
   }));
 
-  // Use the shared tracking utility
   await trackFilesWithProgress(filesToTrack, tuckDir, {
     showCategory: true,
     strategy: options.symlink ? 'symlink' : undefined,
@@ -254,205 +31,9 @@ const addFiles = async (
   });
 };
 
-// ============================================================================
-// Secret Scanning Integration
-// ============================================================================
-
-/**
- * Display scan results in a formatted way
- */
-const displaySecretWarning = (summary: ScanSummary): void => {
-  console.log();
-  console.log(
-    c.error(c.bold(`  Security Warning: Found ${summary.totalSecrets} potential secret(s)`))
-  );
-  console.log();
-
-  for (const result of summary.results) {
-    console.log(`  ${c.brand(result.collapsedPath)}`);
-
-    for (const match of result.matches) {
-      const severityColor =
-        match.severity === 'critical'
-          ? c.error
-          : match.severity === 'high'
-            ? c.warning
-            : match.severity === 'medium'
-              ? c.info
-              : c.muted;
-
-      console.log(
-        `    ${c.muted(`Line ${match.line}:`)} ${match.redactedValue} ${severityColor(`[${match.severity}]`)}`
-      );
-    }
-    console.log();
-  }
-};
-
-/**
- * Handle secret detection with interactive user prompt
- * Returns true if operation should continue, false if aborted
- */
-const handleSecretsDetected = async (
-  summary: ScanSummary,
-  filesToAdd: FileToAdd[],
-  tuckDir: string
-): Promise<{ continue: boolean; filesToAdd: FileToAdd[] }> => {
-  displaySecretWarning(summary);
-
-  const action = await prompts.select('How would you like to proceed?', [
-    {
-      value: 'abort',
-      label: 'Abort operation',
-      hint: 'Do not track these files',
-    },
-    {
-      value: 'redact',
-      label: 'Replace with placeholders',
-      hint: 'Store originals in secrets.local.json (never committed)',
-    },
-    {
-      value: 'ignore',
-      label: 'Add files to .tuckignore',
-      hint: 'Skip these files permanently',
-    },
-    {
-      value: 'proceed',
-      label: 'Proceed anyway',
-      hint: 'Track files with secrets (dangerous!)',
-    },
-  ]);
-
-  switch (action) {
-    case 'abort':
-      logger.info('Operation aborted');
-      return { continue: false, filesToAdd: [] };
-
-    case 'redact': {
-      // Process secrets for redaction
-      const redactionMaps = await processSecretsForRedaction(summary.results, tuckDir);
-
-      // Redact each file
-      let totalRedacted = 0;
-      for (const result of summary.results) {
-        const placeholderMap = redactionMaps.get(result.path);
-        if (placeholderMap && placeholderMap.size > 0) {
-          const redactionResult = await redactFile(result.path, result.matches, placeholderMap);
-          totalRedacted += redactionResult.replacements.length;
-        }
-      }
-
-      console.log();
-      logger.success(`Replaced ${totalRedacted} secret(s) with placeholders`);
-      logger.dim(`Secrets stored in: ${collapsePath(getSecretsPath(tuckDir))} (never committed)`);
-      logger.dim("Run 'tuck secrets list' to see stored secrets");
-      console.log();
-
-      return { continue: true, filesToAdd };
-    }
-
-    case 'ignore': {
-      // Add files with secrets to .tuckignore
-      const filesWithSecrets = new Set(summary.results.map((r) => r.collapsedPath));
-
-      for (const file of filesToAdd) {
-        // Normalize both paths for comparison using collapsePath
-        const normalizedFileSource = collapsePath(file.source);
-        if (filesWithSecrets.has(normalizedFileSource)) {
-          await addToTuckignore(tuckDir, file.source);
-          logger.success(`Added ${normalizedFileSource} to .tuckignore`);
-        }
-      }
-
-      // Remove files with secrets from the list
-      const remainingFiles = filesToAdd.filter((f) => {
-        const normalizedSource = collapsePath(f.source);
-        return !filesWithSecrets.has(normalizedSource);
-      });
-
-      if (remainingFiles.length === 0) {
-        logger.info('No files remaining to track');
-        return { continue: false, filesToAdd: [] };
-      }
-
-      return { continue: true, filesToAdd: remainingFiles };
-    }
-
-    case 'proceed': {
-      // Double-confirm for dangerous action
-      const confirmed = await prompts.confirm(
-        c.error('Are you SURE you want to track files containing secrets?'),
-        false
-      );
-
-      if (!confirmed) {
-        logger.info('Operation aborted');
-        return { continue: false, filesToAdd: [] };
-      }
-
-      logger.warning('Proceeding with secrets - be careful not to push to a public repository!');
-      return { continue: true, filesToAdd };
-    }
-
-    default:
-      return { continue: false, filesToAdd: [] };
-  }
-};
-
-/**
- * Scan files for secrets and handle results
- * Returns updated filesToAdd list (may be modified by user choices)
- */
-const scanAndHandleSecrets = async (
-  filesToAdd: FileToAdd[],
-  tuckDir: string,
-  options: AddOptions
-): Promise<{ continue: boolean; filesToAdd: FileToAdd[] }> => {
-  // Check if scanning is enabled
-  const config = await loadConfig(tuckDir);
-  const security = config.security || {};
-
-  // Skip scanning if disabled in config
-  if (security.scanSecrets === false) {
-    return { continue: true, filesToAdd };
-  }
-
-  // If --force is used, require explicit confirmation
-  if (options.force) {
-    const confirmed = await prompts.confirmDangerous(
-      'Using --force bypasses secret scanning.\n' +
-        'Any secrets in these files may be committed to git and potentially exposed.',
-      'force'
-    );
-    if (!confirmed) {
-      logger.info('Operation cancelled');
-      return { continue: false, filesToAdd: [] };
-    }
-    logger.warning('Secret scanning bypassed with --force');
-    // Audit log for security tracking
-    await logForceSecretBypass('tuck add --force', filesToAdd.length);
-    return { continue: true, filesToAdd };
-  }
-
-  // Get file paths for scanning
-  const filePaths = filesToAdd.map((f) => expandPath(f.source));
-
-  // Scan files
-  const summary = await scanForSecrets(filePaths, tuckDir);
-
-  // If no secrets found, continue normally
-  if (summary.filesWithSecrets === 0) {
-    return { continue: true, filesToAdd };
-  }
-
-  // Handle detected secrets
-  return handleSecretsDetected(summary, filesToAdd, tuckDir);
-};
-
 const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
   prompts.intro('tuck add');
 
-  // Ask for paths
   const pathsInput = await prompts.text('Enter file paths to track (space-separated):', {
     placeholder: '~/.zshrc ~/.gitconfig',
     validate: (value) => {
@@ -462,11 +43,14 @@ const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
   });
 
   const paths = pathsInput.split(/\s+/).filter(Boolean);
+  const candidates: TrackPathCandidate[] = paths.map((path) => ({ path }));
 
-  // Validate and prepare
   let filesToAdd: FileToAdd[];
   try {
-    filesToAdd = await validateAndPrepareFiles(paths, tuckDir, {});
+    filesToAdd = await preparePathsForTracking(candidates, tuckDir, {
+      secretHandling: 'interactive',
+      forceBypassCommand: 'tuck add --force',
+    });
   } catch (error) {
     if (error instanceof Error) {
       prompts.log.error(error.message);
@@ -475,7 +59,11 @@ const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
     return;
   }
 
-  // Show what will be added and ask for category confirmation
+  if (filesToAdd.length === 0) {
+    logger.info('No files to add');
+    return;
+  }
+
   for (const file of filesToAdd) {
     prompts.log.step(`${file.source}`);
 
@@ -485,7 +73,6 @@ const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
       hint: file.category === name ? '(auto-detected)' : undefined,
     }));
 
-    // Move detected category to top
     categoryOptions.sort((a, b) => {
       if (a.value === file.category) return -1;
       if (b.value === file.category) return 1;
@@ -494,12 +81,9 @@ const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
 
     const selectedCategory = await prompts.select('Category:', categoryOptions);
     file.category = selectedCategory as string;
-
-    // Update destination with new category
-    file.destination = getDestinationPath(tuckDir, file.category, file.filename);
+    file.destination = getDestinationPathFromSource(tuckDir, file.category, file.source);
   }
 
-  // Confirm
   const confirm = await prompts.confirm(
     `Add ${filesToAdd.length} ${filesToAdd.length === 1 ? 'file' : 'files'}?`,
     true
@@ -510,7 +94,6 @@ const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
     return;
   }
 
-  // Add files
   await addFiles(filesToAdd, tuckDir, {});
 
   prompts.outro(`Added ${filesToAdd.length} ${filesToAdd.length === 1 ? 'file' : 'files'}`);
@@ -518,9 +101,8 @@ const runInteractiveAdd = async (tuckDir: string): Promise<void> => {
 };
 
 /**
- * Add files programmatically (used by scan command)
- * Note: Throws SecretsDetectedError if secrets are found (unless --force is used)
- * Callers should catch this error and handle it appropriately
+ * Add files programmatically (used by scan/sync flows)
+ * Note: Throws SecretsDetectedError when configured to block.
  */
 export const addFilesFromPaths = async (
   paths: string[],
@@ -528,57 +110,37 @@ export const addFilesFromPaths = async (
 ): Promise<number> => {
   const tuckDir = getTuckDir();
 
-  // Verify tuck is initialized
   try {
     await loadManifest(tuckDir);
   } catch {
     throw new NotInitializedError();
   }
 
-  // Validate and prepare files
-  const filesToAdd = await validateAndPrepareFiles(paths, tuckDir, options);
+  const candidates: TrackPathCandidate[] = paths.map((path) => ({
+    path,
+    category: options.category,
+    name: options.name,
+  }));
+
+  const filesToAdd = await preparePathsForTracking(candidates, tuckDir, {
+    category: options.category,
+    name: options.name,
+    force: options.force,
+    secretHandling: 'strict',
+    forceBypassCommand: 'tuck add --force',
+  });
 
   if (filesToAdd.length === 0) {
     return 0;
   }
 
-  // Scan for secrets (unless --force is used)
-  if (!options.force) {
-    const config = await loadConfig(tuckDir);
-    const security = config.security || {};
-
-    if (security.scanSecrets !== false) {
-      const filePaths = filesToAdd.map((f) => expandPath(f.source));
-      const summary = await scanForSecrets(filePaths, tuckDir);
-
-      if (summary.filesWithSecrets > 0) {
-        // Check if we should block or just warn
-        const shouldBlock = await shouldBlockOnSecrets(tuckDir);
-        if (shouldBlock) {
-          // Throw error to prevent silently adding files with secrets
-          const filesWithSecrets = summary.results
-            .filter((r) => r.hasSecrets)
-            .map((r) => collapsePath(r.path));
-          throw new SecretsDetectedError(summary.totalSecrets, filesWithSecrets);
-        } else {
-          // Warn but continue
-          logger.warning('Secrets detected but blockOnSecrets is disabled - proceeding with add');
-          logger.warning('Make sure your repository is private!');
-        }
-      }
-    }
-  }
-
-  // Add files
   await addFiles(filesToAdd, tuckDir, options);
-
   return filesToAdd.length;
 };
 
 const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
   const tuckDir = getTuckDir();
 
-  // Verify tuck is initialized
   try {
     await loadManifest(tuckDir);
   } catch {
@@ -590,35 +152,32 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
     return;
   }
 
-  // Validate and prepare files
-  let filesToAdd = await validateAndPrepareFiles(paths, tuckDir, options);
+  const candidates: TrackPathCandidate[] = paths.map((path) => ({
+    path,
+    category: options.category,
+    name: options.name,
+  }));
+
+  const filesToAdd = await preparePathsForTracking(candidates, tuckDir, {
+    category: options.category,
+    name: options.name,
+    force: options.force,
+    secretHandling: 'interactive',
+    forceBypassCommand: 'tuck add --force',
+  });
 
   if (filesToAdd.length === 0) {
     logger.info('No files to add');
     return;
   }
 
-  // Scan for secrets (unless --force is used)
-  const secretScanResult = await scanAndHandleSecrets(filesToAdd, tuckDir, options);
-  if (!secretScanResult.continue) {
-    return;
-  }
-  filesToAdd = secretScanResult.filesToAdd;
-
-  if (filesToAdd.length === 0) {
-    return;
-  }
-
-  // Add files
   await addFiles(filesToAdd, tuckDir, options);
 
-  // Ask if user wants to sync now
   console.log();
   const shouldSync = await prompts.confirm('Would you like to sync these changes now?', true);
 
   if (shouldSync) {
     console.log();
-    // Dynamically import sync to avoid circular dependencies
     const { runSync } = await import('./sync.js');
     await runSync({});
   } else {
@@ -632,11 +191,8 @@ export const addCommand = new Command('add')
   .argument('[paths...]', 'Paths to dotfiles to track')
   .option('-c, --category <name>', 'Category to organize under')
   .option('-n, --name <name>', 'Custom name for the file in manifest')
-  .option('--symlink', 'Create symlink instead of copy')
+  .option('--symlink', 'Copy into tuck repo, then replace source path with a symlink')
   .option('-f, --force', 'Skip secret scanning (not recommended)')
-  // TODO: Encryption and templating are planned for a future version
-  // .option('--encrypt', 'Encrypt this file (requires GPG setup)')
-  // .option('--template', 'Treat as template with variable substitution')
   .action(async (paths: string[], options: AddOptions) => {
     await runAdd(paths, options);
   });

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -696,7 +696,7 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
 /**
  * Run non-interactive apply
  */
-const runApply = async (source: string, options: ApplyOptions): Promise<void> => {
+export const runApply = async (source: string, options: ApplyOptions): Promise<void> => {
   // Resolve the source
   const { repoId, isUrl } = await resolveSource(source);
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,8 +1,15 @@
 import { Command } from 'commander';
-import { join } from 'path';
 import { prompts, logger } from '../ui/index.js';
 import { colors as c } from '../ui/theme.js';
-import { getTuckDir, expandPath, pathExists, collapsePath, isDirectory } from '../lib/paths.js';
+import {
+  getTuckDir,
+  expandPath,
+  pathExists,
+  collapsePath,
+  isDirectory,
+  validateSafeSourcePath,
+  getSafeRepoPathFromDestination,
+} from '../lib/paths.js';
 import { loadManifest, getAllTrackedFiles, getTrackedFileBySource } from '../lib/manifest.js';
 import { getDiff } from '../lib/git.js';
 import {
@@ -43,8 +50,9 @@ const getFileDiff = async (tuckDir: string, source: string): Promise<FileDiff | 
     throw new FileNotFoundError(`Not tracked: ${source}`);
   }
 
+  validateSafeSourcePath(tracked.file.source);
   const systemPath = expandPath(source);
-  const repoPath = join(tuckDir, tracked.file.destination);
+  const repoPath = getSafeRepoPathFromDestination(tuckDir, tracked.file.destination);
 
   const diff: FileDiff = {
     source,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,93 @@
+import { Command } from 'commander';
+import { logger, prompts } from '../ui/index.js';
+import {
+  DOCTOR_CATEGORIES,
+  getDoctorExitCode,
+  runDoctorChecks,
+  type DoctorCategory,
+  type DoctorReport,
+} from '../lib/doctor.js';
+import type { DoctorOptions } from '../types.js';
+
+const isDoctorCategory = (value: string): value is DoctorCategory => {
+  return (DOCTOR_CATEGORIES as readonly string[]).includes(value);
+};
+
+const formatCheckId = (id: string): string => {
+  return id.replace('.', ': ');
+};
+
+const printHumanReport = (report: DoctorReport): void => {
+  prompts.intro('tuck doctor');
+
+  for (const check of report.checks) {
+    const label = `[${check.category}] ${formatCheckId(check.id)} - ${check.message}`;
+
+    if (check.status === 'pass') {
+      logger.success(label);
+    } else if (check.status === 'warn') {
+      logger.warning(label);
+    } else {
+      logger.error(label);
+    }
+
+    if (check.details) {
+      logger.dim(`  Details: ${check.details}`);
+    }
+    if (check.fix) {
+      logger.dim(`  Fix: ${check.fix}`);
+    }
+  }
+
+  logger.blank();
+  logger.info(
+    `Summary: ${report.summary.passed} passed, ${report.summary.warnings} warnings, ${report.summary.failed} failed`
+  );
+};
+
+export const runDoctor = async (options: DoctorOptions = {}): Promise<DoctorReport> => {
+  const report = await runDoctorChecks({
+    category: options.category,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHumanReport(report);
+  }
+
+  const exitCode = getDoctorExitCode(report, options.strict);
+  process.exitCode = exitCode;
+
+  if (!options.json) {
+    if (exitCode === 0) {
+      prompts.outro('Doctor checks completed successfully');
+    } else if (exitCode === 2) {
+      prompts.outro('Doctor completed with warnings (strict mode enabled)');
+    } else {
+      prompts.outro('Doctor found blocking issues');
+    }
+  }
+
+  return report;
+};
+
+export const doctorCommand = new Command('doctor')
+  .description('Run repository health and safety diagnostics')
+  .option('--json', 'Output as JSON')
+  .option('--strict', 'Exit non-zero on warnings')
+  .option(
+    '-c, --category <category>',
+    `Run only one category (${DOCTOR_CATEGORIES.join('|')})`,
+    (value: string): DoctorCategory => {
+      if (!isDoctorCategory(value)) {
+        throw new Error(
+          `Invalid category "${value}". Expected one of: ${DOCTOR_CATEGORIES.join(', ')}`
+        );
+      }
+      return value;
+    }
+  )
+  .action(async (options: DoctorOptions) => {
+    await runDoctor(options);
+  });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,3 +14,4 @@ export { undoCommand } from './undo.js';
 export { scanCommand } from './scan.js';
 export { secretsCommand } from './secrets.js';
 export { encryptionCommand } from './encryption.js';
+export { doctorCommand } from './doctor.js';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -47,7 +47,7 @@ import {
   getGitHubCLIInstallInstructions,
   storeGitHubCredentials,
   detectTokenType,
-  configureGitCredentialHelper,
+  configureGitCredentialHelperWithOptions,
   testStoredCredentials,
   diagnoseAuthIssue,
   MIN_GITHUB_TOKEN_LENGTH,
@@ -62,6 +62,7 @@ import { CATEGORIES } from '../constants.js';
 import { defaultConfig } from '../schemas/config.schema.js';
 import type { InitOptions } from '../types.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
+import { preparePathsForTracking } from '../lib/trackPipeline.js';
 import { errorToMessage } from '../lib/validation.js';
 
 const GITIGNORE_TEMPLATE = `# OS generated files
@@ -90,9 +91,21 @@ const trackFilesWithProgressInit = async (
   selectedPaths: string[],
   tuckDir: string
 ): Promise<number> => {
-  // Convert paths to FileToTrack
-  const filesToTrack: FileToTrack[] = selectedPaths.map((path) => ({
-    path,
+  const prepared = await preparePathsForTracking(
+    selectedPaths.map((path) => ({ path })),
+    tuckDir,
+    {
+      secretHandling: 'interactive',
+    }
+  );
+
+  if (prepared.length === 0) {
+    return 0;
+  }
+
+  const filesToTrack: FileToTrack[] = prepared.map((file) => ({
+    path: file.source,
+    category: file.category,
   }));
 
   // Use the shared tracking utility
@@ -542,11 +555,27 @@ const setupTokenAuth = async (
     prompts.log.info('You may be prompted for credentials when pushing');
   }
 
-  // Configure git credential helper (best-effort; Git can still prompt for credentials if this fails)
-  await configureGitCredentialHelper().catch((error) => {
-    const errorMsg = error instanceof Error ? error.message : String(error);
-    logger?.debug?.(`Failed to configure git credential helper (non-fatal): ${errorMsg}`);
-  });
+  const configureHelper = await prompts.confirm(
+    'Configure a global Git credential helper now? This updates `git config --global credential.helper`.',
+    true
+  );
+
+  if (configureHelper) {
+    await configureGitCredentialHelperWithOptions({ allowGlobalConfigChange: true }).catch(
+      (error) => {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger?.debug?.(`Failed to configure git credential helper (non-fatal): ${errorMsg}`);
+        prompts.log.warning(
+          'Could not configure a credential helper automatically. ' +
+            'Set one manually for secure token storage (osxkeychain/libsecret/manager-core).'
+        );
+      }
+    );
+  } else {
+    prompts.log.info(
+      'Skipping credential helper setup. Git may prompt for credentials unless a helper is configured.'
+    );
+  }
 
   return await promptForManualRepoUrl(tuckDir, username, 'https');
 };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1666,7 +1666,7 @@ const runInteractiveInit = async (): Promise<void> => {
   ]);
 };
 
-const runInit = async (options: InitOptions): Promise<void> => {
+export const runInit = async (options: InitOptions): Promise<void> => {
   const tuckDir = getTuckDir(options.dir);
 
   // If --from is provided, clone from remote

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -186,7 +186,7 @@ const restoreFilesInternal = async (
     // Create backup if needed
     if (shouldBackup && file.existsAtTarget) {
       await withSpinner(`Backing up ${file.source}...`, async () => {
-        await createBackup(targetPath);
+        await createBackup(targetPath, config.files.backupDir, tuckDir);
       });
     }
 
@@ -421,7 +421,7 @@ export const restoreCommand = new Command('restore')
   .description('Restore dotfiles to the system')
   .argument('[paths...]', 'Paths to restore (or use --all)')
   .option('-a, --all', 'Restore all tracked files')
-  .option('--symlink', 'Create symlinks instead of copies')
+  .option('--symlink', 'Create symlinks from source paths to tuck repo files')
   .option('--backup', 'Backup existing files before restore')
   .option('--no-backup', 'Skip backup of existing files')
   .option('--dry-run', 'Show what would be done')

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -227,7 +227,7 @@ const addFilesWithProgress = async (
 /**
  * Main scan function
  */
-const runScan = async (options: ScanOptions): Promise<void> => {
+export const runScan = async (options: ScanOptions): Promise<void> => {
   const tuckDir = getTuckDir();
 
   // Check if tuck is initialized

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -721,7 +721,7 @@ export const runSync = async (options: SyncOptions = {}): Promise<void> => {
   await runInteractiveSync(tuckDir, options);
 };
 
-const runSyncCommand = async (
+export const runSyncCommand = async (
   messageArg: string | undefined,
   options: SyncOptions
 ): Promise<void> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   scanCommand,
   secretsCommand,
   encryptionCommand,
+  doctorCommand,
 } from './commands/index.js';
 import { handleError } from './errors.js';
 import { VERSION, DESCRIPTION } from './constants.js';
@@ -56,6 +57,7 @@ program.addCommand(undoCommand);
 program.addCommand(scanCommand);
 program.addCommand(secretsCommand);
 program.addCommand(encryptionCommand);
+program.addCommand(doctorCommand);
 
 // Default action when no command is provided
 const runDefaultAction = async (): Promise<void> => {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -4,6 +4,7 @@ import { copy, ensureDir, pathExists } from 'fs-extra';
 import { BACKUP_DIR } from '../constants.js';
 import { expandPath, collapsePath, pathExists as checkPathExists } from './paths.js';
 import { toPosixPath } from './platform.js';
+import { loadConfig } from './config.js';
 
 export interface BackupInfo {
   path: string;
@@ -17,23 +18,32 @@ export interface BackupResult {
   date: Date;
 }
 
-const getBackupDir = (): string => {
-  return expandPath(BACKUP_DIR);
+const getBackupDir = async (customBackupDir?: string, tuckDir?: string): Promise<string> => {
+  if (customBackupDir) {
+    return expandPath(customBackupDir);
+  }
+
+  try {
+    const config = await loadConfig(tuckDir);
+    return expandPath(config.files.backupDir || BACKUP_DIR);
+  } catch {
+    return expandPath(BACKUP_DIR);
+  }
 };
 
 const formatDateForBackup = (date: Date): string => {
   return date.toISOString().slice(0, 10); // YYYY-MM-DD
 };
 
-const getTimestampedBackupDir = (date: Date): string => {
-  const backupRoot = getBackupDir();
+const getTimestampedBackupDir = (date: Date, backupRoot: string): string => {
   const timestamp = formatDateForBackup(date);
   return join(backupRoot, timestamp);
 };
 
 export const createBackup = async (
   sourcePath: string,
-  customBackupDir?: string
+  customBackupDir?: string,
+  tuckDir?: string
 ): Promise<BackupResult> => {
   const expandedSource = expandPath(sourcePath);
   const date = new Date();
@@ -43,10 +53,9 @@ export const createBackup = async (
   }
 
   // Create backup directory with date
-  const backupRoot = customBackupDir
-    ? expandPath(customBackupDir)
-    : getTimestampedBackupDir(date);
-  await ensureDir(backupRoot);
+  const backupRoot = await getBackupDir(customBackupDir, tuckDir);
+  const datedBackupDir = getTimestampedBackupDir(date, backupRoot);
+  await ensureDir(datedBackupDir);
 
   // Generate backup filename that preserves structure
   // Normalize to POSIX-style (forward slashes) for consistent backup naming across platforms
@@ -58,7 +67,7 @@ export const createBackup = async (
 
   // Add timestamp to handle multiple backups of same file in a day
   const timestamp = date.toISOString().replace(/[:.]/g, '-').slice(11, 19);
-  const backupPath = join(backupRoot, `${backupName}_${timestamp}`);
+  const backupPath = join(datedBackupDir, `${backupName}_${timestamp}`);
 
   await copy(expandedSource, backupPath, { overwrite: true });
 
@@ -71,20 +80,24 @@ export const createBackup = async (
 
 export const createMultipleBackups = async (
   sourcePaths: string[],
-  customBackupDir?: string
+  customBackupDir?: string,
+  tuckDir?: string
 ): Promise<BackupResult[]> => {
   const results: BackupResult[] = [];
 
   for (const path of sourcePaths) {
-    const result = await createBackup(path, customBackupDir);
+    const result = await createBackup(path, customBackupDir, tuckDir);
     results.push(result);
   }
 
   return results;
 };
 
-export const listBackups = async (): Promise<BackupInfo[]> => {
-  const backupRoot = getBackupDir();
+export const listBackups = async (
+  customBackupDir?: string,
+  tuckDir?: string
+): Promise<BackupInfo[]> => {
+  const backupRoot = await getBackupDir(customBackupDir, tuckDir);
 
   if (!(await pathExists(backupRoot))) {
     return [];
@@ -116,8 +129,13 @@ export const listBackups = async (): Promise<BackupInfo[]> => {
   return backups.sort((a, b) => b.date.getTime() - a.date.getTime());
 };
 
-export const getBackupsByDate = async (date: Date): Promise<string[]> => {
-  const backupDir = getTimestampedBackupDir(date);
+export const getBackupsByDate = async (
+  date: Date,
+  customBackupDir?: string,
+  tuckDir?: string
+): Promise<string[]> => {
+  const backupRoot = await getBackupDir(customBackupDir, tuckDir);
+  const backupDir = getTimestampedBackupDir(date, backupRoot);
 
   if (!(await pathExists(backupDir))) {
     return [];
@@ -127,7 +145,12 @@ export const getBackupsByDate = async (date: Date): Promise<string[]> => {
   return files.map((f) => join(backupDir, f));
 };
 
-export const restoreBackup = async (backupPath: string, targetPath: string): Promise<void> => {
+export const restoreBackup = async (
+  backupPath: string,
+  targetPath: string,
+  customBackupDir?: string,
+  tuckDir?: string
+): Promise<void> => {
   const expandedBackup = expandPath(backupPath);
   const expandedTarget = expandPath(targetPath);
 
@@ -137,7 +160,7 @@ export const restoreBackup = async (backupPath: string, targetPath: string): Pro
 
   // Create backup of current state before restoring
   if (await checkPathExists(expandedTarget)) {
-    await createBackup(expandedTarget);
+    await createBackup(expandedTarget, customBackupDir, tuckDir);
   }
 
   await copy(expandedBackup, expandedTarget, { overwrite: true });
@@ -151,8 +174,12 @@ export const deleteBackup = async (backupPath: string): Promise<void> => {
   }
 };
 
-export const cleanOldBackups = async (daysToKeep: number): Promise<number> => {
-  const backups = await listBackups();
+export const cleanOldBackups = async (
+  daysToKeep: number,
+  customBackupDir?: string,
+  tuckDir?: string
+): Promise<number> => {
+  const backups = await listBackups(customBackupDir, tuckDir);
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - daysToKeep);
 
@@ -168,8 +195,11 @@ export const cleanOldBackups = async (daysToKeep: number): Promise<number> => {
   return deletedCount;
 };
 
-export const getBackupSize = async (): Promise<number> => {
-  const backups = await listBackups();
+export const getBackupSize = async (
+  customBackupDir?: string,
+  tuckDir?: string
+): Promise<number> => {
+  const backups = await listBackups(customBackupDir, tuckDir);
   let totalSize = 0;
 
   for (const backup of backups) {

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -1,0 +1,684 @@
+import { join } from 'path';
+import type { TuckConfigOutput } from '../schemas/config.schema.js';
+import type { TuckManifestOutput } from '../schemas/manifest.schema.js';
+import { loadConfig } from './config.js';
+import { getStatus } from './git.js';
+import { loadManifest } from './manifest.js';
+import {
+  collapsePath,
+  expandPath,
+  getConfigPath,
+  getManifestPath,
+  getTuckDir,
+  pathExists,
+  validatePathWithinRoot,
+  validateSafeManifestDestination,
+  validateSafeSourcePath,
+} from './paths.js';
+
+export const DOCTOR_CATEGORIES = ['env', 'repo', 'manifest', 'security', 'hooks'] as const;
+
+export type DoctorCategory = (typeof DOCTOR_CATEGORIES)[number];
+export type DoctorStatus = 'pass' | 'warn' | 'fail';
+
+export interface DoctorCheckResult {
+  id: string;
+  category: DoctorCategory;
+  status: DoctorStatus;
+  message: string;
+  details?: string;
+  fix?: string;
+}
+
+export interface DoctorSummary {
+  passed: number;
+  warnings: number;
+  failed: number;
+}
+
+export interface DoctorReport {
+  generatedAt: string;
+  tuckDir: string;
+  summary: DoctorSummary;
+  checks: DoctorCheckResult[];
+}
+
+export interface DoctorRunOptions {
+  category?: DoctorCategory;
+}
+
+interface DoctorContext {
+  tuckDir: string;
+  manifestPath: string;
+  configPath: string;
+  hasTuckDir: boolean;
+  hasGitDir: boolean;
+  hasManifestFile: boolean;
+  hasConfigFile: boolean;
+  manifestLoadError?: string;
+  configLoadError?: string;
+  manifest?: TuckManifestOutput;
+  config?: TuckConfigOutput;
+}
+
+interface DoctorCheck {
+  id: string;
+  category: DoctorCategory;
+  run: (context: DoctorContext) => Promise<DoctorCheckResult>;
+}
+
+const checkNodeVersion: DoctorCheck = {
+  id: 'env.node-version',
+  category: 'env',
+  run: async () => {
+    const major = Number.parseInt(process.versions.node.split('.')[0] || '0', 10);
+    if (major >= 18) {
+      return {
+        id: 'env.node-version',
+        category: 'env',
+        status: 'pass',
+        message: `Node.js ${process.versions.node} is supported`,
+      };
+    }
+
+    return {
+      id: 'env.node-version',
+      category: 'env',
+      status: 'fail',
+      message: `Node.js ${process.versions.node} is unsupported`,
+      fix: 'Upgrade Node.js to version 18 or newer',
+    };
+  },
+};
+
+const checkHomeDirectory: DoctorCheck = {
+  id: 'env.home-directory',
+  category: 'env',
+  run: async () => {
+    const home = process.env.HOME || process.env.USERPROFILE;
+    if (!home) {
+      return {
+        id: 'env.home-directory',
+        category: 'env',
+        status: 'fail',
+        message: 'Home directory is not set',
+        fix: 'Set HOME (macOS/Linux) or USERPROFILE (Windows) before running tuck',
+      };
+    }
+
+    return {
+      id: 'env.home-directory',
+      category: 'env',
+      status: 'pass',
+      message: `Home directory resolved: ${collapsePath(home)}`,
+    };
+  },
+};
+
+const checkTuckDirectory: DoctorCheck = {
+  id: 'repo.tuck-directory',
+  category: 'repo',
+  run: async (context) => {
+    if (context.hasTuckDir) {
+      return {
+        id: 'repo.tuck-directory',
+        category: 'repo',
+        status: 'pass',
+        message: `Tuck directory exists: ${collapsePath(context.tuckDir)}`,
+      };
+    }
+
+    return {
+      id: 'repo.tuck-directory',
+      category: 'repo',
+      status: 'fail',
+      message: `Tuck directory missing: ${collapsePath(context.tuckDir)}`,
+      fix: 'Run `tuck init` to initialize this machine',
+    };
+  },
+};
+
+const checkGitDirectory: DoctorCheck = {
+  id: 'repo.git-directory',
+  category: 'repo',
+  run: async (context) => {
+    if (!context.hasTuckDir) {
+      return {
+        id: 'repo.git-directory',
+        category: 'repo',
+        status: 'warn',
+        message: 'Skipped git checks because tuck is not initialized',
+      };
+    }
+
+    if (context.hasGitDir) {
+      return {
+        id: 'repo.git-directory',
+        category: 'repo',
+        status: 'pass',
+        message: 'Git metadata is present in tuck directory',
+      };
+    }
+
+    return {
+      id: 'repo.git-directory',
+      category: 'repo',
+      status: 'fail',
+      message: 'Missing .git directory under tuck repository',
+      fix: 'Reinitialize with `tuck init` or restore the git metadata',
+    };
+  },
+};
+
+const checkGitStatusReadable: DoctorCheck = {
+  id: 'repo.git-status',
+  category: 'repo',
+  run: async (context) => {
+    if (!context.hasTuckDir || !context.hasGitDir) {
+      return {
+        id: 'repo.git-status',
+        category: 'repo',
+        status: 'warn',
+        message: 'Skipped git status check because repository is unavailable',
+      };
+    }
+
+    try {
+      await getStatus(context.tuckDir);
+      return {
+        id: 'repo.git-status',
+        category: 'repo',
+        status: 'pass',
+        message: 'Git status can be read successfully',
+      };
+    } catch (error) {
+      return {
+        id: 'repo.git-status',
+        category: 'repo',
+        status: 'fail',
+        message: 'Failed to read git status',
+        details: error instanceof Error ? error.message : String(error),
+        fix: 'Run `git status` inside the tuck directory and resolve repository errors',
+      };
+    }
+  },
+};
+
+const checkManifestLoadable: DoctorCheck = {
+  id: 'repo.manifest-loadable',
+  category: 'repo',
+  run: async (context) => {
+    if (!context.hasTuckDir) {
+      return {
+        id: 'repo.manifest-loadable',
+        category: 'repo',
+        status: 'warn',
+        message: 'Skipped manifest load check because tuck is not initialized',
+      };
+    }
+
+    if (!context.hasManifestFile) {
+      return {
+        id: 'repo.manifest-loadable',
+        category: 'repo',
+        status: 'fail',
+        message: `Manifest missing: ${collapsePath(context.manifestPath)}`,
+        fix: 'Recreate with `tuck init` or restore `.tuckmanifest.json` from backup',
+      };
+    }
+
+    if (context.manifest) {
+      return {
+        id: 'repo.manifest-loadable',
+        category: 'repo',
+        status: 'pass',
+        message: 'Manifest is present and valid',
+      };
+    }
+
+    return {
+      id: 'repo.manifest-loadable',
+      category: 'repo',
+      status: 'fail',
+      message: 'Manifest exists but failed to parse',
+      details: context.manifestLoadError,
+      fix: 'Repair `.tuckmanifest.json` using a valid schema or restore from git',
+    };
+  },
+};
+
+const checkConfigLoadable: DoctorCheck = {
+  id: 'repo.config-loadable',
+  category: 'repo',
+  run: async (context) => {
+    if (!context.hasTuckDir) {
+      return {
+        id: 'repo.config-loadable',
+        category: 'repo',
+        status: 'warn',
+        message: 'Skipped config load check because tuck is not initialized',
+      };
+    }
+
+    if (!context.hasConfigFile) {
+      return {
+        id: 'repo.config-loadable',
+        category: 'repo',
+        status: 'warn',
+        message: `Config file missing: ${collapsePath(context.configPath)} (defaults will be used)`,
+        fix: 'Run `tuck config reset` to generate a config file with defaults',
+      };
+    }
+
+    if (context.config) {
+      return {
+        id: 'repo.config-loadable',
+        category: 'repo',
+        status: 'pass',
+        message: 'Configuration is present and valid',
+      };
+    }
+
+    return {
+      id: 'repo.config-loadable',
+      category: 'repo',
+      status: 'fail',
+      message: 'Configuration exists but failed to parse',
+      details: context.configLoadError,
+      fix: 'Repair `.tuckrc.json` or run `tuck config reset`',
+    };
+  },
+};
+
+const checkManifestPathSafety: DoctorCheck = {
+  id: 'manifest.path-safety',
+  category: 'manifest',
+  run: async (context) => {
+    if (!context.manifest) {
+      return {
+        id: 'manifest.path-safety',
+        category: 'manifest',
+        status: 'warn',
+        message: 'Skipped manifest path checks because manifest is unavailable',
+      };
+    }
+
+    const violations: string[] = [];
+    for (const [id, file] of Object.entries(context.manifest.files)) {
+      try {
+        validateSafeSourcePath(file.source);
+      } catch (error) {
+        violations.push(`${id}: unsafe source ${file.source} (${error instanceof Error ? error.message : String(error)})`);
+        continue;
+      }
+
+      try {
+        validateSafeManifestDestination(file.destination);
+      } catch (error) {
+        violations.push(
+          `${id}: unsafe destination ${file.destination} (${error instanceof Error ? error.message : String(error)})`
+        );
+        continue;
+      }
+
+      try {
+        validatePathWithinRoot(join(context.tuckDir, file.destination), context.tuckDir, 'manifest destination');
+      } catch (error) {
+        violations.push(
+          `${id}: destination escapes tuck dir (${error instanceof Error ? error.message : String(error)})`
+        );
+      }
+    }
+
+    if (violations.length === 0) {
+      return {
+        id: 'manifest.path-safety',
+        category: 'manifest',
+        status: 'pass',
+        message: 'All manifest paths are safe',
+      };
+    }
+
+    return {
+      id: 'manifest.path-safety',
+      category: 'manifest',
+      status: 'fail',
+      message: `Detected ${violations.length} unsafe manifest path entr${violations.length === 1 ? 'y' : 'ies'}`,
+      details: violations.slice(0, 3).join('; '),
+      fix: 'Replace unsafe paths with home-scoped sources and `files/...` destinations',
+    };
+  },
+};
+
+const checkManifestDuplicateSources: DoctorCheck = {
+  id: 'manifest.duplicate-sources',
+  category: 'manifest',
+  run: async (context) => {
+    if (!context.manifest) {
+      return {
+        id: 'manifest.duplicate-sources',
+        category: 'manifest',
+        status: 'warn',
+        message: 'Skipped duplicate source checks because manifest is unavailable',
+      };
+    }
+
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+
+    for (const file of Object.values(context.manifest.files)) {
+      const normalized = expandPath(file.source);
+      if (seen.has(normalized)) {
+        duplicates.push(file.source);
+      }
+      seen.add(normalized);
+    }
+
+    if (duplicates.length === 0) {
+      return {
+        id: 'manifest.duplicate-sources',
+        category: 'manifest',
+        status: 'pass',
+        message: 'No duplicate source paths detected',
+      };
+    }
+
+    return {
+      id: 'manifest.duplicate-sources',
+      category: 'manifest',
+      status: 'fail',
+      message: `Detected duplicate source paths (${duplicates.length})`,
+      details: duplicates.slice(0, 5).join(', '),
+      fix: 'Keep each source path tracked exactly once in `.tuckmanifest.json`',
+    };
+  },
+};
+
+const checkManifestDuplicateDestinations: DoctorCheck = {
+  id: 'manifest.duplicate-destinations',
+  category: 'manifest',
+  run: async (context) => {
+    if (!context.manifest) {
+      return {
+        id: 'manifest.duplicate-destinations',
+        category: 'manifest',
+        status: 'warn',
+        message: 'Skipped duplicate destination checks because manifest is unavailable',
+      };
+    }
+
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+
+    for (const file of Object.values(context.manifest.files)) {
+      const normalized = file.destination.replace(/\\/g, '/');
+      if (seen.has(normalized)) {
+        duplicates.push(file.destination);
+      }
+      seen.add(normalized);
+    }
+
+    if (duplicates.length === 0) {
+      return {
+        id: 'manifest.duplicate-destinations',
+        category: 'manifest',
+        status: 'pass',
+        message: 'No duplicate repository destinations detected',
+      };
+    }
+
+    return {
+      id: 'manifest.duplicate-destinations',
+      category: 'manifest',
+      status: 'fail',
+      message: `Detected duplicate destinations (${duplicates.length})`,
+      details: duplicates.slice(0, 5).join(', '),
+      fix: 'Assign each tracked file a unique destination under `files/`',
+    };
+  },
+};
+
+const checkSecretScanning: DoctorCheck = {
+  id: 'security.secret-scanning',
+  category: 'security',
+  run: async (context) => {
+    if (!context.config) {
+      return {
+        id: 'security.secret-scanning',
+        category: 'security',
+        status: 'warn',
+        message: 'Skipped secret scanning checks because config is unavailable',
+      };
+    }
+
+    if (!context.config.security.scanSecrets) {
+      return {
+        id: 'security.secret-scanning',
+        category: 'security',
+        status: 'warn',
+        message: 'Secret scanning is disabled',
+        fix: 'Enable with `tuck config set security.scanSecrets true`',
+      };
+    }
+
+    return {
+      id: 'security.secret-scanning',
+      category: 'security',
+      status: 'pass',
+      message: 'Secret scanning is enabled',
+    };
+  },
+};
+
+const checkBackupOnRestore: DoctorCheck = {
+  id: 'security.backup-on-restore',
+  category: 'security',
+  run: async (context) => {
+    if (!context.config) {
+      return {
+        id: 'security.backup-on-restore',
+        category: 'security',
+        status: 'warn',
+        message: 'Skipped backup checks because config is unavailable',
+      };
+    }
+
+    if (!context.config.files.backupOnRestore) {
+      return {
+        id: 'security.backup-on-restore',
+        category: 'security',
+        status: 'warn',
+        message: 'Backup before restore is disabled',
+        fix: 'Enable with `tuck config set files.backupOnRestore true`',
+      };
+    }
+
+    return {
+      id: 'security.backup-on-restore',
+      category: 'security',
+      status: 'pass',
+      message: 'Backup before restore is enabled',
+    };
+  },
+};
+
+const checkHooksSafety: DoctorCheck = {
+  id: 'hooks.commands',
+  category: 'hooks',
+  run: async (context) => {
+    if (!context.config) {
+      return {
+        id: 'hooks.commands',
+        category: 'hooks',
+        status: 'warn',
+        message: 'Skipped hook checks because config is unavailable',
+      };
+    }
+
+    const hooks = context.config.hooks;
+    const configuredHooks = Object.entries(hooks).filter(
+      ([, command]) => typeof command === 'string' && command.trim().length > 0
+    );
+
+    if (configuredHooks.length === 0) {
+      return {
+        id: 'hooks.commands',
+        category: 'hooks',
+        status: 'pass',
+        message: 'No lifecycle hooks configured',
+      };
+    }
+
+    const suspiciousPatterns = [/&&/u, /\|\|/u, /;{1}/u, /\$\(/u, /`/u];
+    const suspicious = configuredHooks.filter(([, command]) =>
+      suspiciousPatterns.some((pattern) => pattern.test(command as string))
+    );
+
+    if (suspicious.length > 0) {
+      return {
+        id: 'hooks.commands',
+        category: 'hooks',
+        status: 'warn',
+        message: `Detected ${suspicious.length} hook command${suspicious.length === 1 ? '' : 's'} with complex shell syntax`,
+        details: suspicious.map(([name]) => name).join(', '),
+        fix: 'Review hook commands and keep them minimal and auditable',
+      };
+    }
+
+    return {
+      id: 'hooks.commands',
+      category: 'hooks',
+      status: 'pass',
+      message: `Validated ${configuredHooks.length} hook command${configuredHooks.length === 1 ? '' : 's'}`,
+    };
+  },
+};
+
+const doctorChecks: DoctorCheck[] = [
+  checkNodeVersion,
+  checkHomeDirectory,
+  checkTuckDirectory,
+  checkGitDirectory,
+  checkGitStatusReadable,
+  checkManifestLoadable,
+  checkConfigLoadable,
+  checkManifestPathSafety,
+  checkManifestDuplicateSources,
+  checkManifestDuplicateDestinations,
+  checkSecretScanning,
+  checkBackupOnRestore,
+  checkHooksSafety,
+];
+
+const buildDoctorSummary = (checks: DoctorCheckResult[]): DoctorSummary => {
+  return checks.reduce<DoctorSummary>(
+    (summary, check) => {
+      if (check.status === 'pass') {
+        summary.passed += 1;
+      } else if (check.status === 'warn') {
+        summary.warnings += 1;
+      } else {
+        summary.failed += 1;
+      }
+      return summary;
+    },
+    {
+      passed: 0,
+      warnings: 0,
+      failed: 0,
+    }
+  );
+};
+
+const buildDoctorContext = async (): Promise<DoctorContext> => {
+  const tuckDir = getTuckDir();
+  const manifestPath = getManifestPath(tuckDir);
+  const configPath = getConfigPath(tuckDir);
+  const hasTuckDir = await pathExists(tuckDir);
+  const hasGitDir = await pathExists(join(tuckDir, '.git'));
+  const hasManifestFile = await pathExists(manifestPath);
+  const hasConfigFile = await pathExists(configPath);
+
+  const context: DoctorContext = {
+    tuckDir,
+    manifestPath,
+    configPath,
+    hasTuckDir,
+    hasGitDir,
+    hasManifestFile,
+    hasConfigFile,
+  };
+
+  if (hasManifestFile) {
+    try {
+      context.manifest = await loadManifest(tuckDir);
+    } catch (error) {
+      context.manifestLoadError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  if (hasConfigFile) {
+    try {
+      context.config = await loadConfig(tuckDir);
+    } catch (error) {
+      context.configLoadError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  return context;
+};
+
+const normalizeCategory = (category?: string): DoctorCategory | undefined => {
+  if (!category) {
+    return undefined;
+  }
+
+  if ((DOCTOR_CATEGORIES as readonly string[]).includes(category)) {
+    return category as DoctorCategory;
+  }
+
+  return undefined;
+};
+
+export const runDoctorChecks = async (options: DoctorRunOptions = {}): Promise<DoctorReport> => {
+  const context = await buildDoctorContext();
+  const category = normalizeCategory(options.category);
+  const selectedChecks = category
+    ? doctorChecks.filter((check) => check.category === category)
+    : doctorChecks;
+
+  const checks: DoctorCheckResult[] = [];
+  for (const check of selectedChecks) {
+    try {
+      checks.push(await check.run(context));
+    } catch (error) {
+      checks.push({
+        id: check.id,
+        category: check.category,
+        status: 'fail',
+        message: 'Doctor check crashed unexpectedly',
+        details: error instanceof Error ? error.message : String(error),
+        fix: 'Run with DEBUG=1 and inspect the stack trace',
+      });
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    tuckDir: context.tuckDir,
+    summary: buildDoctorSummary(checks),
+    checks,
+  };
+};
+
+export const getDoctorExitCode = (report: DoctorReport, strict = false): number => {
+  if (report.summary.failed > 0) {
+    return 1;
+  }
+
+  if (strict && report.summary.warnings > 0) {
+    return 2;
+  }
+
+  return 0;
+};

--- a/src/lib/fileTracking.ts
+++ b/src/lib/fileTracking.ts
@@ -20,6 +20,7 @@ import { toPosixPath } from './platform.js';
 export interface FileToTrack {
   path: string;
   category?: string;
+  name?: string;
 }
 
 export interface FileTrackingOptions {
@@ -156,7 +157,7 @@ export const trackFilesWithProgress = async (
     const categoryInfo = CATEGORIES[category];
     const icon = categoryInfo?.icon || '○';
     const sourcePath = collapsePath(file.path);
-    const relativeDestination = getRelativeDestinationFromSource(category, expandedPath);
+    const relativeDestination = getRelativeDestinationFromSource(category, expandedPath, file.name);
     const normalizedDestination = toPosixPath(relativeDestination);
     const existingSource = trackedDestinations.get(normalizedDestination);
 
@@ -176,7 +177,7 @@ export const trackFilesWithProgress = async (
       }
 
       // Get destination path
-      const destination = getDestinationPathFromSource(tuckDir, category, expandedPath);
+      const destination = getDestinationPathFromSource(tuckDir, category, expandedPath, file.name);
 
       // Ensure category directory exists
       await ensureDir(dirname(destination));

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -58,6 +58,7 @@ export const getFileInfo = async (filepath: string): Promise<FileInfo> => {
 
   try {
     const stats = await stat(expandedPath);
+    const linkStats = await lstat(expandedPath);
     // On Windows, Unix-style permissions are not meaningful
     // Return a sensible default (644 for files, 755 for dirs)
     const permissions = IS_WINDOWS
@@ -67,7 +68,7 @@ export const getFileInfo = async (filepath: string): Promise<FileInfo> => {
     return {
       path: expandedPath,
       isDirectory: stats.isDirectory(),
-      isSymlink: stats.isSymbolicLink(),
+      isSymlink: linkStats.isSymbolicLink(),
       size: stats.size,
       permissions,
       modified: stats.mtime,

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -4,7 +4,7 @@ import { copy, ensureDir } from 'fs-extra';
 import { join, dirname, basename } from 'path';
 import { constants } from 'fs';
 import { FileNotFoundError, PermissionError } from '../errors.js';
-import { expandPath, pathExists, isDirectory } from './paths.js';
+import { expandPath, pathExists, isDirectory, validateSafeDestinationPath } from './paths.js';
 import { IS_WINDOWS } from './platform.js';
 
 export interface FileInfo {
@@ -171,6 +171,8 @@ export const copyFileOrDir = async (
     throw new FileNotFoundError(source);
   }
 
+  validateSafeDestinationPath(expandedDest);
+
   // Ensure destination directory exists
   await ensureDir(dirname(expandedDest));
 
@@ -247,6 +249,8 @@ export const createSymlink = async (
   if (!(await pathExists(expandedTarget))) {
     throw new FileNotFoundError(target);
   }
+
+  validateSafeDestinationPath(expandedLink);
 
   // Ensure link parent directory exists
   await ensureDir(dirname(expandedLink));

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -662,11 +662,13 @@ To create a Fine-grained Personal Access Token (recommended):
    - Username: your-github-username
    - Password: github_pat_xxxxxxxxxxxx (your token)
 
-   Or configure credential storage:
-   git config --global credential.helper store
+   Configure a secure credential helper instead:
+   - macOS: git config --global credential.helper osxkeychain
+   - Linux: git config --global credential.helper libsecret
+   - Windows: git config --global credential.helper manager-core
+   - Or with GitHub CLI: gh auth setup-git
 
-   Then on first push, enter your token as the password
-   and it will be saved for future use.
+   Then on first push, enter your token as the password.
 `.trim();
 };
 
@@ -709,8 +711,11 @@ but classic tokens work if you need broader access.
    - Username: your-github-username
    - Password: ghp_xxxxxxxxxxxx (your token)
 
-   Or configure credential storage:
-   git config --global credential.helper store
+   Configure a secure credential helper instead:
+   - macOS: git config --global credential.helper osxkeychain
+   - Linux: git config --global credential.helper libsecret
+   - Windows: git config --global credential.helper manager-core
+   - Or with GitHub CLI: gh auth setup-git
 
    Then on first push, enter your token as the password.
 `.trim();

--- a/src/lib/providers/custom.ts
+++ b/src/lib/providers/custom.ts
@@ -248,11 +248,11 @@ For SSH URLs (git@...):
 
 For HTTPS URLs:
 1. Create a personal access token on your hosting service
-2. Configure git credential helper:
-   git config --global credential.helper store
-3. On first push, enter your token as password
-
-Or use git credential manager for more secure storage.`;
+2. Configure a secure git credential helper:
+   - macOS: git config --global credential.helper osxkeychain
+   - Linux: git config --global credential.helper libsecret
+   - Windows: git config --global credential.helper manager-core
+3. On first push, enter your token as password`;
   }
 
   // -------------------------------------------------------------------------

--- a/src/lib/secrets/regexSafety.ts
+++ b/src/lib/secrets/regexSafety.ts
@@ -1,0 +1,217 @@
+/**
+ * Safety checks for user-supplied regex patterns.
+ *
+ * JavaScript regex execution cannot be interrupted mid-exec(), so custom
+ * patterns must be validated before they are allowed in the scanner.
+ */
+
+const MAX_CUSTOM_PATTERN_LENGTH = 500;
+const MAX_GROUP_DEPTH = 16;
+const ALLOWED_CUSTOM_REGEX_FLAGS = new Set(['d', 'g', 'i', 'm', 's', 'u', 'y']);
+
+interface GroupState {
+  hasVariableQuantifier: boolean;
+  hasAlternation: boolean;
+}
+
+type LastTokenType = 'none' | 'literal' | 'group' | 'quantifier';
+
+interface LastToken {
+  type: LastTokenType;
+  group?: GroupState;
+}
+
+interface BraceQuantifier {
+  endIndex: number;
+  variable: boolean;
+  unbounded: boolean;
+}
+
+const parseBraceQuantifier = (source: string, start: number): BraceQuantifier | null => {
+  if (source[start] !== '{') {
+    return null;
+  }
+
+  let index = start + 1;
+  let min = '';
+  let max = '';
+  let hasComma = false;
+
+  while (index < source.length && /[0-9]/.test(source[index])) {
+    min += source[index];
+    index++;
+  }
+
+  if (source[index] === ',') {
+    hasComma = true;
+    index++;
+    while (index < source.length && /[0-9]/.test(source[index])) {
+      max += source[index];
+      index++;
+    }
+  }
+
+  if (source[index] !== '}') {
+    return null;
+  }
+
+  if (min.length === 0) {
+    return null;
+  }
+
+  const unbounded = hasComma && max.length === 0;
+  const variable = hasComma && (max.length === 0 || max !== min);
+  return { endIndex: index, variable, unbounded };
+};
+
+const getSafetyIssue = (source: string): string | null => {
+  const stack: GroupState[] = [{ hasVariableQuantifier: false, hasAlternation: false }];
+  let lastToken: LastToken = { type: 'none' };
+  let inCharClass = false;
+
+  for (let i = 0; i < source.length; ) {
+    const char = source[i];
+
+    // Handle escapes and detect backreferences (\1, \2, \k<name>)
+    if (char === '\\') {
+      const next = source[i + 1];
+      if (next && /[1-9]/.test(next)) {
+        return 'backreferences are not allowed';
+      }
+      if (next === 'k' && source[i + 2] === '<') {
+        return 'named backreferences are not allowed';
+      }
+      lastToken = { type: 'literal' };
+      i += 2;
+      continue;
+    }
+
+    if (inCharClass) {
+      if (char === ']') {
+        inCharClass = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (char === '[') {
+      inCharClass = true;
+      lastToken = { type: 'literal' };
+      i++;
+      continue;
+    }
+
+    if (char === '(') {
+      if (source.startsWith('(?<=', i) || source.startsWith('(?<!', i)) {
+        return 'lookbehind assertions are not allowed';
+      }
+      stack.push({ hasVariableQuantifier: false, hasAlternation: false });
+      if (stack.length > MAX_GROUP_DEPTH) {
+        return `pattern nesting is too deep (max ${MAX_GROUP_DEPTH} groups)`;
+      }
+      lastToken = { type: 'none' };
+      i++;
+      continue;
+    }
+
+    if (char === ')') {
+      if (stack.length > 1) {
+        const closed = stack.pop();
+        lastToken = { type: 'group', group: closed };
+      } else {
+        lastToken = { type: 'literal' };
+      }
+      i++;
+      continue;
+    }
+
+    if (char === '|') {
+      stack[stack.length - 1].hasAlternation = true;
+      lastToken = { type: 'none' };
+      i++;
+      continue;
+    }
+
+    const braceQuantifier = parseBraceQuantifier(source, i);
+    if (braceQuantifier && (lastToken.type === 'literal' || lastToken.type === 'group')) {
+      if (braceQuantifier.variable) {
+        stack[stack.length - 1].hasVariableQuantifier = true;
+      }
+
+      if (lastToken.type === 'group' && braceQuantifier.unbounded) {
+        if (lastToken.group?.hasVariableQuantifier) {
+          return 'nested quantified groups are not allowed';
+        }
+        if (lastToken.group?.hasAlternation) {
+          return 'unbounded quantifiers on alternation groups are not allowed';
+        }
+      }
+
+      lastToken = { type: 'quantifier' };
+      i = braceQuantifier.endIndex + 1;
+      if (source[i] === '?') {
+        i++;
+      }
+      continue;
+    }
+
+    if ((char === '*' || char === '+' || char === '?') && (lastToken.type === 'literal' || lastToken.type === 'group')) {
+      stack[stack.length - 1].hasVariableQuantifier = true;
+
+      const unbounded = char === '*' || char === '+';
+      if (lastToken.type === 'group' && unbounded) {
+        if (lastToken.group?.hasVariableQuantifier) {
+          return 'nested quantified groups are not allowed';
+        }
+        if (lastToken.group?.hasAlternation) {
+          return 'unbounded quantifiers on alternation groups are not allowed';
+        }
+      }
+
+      lastToken = { type: 'quantifier' };
+      i++;
+      if (source[i] === '?') {
+        i++;
+      }
+      continue;
+    }
+
+    lastToken = { type: 'literal' };
+    i++;
+  }
+
+  return null;
+};
+
+export const normalizeCustomRegexFlags = (flags = 'g'): string => {
+  const merged = `${flags}g`;
+  let normalized = '';
+  const seen = new Set<string>();
+
+  for (const flag of merged) {
+    if (!ALLOWED_CUSTOM_REGEX_FLAGS.has(flag)) {
+      throw new Error(`Unsupported regex flag "${flag}" in custom pattern`);
+    }
+    if (!seen.has(flag)) {
+      seen.add(flag);
+      normalized += flag;
+    }
+  }
+
+  return normalized;
+};
+
+export const assertSafeCustomRegex = (source: string): void => {
+  if (!source.trim()) {
+    throw new Error('Custom pattern cannot be empty');
+  }
+
+  if (source.length > MAX_CUSTOM_PATTERN_LENGTH) {
+    throw new Error(`Custom pattern is too long (${source.length} > ${MAX_CUSTOM_PATTERN_LENGTH})`);
+  }
+
+  const issue = getSafetyIssue(source);
+  if (issue) {
+    throw new Error(`Unsafe custom regex pattern rejected: ${issue}`);
+  }
+};

--- a/src/lib/secrets/scanner.ts
+++ b/src/lib/secrets/scanner.ts
@@ -8,6 +8,7 @@ import { readFile, stat } from 'fs/promises';
 import { expandPath, collapsePath, pathExists } from '../paths.js';
 import {
   ALL_SECRET_PATTERNS,
+  assertSafeCustomRegex,
   getPatternsAboveSeverity,
   shouldSkipFile,
   type SecretPattern,
@@ -195,7 +196,8 @@ const getContext = (content: string, lineNum: number, secretValue: string): stri
  * Clone a regex pattern to reset its lastIndex
  */
 const clonePattern = (pattern: RegExp): RegExp => {
-  return new RegExp(pattern.source, pattern.flags);
+  const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  return new RegExp(pattern.source, flags);
 };
 
 // ============================================================================
@@ -225,6 +227,9 @@ export const scanContent = (content: string, options: ScanOptions = {}): SecretM
 
   // Add custom patterns
   if (options.customPatterns) {
+    for (const customPattern of options.customPatterns) {
+      assertSafeCustomRegex(customPattern.pattern.source);
+    }
     patterns = [...patterns, ...options.customPatterns];
   }
 

--- a/src/lib/trackPipeline.ts
+++ b/src/lib/trackPipeline.ts
@@ -70,6 +70,7 @@ export interface PreparedTrackFile {
   destination: string;
   category: string;
   filename: string;
+  nameOverride?: string;
   isDir: boolean;
   fileCount: number;
   sensitive: boolean;
@@ -358,14 +359,16 @@ export const preparePathsForTracking = async (
     const isDir = await isDirectory(expandedPath);
     const fileCount = isDir ? await getDirectoryFileCount(expandedPath) : 1;
     const category = candidate.category || options.category || detectCategory(expandedPath);
-    const customName = candidate.name || options.name;
-    const filename = customName || sanitizeFilename(expandedPath);
+    const customName = candidate.name ?? options.name;
+    const nameOverride = customName ? sanitizeFilename(customName) : undefined;
+    const filename = nameOverride || sanitizeFilename(expandedPath);
 
     prepared.push({
       source: collapsedPath,
-      destination: getDestinationPathFromSource(tuckDir, category, expandedPath),
+      destination: getDestinationPathFromSource(tuckDir, category, expandedPath, nameOverride),
       category,
       filename,
+      nameOverride,
       isDir,
       fileCount,
       sensitive: isSensitiveFile(collapsedPath),

--- a/src/lib/trackPipeline.ts
+++ b/src/lib/trackPipeline.ts
@@ -1,0 +1,376 @@
+import { basename } from 'path';
+import { colors as c, logger, prompts } from '../ui/index.js';
+import {
+  collapsePath,
+  detectCategory,
+  getDestinationPathFromSource,
+  expandPath,
+  isDirectory,
+  pathExists,
+  sanitizeFilename,
+  validateSafeSourcePath,
+} from './paths.js';
+import { isFileTracked } from './manifest.js';
+import { checkFileSizeThreshold, formatFileSize, getDirectoryFileCount } from './files.js';
+import { shouldExcludeFromBin } from './binary.js';
+import { addToTuckignore, isIgnored } from './tuckignore.js';
+import {
+  FileAlreadyTrackedError,
+  FileNotFoundError,
+  OperationCancelledError,
+  PrivateKeyError,
+  SecretsDetectedError,
+} from '../errors.js';
+import { logForceSecretBypass } from './audit.js';
+import {
+  getSecretsPath,
+  isSecretScanningEnabled,
+  processSecretsForRedaction,
+  redactFile,
+  scanForSecrets,
+  shouldBlockOnSecrets,
+  type ScanSummary,
+} from './secrets/index.js';
+
+const PRIVATE_KEY_PATTERNS = [
+  /^id_rsa$/,
+  /^id_dsa$/,
+  /^id_ecdsa$/,
+  /^id_ed25519$/,
+  /^id_.*$/,
+  /\.pem$/,
+  /\.key$/,
+  /^.*_key$/,
+];
+
+const SENSITIVE_FILE_PATTERNS = [
+  /^\.netrc$/,
+  /^\.aws\/credentials$/,
+  /^\.docker\/config\.json$/,
+  /^\.npmrc$/,
+  /^\.pypirc$/,
+  /^\.kube\/config$/,
+  /^\.ssh\/config$/,
+  /^\.gnupg\//,
+  /credentials/i,
+  /secrets?/i,
+  /tokens?\.json$/i,
+  /\.env$/,
+  /\.env\./,
+];
+
+export interface TrackPathCandidate {
+  path: string;
+  category?: string;
+  name?: string;
+}
+
+export interface PreparedTrackFile {
+  source: string;
+  destination: string;
+  category: string;
+  filename: string;
+  isDir: boolean;
+  fileCount: number;
+  sensitive: boolean;
+}
+
+export interface PreparePathsForTrackingOptions {
+  category?: string;
+  name?: string;
+  force?: boolean;
+  allowAlreadyTracked?: boolean;
+  secretHandling?: 'interactive' | 'strict';
+  forceBypassCommand?: string;
+}
+
+const isPrivateKey = (collapsedPath: string): boolean => {
+  const name = basename(collapsedPath);
+
+  if (collapsedPath.includes('.ssh/') && !name.endsWith('.pub')) {
+    return PRIVATE_KEY_PATTERNS.some((pattern) => pattern.test(name));
+  }
+
+  return name.endsWith('.pem') || name.endsWith('.key');
+};
+
+const isSensitiveFile = (collapsedPath: string): boolean => {
+  const pathToTest = collapsedPath.startsWith('~/') ? collapsedPath.slice(2) : collapsedPath;
+  return SENSITIVE_FILE_PATTERNS.some((pattern) => pattern.test(pathToTest));
+};
+
+const displaySecretWarning = (summary: ScanSummary): void => {
+  console.log();
+  console.log(c.error(c.bold(`  Security Warning: Found ${summary.totalSecrets} potential secret(s)`)));
+  console.log();
+
+  for (const result of summary.results) {
+    console.log(`  ${c.brand(result.collapsedPath)}`);
+
+    for (const match of result.matches) {
+      const severityColor =
+        match.severity === 'critical'
+          ? c.error
+          : match.severity === 'high'
+            ? c.warning
+            : match.severity === 'medium'
+              ? c.info
+              : c.muted;
+
+      console.log(
+        `    ${c.muted(`Line ${match.line}:`)} ${match.redactedValue} ${severityColor(`[${match.severity}]`)}`
+      );
+    }
+    console.log();
+  }
+};
+
+const handleFileSizePolicy = async (
+  collapsedPath: string,
+  sizeBytes: number,
+  tuckDir: string,
+  secretHandling: 'interactive' | 'strict'
+): Promise<boolean> => {
+  const sizeLabel = formatFileSize(sizeBytes);
+  const isWarn = sizeBytes >= 50 * 1024 * 1024;
+  const isBlock = sizeBytes >= 100 * 1024 * 1024;
+
+  if (!isWarn && !isBlock) {
+    return true;
+  }
+
+  if (secretHandling === 'strict') {
+    if (isBlock) {
+      throw new OperationCancelledError('file size exceeds GitHub limit');
+    }
+    logger.warning(`File ${collapsedPath} is ${sizeLabel}. GitHub recommends files under 50MB.`);
+    return true;
+  }
+
+  if (isBlock) {
+    logger.warning(`File ${collapsedPath} is ${sizeLabel} (exceeds GitHub's 100MB limit)`);
+
+    const action = await prompts.select('How would you like to proceed?', [
+      { value: 'ignore', label: 'Add to .tuckignore and skip' },
+      { value: 'cancel', label: 'Cancel operation' },
+    ]);
+
+    if (action === 'ignore') {
+      await addToTuckignore(tuckDir, collapsedPath);
+      logger.success(`Added ${collapsedPath} to .tuckignore`);
+      return false;
+    }
+
+    throw new OperationCancelledError('file size exceeds GitHub limit');
+  }
+
+  logger.warning(`File ${collapsedPath} is ${sizeLabel}. GitHub recommends files under 50MB.`);
+  const action = await prompts.select('How would you like to proceed?', [
+    { value: 'continue', label: 'Track it anyway' },
+    { value: 'ignore', label: 'Add to .tuckignore and skip' },
+    { value: 'cancel', label: 'Cancel operation' },
+  ]);
+
+  if (action === 'ignore') {
+    await addToTuckignore(tuckDir, collapsedPath);
+    logger.success(`Added ${collapsedPath} to .tuckignore`);
+    return false;
+  }
+  if (action === 'cancel') {
+    throw new OperationCancelledError('file size warning');
+  }
+
+  return true;
+};
+
+const applySecretPolicy = async (
+  files: PreparedTrackFile[],
+  tuckDir: string,
+  options: PreparePathsForTrackingOptions
+): Promise<PreparedTrackFile[]> => {
+  if (files.length === 0) {
+    return files;
+  }
+
+  if (!(await isSecretScanningEnabled(tuckDir))) {
+    return files;
+  }
+
+  const secretHandling = options.secretHandling ?? 'interactive';
+
+  if (options.force) {
+    if (secretHandling === 'interactive') {
+      const confirmed = await prompts.confirmDangerous(
+        'Using --force bypasses secret scanning.\n' +
+          'Any secrets in these files may be committed to git and potentially exposed.',
+        'force'
+      );
+      if (!confirmed) {
+        logger.info('Operation cancelled');
+        return [];
+      }
+    }
+    logger.warning('Secret scanning bypassed with --force');
+    await logForceSecretBypass(options.forceBypassCommand ?? 'tuck add --force', files.length);
+    return files;
+  }
+
+  const filePaths = files.map((f) => expandPath(f.source));
+  const summary = await scanForSecrets(filePaths, tuckDir);
+
+  if (summary.filesWithSecrets === 0) {
+    return files;
+  }
+
+  if (secretHandling === 'strict') {
+    const shouldBlock = await shouldBlockOnSecrets(tuckDir);
+    if (shouldBlock) {
+      const filesWithSecrets = summary.results
+        .filter((result) => result.hasSecrets)
+        .map((result) => collapsePath(result.path));
+      throw new SecretsDetectedError(summary.totalSecrets, filesWithSecrets);
+    }
+    logger.warning('Secrets detected but blockOnSecrets is disabled - proceeding with tracking');
+    logger.warning('Make sure your repository is private!');
+    return files;
+  }
+
+  displaySecretWarning(summary);
+
+  const action = await prompts.select('How would you like to proceed?', [
+    { value: 'abort', label: 'Abort operation', hint: 'Do not track these files' },
+    {
+      value: 'redact',
+      label: 'Replace with placeholders',
+      hint: 'Store originals in secrets.local.json (never committed)',
+    },
+    { value: 'ignore', label: 'Add files to .tuckignore', hint: 'Skip these files permanently' },
+    { value: 'proceed', label: 'Proceed anyway', hint: 'Track files with secrets (dangerous!)' },
+  ]);
+
+  if (action === 'abort') {
+    logger.info('Operation aborted');
+    return [];
+  }
+
+  if (action === 'redact') {
+    const redactionMaps = await processSecretsForRedaction(summary.results, tuckDir);
+    let totalRedacted = 0;
+
+    for (const result of summary.results) {
+      const placeholderMap = redactionMaps.get(result.path);
+      if (placeholderMap && placeholderMap.size > 0) {
+        const redactionResult = await redactFile(result.path, result.matches, placeholderMap);
+        totalRedacted += redactionResult.replacements.length;
+      }
+    }
+
+    console.log();
+    logger.success(`Replaced ${totalRedacted} secret(s) with placeholders`);
+    logger.dim(`Secrets stored in: ${collapsePath(getSecretsPath(tuckDir))} (never committed)`);
+    logger.dim("Run 'tuck secrets list' to see stored secrets");
+    console.log();
+    return files;
+  }
+
+  if (action === 'ignore') {
+    const filesWithSecrets = new Set(summary.results.map((result) => result.collapsedPath));
+
+    for (const file of files) {
+      const normalizedSource = collapsePath(file.source);
+      if (filesWithSecrets.has(normalizedSource)) {
+        await addToTuckignore(tuckDir, file.source);
+        logger.success(`Added ${normalizedSource} to .tuckignore`);
+      }
+    }
+
+    const remaining = files.filter((file) => !filesWithSecrets.has(collapsePath(file.source)));
+    if (remaining.length === 0) {
+      logger.info('No files remaining to track');
+    }
+    return remaining;
+  }
+
+  const confirmed = await prompts.confirm(
+    c.error('Are you SURE you want to track files containing secrets?'),
+    false
+  );
+  if (!confirmed) {
+    logger.info('Operation aborted');
+    return [];
+  }
+
+  logger.warning('Proceeding with secrets - be careful not to push to a public repository!');
+  return files;
+};
+
+export const preparePathsForTracking = async (
+  candidates: TrackPathCandidate[],
+  tuckDir: string,
+  options: PreparePathsForTrackingOptions = {}
+): Promise<PreparedTrackFile[]> => {
+  const secretHandling = options.secretHandling ?? 'interactive';
+  const prepared: PreparedTrackFile[] = [];
+
+  for (const candidate of candidates) {
+    const expandedPath = expandPath(candidate.path);
+    const collapsedPath = collapsePath(expandedPath);
+    validateSafeSourcePath(collapsedPath);
+
+    if (isPrivateKey(collapsedPath)) {
+      throw new PrivateKeyError(candidate.path);
+    }
+
+    if (!(await pathExists(expandedPath))) {
+      throw new FileNotFoundError(candidate.path);
+    }
+
+    if (!options.allowAlreadyTracked && (await isFileTracked(tuckDir, collapsedPath))) {
+      throw new FileAlreadyTrackedError(candidate.path);
+    }
+
+    if (await isIgnored(tuckDir, collapsedPath)) {
+      logger.info(`Skipping ${collapsedPath} (in .tuckignore)`);
+      continue;
+    }
+
+    if (await shouldExcludeFromBin(expandedPath)) {
+      const sizeCheck = await checkFileSizeThreshold(expandedPath);
+      logger.info(
+        `Skipping binary executable: ${collapsedPath}` +
+          `${sizeCheck.size > 0 ? ` (${formatFileSize(sizeCheck.size)})` : ''}` +
+          ' - Add to .tuckignore to customize'
+      );
+      continue;
+    }
+
+    const sizeCheck = await checkFileSizeThreshold(expandedPath);
+    const shouldTrack = await handleFileSizePolicy(
+      collapsedPath,
+      sizeCheck.size,
+      tuckDir,
+      secretHandling
+    );
+    if (!shouldTrack) {
+      continue;
+    }
+
+    const isDir = await isDirectory(expandedPath);
+    const fileCount = isDir ? await getDirectoryFileCount(expandedPath) : 1;
+    const category = candidate.category || options.category || detectCategory(expandedPath);
+    const customName = candidate.name || options.name;
+    const filename = customName || sanitizeFilename(expandedPath);
+
+    prepared.push({
+      source: collapsedPath,
+      destination: getDestinationPathFromSource(tuckDir, category, expandedPath),
+      category,
+      filename,
+      isDir,
+      fileCount,
+      sensitive: isSensitiveFile(collapsedPath),
+    });
+  }
+
+  return applySecretPolicy(prepared, tuckDir, options);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,12 @@ export interface DiffOptions {
   exitCode?: boolean;
 }
 
+export interface DoctorOptions {
+  json?: boolean;
+  strict?: boolean;
+  category?: 'env' | 'repo' | 'manifest' | 'security' | 'hooks';
+}
+
 export interface FileChange {
   path: string;
   status: 'modified' | 'added' | 'deleted' | 'untracked';

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -14,6 +14,7 @@ const isDirectoryMock = vi.fn();
 const detectCategoryMock = vi.fn();
 const sanitizeFilenameMock = vi.fn();
 const getDestinationPathMock = vi.fn();
+const validateSafeSourcePathMock = vi.fn();
 const loadConfigMock = vi.fn();
 const scanForSecretsMock = vi.fn();
 const shouldBlockOnSecretsMock = vi.fn();
@@ -77,6 +78,7 @@ vi.mock('../../src/lib/paths.js', () => ({
   detectCategory: detectCategoryMock,
   sanitizeFilename: sanitizeFilenameMock,
   getDestinationPath: getDestinationPathMock,
+  validateSafeSourcePath: validateSafeSourcePathMock,
 }));
 
 vi.mock('../../src/lib/config.js', () => ({
@@ -127,6 +129,7 @@ describe('add command behavior', () => {
     detectCategoryMock.mockReturnValue('shell');
     sanitizeFilenameMock.mockReturnValue('zshrc');
     getDestinationPathMock.mockReturnValue('/test-home/.tuck/files/shell/zshrc');
+    validateSafeSourcePathMock.mockImplementation(() => {});
     loadConfigMock.mockResolvedValue({
       security: { scanSecrets: true },
     });

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -1,284 +1,203 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { vol } from 'memfs';
-import { TEST_HOME, TEST_TUCK_DIR, TEST_HOME_NATIVE } from '../setup.js';
-import { initTestTuck, createTestDotfile, getTestManifest } from '../utils/testHelpers.js';
-import { createMockTrackedFile } from '../utils/factories.js';
-import path from 'path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  NotInitializedError,
+  FileNotFoundError,
+  FileAlreadyTrackedError,
+  SecretsDetectedError,
+} from '../../src/errors.js';
 
-// Mock UI
+const loadManifestMock = vi.fn();
+const isFileTrackedMock = vi.fn();
+const trackFilesWithProgressMock = vi.fn();
+const pathExistsMock = vi.fn();
+const isDirectoryMock = vi.fn();
+const detectCategoryMock = vi.fn();
+const sanitizeFilenameMock = vi.fn();
+const getDestinationPathMock = vi.fn();
+const loadConfigMock = vi.fn();
+const scanForSecretsMock = vi.fn();
+const shouldBlockOnSecretsMock = vi.fn();
+const isIgnoredMock = vi.fn();
+const shouldExcludeFromBinMock = vi.fn();
+const getDirectoryFileCountMock = vi.fn();
+const checkFileSizeThresholdMock = vi.fn();
+
 vi.mock('../../src/ui/index.js', () => ({
   prompts: {
     intro: vi.fn(),
     outro: vi.fn(),
-    confirm: vi.fn().mockResolvedValue(true),
-    select: vi.fn().mockResolvedValue('general'),
+    confirm: vi.fn().mockResolvedValue(false),
+    confirmDangerous: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('continue'),
     text: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
     log: {
       info: vi.fn(),
       success: vi.fn(),
-      warn: vi.fn(),
+      warning: vi.fn(),
       error: vi.fn(),
       step: vi.fn(),
+      message: vi.fn(),
     },
-    note: vi.fn(),
-    cancel: vi.fn(),
-    spinner: vi.fn(() => ({
-      start: vi.fn(),
-      stop: vi.fn(),
-      message: '',
-    })),
   },
   logger: {
     info: vi.fn(),
     success: vi.fn(),
-    warn: vi.fn(),
+    warning: vi.fn(),
     error: vi.fn(),
-    debug: vi.fn(),
+    dim: vi.fn(),
   },
-  banner: vi.fn(),
+  colors: {
+    error: (x: string) => x,
+    warning: (x: string) => x,
+    info: (x: string) => x,
+    brand: (x: string) => x,
+    muted: (x: string) => x,
+    bold: (x: string) => x,
+  },
 }));
 
-describe('add command', () => {
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  isFileTracked: isFileTrackedMock,
+}));
+
+vi.mock('../../src/lib/fileTracking.js', () => ({
+  trackFilesWithProgress: trackFilesWithProgressMock,
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  collapsePath: vi.fn((p: string) => p.replace('/test-home/', '~/')),
+  pathExists: pathExistsMock,
+  isDirectory: isDirectoryMock,
+  detectCategory: detectCategoryMock,
+  sanitizeFilename: sanitizeFilenameMock,
+  getDestinationPath: getDestinationPathMock,
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  scanForSecrets: scanForSecretsMock,
+  shouldBlockOnSecrets: shouldBlockOnSecretsMock,
+  processSecretsForRedaction: vi.fn(),
+  redactFile: vi.fn(),
+  getSecretsPath: vi.fn(),
+}));
+
+vi.mock('../../src/lib/tuckignore.js', () => ({
+  isIgnored: isIgnoredMock,
+  addToTuckignore: vi.fn(),
+}));
+
+vi.mock('../../src/lib/binary.js', () => ({
+  shouldExcludeFromBin: shouldExcludeFromBinMock,
+}));
+
+vi.mock('../../src/lib/files.js', () => ({
+  getDirectoryFileCount: getDirectoryFileCountMock,
+  checkFileSizeThreshold: checkFileSizeThresholdMock,
+  formatFileSize: vi.fn((size: number) => `${size} B`),
+}));
+
+vi.mock('../../src/lib/audit.js', () => ({
+  logForceSecretBypass: vi.fn(),
+}));
+
+describe('add command behavior', () => {
   beforeEach(() => {
-    vol.reset();
     vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    isFileTrackedMock.mockResolvedValue(false);
+    trackFilesWithProgressMock.mockResolvedValue({
+      succeeded: 1,
+      failed: 0,
+      errors: [],
+      sensitiveFiles: [],
+    });
+    pathExistsMock.mockResolvedValue(true);
+    isDirectoryMock.mockResolvedValue(false);
+    detectCategoryMock.mockReturnValue('shell');
+    sanitizeFilenameMock.mockReturnValue('zshrc');
+    getDestinationPathMock.mockReturnValue('/test-home/.tuck/files/shell/zshrc');
+    loadConfigMock.mockResolvedValue({
+      security: { scanSecrets: true },
+    });
+    scanForSecretsMock.mockResolvedValue({
+      totalSecrets: 0,
+      filesWithSecrets: 0,
+      results: [],
+    });
+    shouldBlockOnSecretsMock.mockResolvedValue(true);
+    isIgnoredMock.mockResolvedValue(false);
+    shouldExcludeFromBinMock.mockResolvedValue(false);
+    getDirectoryFileCountMock.mockResolvedValue(1);
+    checkFileSizeThresholdMock.mockResolvedValue({ warn: false, block: false, size: 12 });
   });
 
-  afterEach(() => {
-    vol.reset();
+  it('tracks valid files and returns tracked count', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
+
+    const count = await addFilesFromPaths(['~/.zshrc']);
+
+    expect(count).toBe(1);
+    expect(trackFilesWithProgressMock).toHaveBeenCalledTimes(1);
+    expect(scanForSecretsMock).toHaveBeenCalledTimes(1);
   });
 
-  describe('file validation', () => {
-    it('should require file to exist', async () => {
-      await initTestTuck();
+  it('throws NotInitializedError when manifest cannot be loaded', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
+    loadManifestMock.mockRejectedValueOnce(new Error('missing manifest'));
 
-      const nonExistentPath = path.join(TEST_HOME, '.nonexistent');
-      const exists = vol.existsSync(nonExistentPath);
-
-      expect(exists).toBe(false);
-    });
-
-    it('should accept existing files', async () => {
-      await initTestTuck();
-      await createTestDotfile('.zshrc', 'export PATH=$PATH:/usr/local/bin');
-
-      const filePath = path.join(TEST_HOME, '.zshrc');
-      const exists = vol.existsSync(filePath);
-
-      expect(exists).toBe(true);
-    });
-
-    it('should reject directories by default', async () => {
-      await initTestTuck();
-
-      const dirPath = path.join(TEST_HOME, '.config');
-      vol.mkdirSync(dirPath, { recursive: true });
-
-      const stat = vol.statSync(dirPath);
-      expect(stat.isDirectory()).toBe(true);
-    });
+    await expect(addFilesFromPaths(['~/.zshrc'])).rejects.toBeInstanceOf(NotInitializedError);
   });
 
-  describe('file tracking', () => {
-    it('should add file to manifest', async () => {
-      await initTestTuck();
-      await createTestDotfile('.zshrc', 'zsh config');
+  it('throws FileNotFoundError when source path does not exist', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
+    pathExistsMock.mockResolvedValueOnce(false);
 
-      // Simulate adding file to manifest
-      const manifest = await getTestManifest();
-      manifest.files['zshrc'] = createMockTrackedFile({
-        source: '~/.zshrc',
-        destination: 'files/zshrc',
-        category: 'shell',
-      });
-
-      // Verify structure
-      expect(manifest.files['zshrc']).toBeDefined();
-      expect(manifest.files['zshrc'].source).toBe('~/.zshrc');
-      expect(manifest.files['zshrc'].category).toBe('shell');
-    });
-
-    it('should copy file to tuck directory', async () => {
-      await initTestTuck();
-      await createTestDotfile('.zshrc', 'zsh config content');
-
-      // Create files directory
-      const filesDir = path.join(TEST_TUCK_DIR, 'files');
-      vol.mkdirSync(filesDir, { recursive: true });
-
-      // Copy file
-      const sourceContent = vol.readFileSync(
-        path.join(TEST_HOME, '.zshrc'),
-        'utf-8'
-      );
-      vol.writeFileSync(
-        path.join(filesDir, 'zshrc'),
-        sourceContent as string
-      );
-
-      // Verify copy
-      const trackedContent = vol.readFileSync(
-        path.join(filesDir, 'zshrc'),
-        'utf-8'
-      );
-      expect(trackedContent).toBe('zsh config content');
-    });
-
-    it('should support symlink strategy', async () => {
-      const trackedFile = createMockTrackedFile({
-        source: '~/.zshrc',
-        destination: 'files/zshrc',
-        strategy: 'symlink',
-      });
-
-      expect(trackedFile.strategy).toBe('symlink');
-    });
-
-    it('should support copy strategy', async () => {
-      const trackedFile = createMockTrackedFile({
-        source: '~/.zshrc',
-        destination: 'files/zshrc',
-        strategy: 'copy',
-      });
-
-      expect(trackedFile.strategy).toBe('copy');
-    });
+    await expect(addFilesFromPaths(['~/.missing'])).rejects.toBeInstanceOf(FileNotFoundError);
   });
 
-  describe('category assignment', () => {
-    it('should allow custom category', async () => {
-      await initTestTuck();
+  it('throws FileAlreadyTrackedError when file is already tracked', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
+    isFileTrackedMock.mockResolvedValueOnce(true);
 
-      const trackedFile = createMockTrackedFile({
-        source: '~/.custom',
-        destination: 'files/custom',
-        category: 'custom-category',
-      });
-
-      expect(trackedFile.category).toBe('custom-category');
-    });
-
-    it('should auto-detect shell category for shell files', async () => {
-      // Shell files should be categorized as 'shell'
-      const shellFiles = ['.zshrc', '.bashrc', '.bash_profile', '.profile'];
-
-      for (const file of shellFiles) {
-        // Simple pattern matching
-        const isShell = /\.(zshrc|bashrc|bash_profile|profile|zprofile|zshenv)$/i.test(file) ||
-                        file.includes('sh');
-        expect(isShell).toBe(true);
-      }
-    });
-
-    it('should auto-detect git category for git files', async () => {
-      const gitFiles = ['.gitconfig', '.gitignore_global'];
-
-      for (const file of gitFiles) {
-        const isGit = file.includes('git');
-        expect(isGit).toBe(true);
-      }
-    });
+    await expect(addFilesFromPaths(['~/.zshrc'])).rejects.toBeInstanceOf(FileAlreadyTrackedError);
   });
 
-  describe('duplicate handling', () => {
-    it('should prevent adding already tracked files', async () => {
-      await initTestTuck();
-
-      const manifest = await getTestManifest();
-      manifest.files['zshrc'] = createMockTrackedFile({
-        source: '~/.zshrc',
-        destination: 'files/zshrc',
-      });
-
-      // Check if file is already tracked
-      const isTracked = 'zshrc' in manifest.files;
-      expect(isTracked).toBe(true);
+  it('throws SecretsDetectedError when scanner blocks detected secrets', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
+    scanForSecretsMock.mockResolvedValueOnce({
+      totalSecrets: 2,
+      filesWithSecrets: 1,
+      results: [
+        {
+          path: '/test-home/.zshrc',
+          hasSecrets: true,
+          matches: [],
+        },
+      ],
     });
+    shouldBlockOnSecretsMock.mockResolvedValueOnce(true);
 
-    it('should allow force re-add with different name', async () => {
-      await initTestTuck();
-
-      const manifest = await getTestManifest();
-      manifest.files['zshrc'] = createMockTrackedFile({
-        source: '~/.zshrc',
-        destination: 'files/zshrc',
-      });
-
-      // Can add same source with different name
-      manifest.files['zshrc-backup'] = createMockTrackedFile({
-        source: '~/.zshrc',
-        destination: 'files/zshrc-backup',
-      });
-
-      expect(manifest.files['zshrc']).toBeDefined();
-      expect(manifest.files['zshrc-backup']).toBeDefined();
-    });
+    await expect(addFilesFromPaths(['~/.zshrc'])).rejects.toBeInstanceOf(SecretsDetectedError);
   });
 
-  describe('path handling', () => {
-    it('should expand tilde in paths', () => {
-      const tildePath = '~/.zshrc';
-      // String replacement preserves forward slashes from TEST_HOME
-      const expanded = tildePath.replace('~', TEST_HOME);
-      // Compare with a similarly constructed path using string concatenation
-      expect(expanded).toBe(TEST_HOME + '/.zshrc');
-    });
+  it('skips scanning when force flag is enabled', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
 
-    it('should handle absolute paths', async () => {
-      await initTestTuck();
+    const count = await addFilesFromPaths(['~/.zshrc'], { force: true });
 
-      const absolutePath = path.join(TEST_HOME, '.zshrc');
-      await createTestDotfile('.zshrc', 'content');
-
-      const exists = vol.existsSync(absolutePath);
-      expect(exists).toBe(true);
-    });
-
-    it('should normalize destination paths', () => {
-      const source = '~/.config/nvim/init.vim';
-      // Destination should be a safe filename
-      const destination = source
-        .replace('~/', '')
-        .replace(/\//g, '_')
-        .replace(/\./g, '');
-
-      expect(destination).not.toContain('/');
-    });
-  });
-
-  describe('metadata', () => {
-    it('should store add timestamp', () => {
-      const trackedFile = createMockTrackedFile({
-        added: '2024-01-15T10:30:00.000Z',
-      });
-
-      expect(trackedFile.added).toBeDefined();
-      expect(new Date(trackedFile.added).getTime()).toBeGreaterThan(0);
-    });
-
-    it('should store file checksum', () => {
-      const trackedFile = createMockTrackedFile({
-        checksum: 'abc123def456',
-      });
-
-      expect(trackedFile.checksum).toBeDefined();
-      expect(trackedFile.checksum.length).toBeGreaterThan(0);
-    });
-
-    it('should track encryption status', () => {
-      const unencrypted = createMockTrackedFile({ encrypted: false });
-      const encrypted = createMockTrackedFile({ encrypted: true });
-
-      expect(unencrypted.encrypted).toBe(false);
-      expect(encrypted.encrypted).toBe(true);
-    });
-
-    it('should track template status', () => {
-      const nonTemplate = createMockTrackedFile({ template: false });
-      const template = createMockTrackedFile({ template: true });
-
-      expect(nonTemplate.template).toBe(false);
-      expect(template.template).toBe(true);
-    });
+    expect(count).toBe(1);
+    expect(scanForSecretsMock).not.toHaveBeenCalled();
+    expect(trackFilesWithProgressMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -220,4 +220,19 @@ describe('add command behavior', () => {
       })
     );
   });
+
+  it('passes custom --name through to tracking destination generation', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
+    sanitizeFilenameMock.mockReturnValueOnce('custom-zshrc');
+
+    await addFilesFromPaths(['~/.zshrc'], { force: true, name: 'custom-zshrc' });
+
+    expect(trackFilesWithProgressMock).toHaveBeenCalledWith(
+      [{ path: '~/.zshrc', category: 'shell', name: 'custom-zshrc' }],
+      '/test-home/.tuck',
+      expect.objectContaining({
+        strategy: undefined,
+      })
+    );
+  });
 });

--- a/tests/commands/apply.test.ts
+++ b/tests/commands/apply.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+
+const cloneRepoMock = vi.fn();
+const createPreApplySnapshotMock = vi.fn();
+const findPlaceholdersMock = vi.fn();
+const restoreContentMock = vi.fn();
+const restoreSecretsMock = vi.fn();
+const getAllSecretsMock = vi.fn();
+const getSecretCountMock = vi.fn();
+
+const loggerInfoMock = vi.fn();
+const loggerSuccessMock = vi.fn();
+const loggerWarningMock = vi.fn();
+const loggerHeadingMock = vi.fn();
+const loggerBlankMock = vi.fn();
+const loggerFileMock = vi.fn();
+const loggerDimMock = vi.fn();
+
+let cloneSetup: ((dir: string) => void) | null = null;
+let clonedDir: string | null = null;
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+    },
+    note: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('merge'),
+    multiselect: vi.fn().mockResolvedValue([]),
+    cancel: vi.fn(),
+  },
+  logger: {
+    info: loggerInfoMock,
+    success: loggerSuccessMock,
+    warning: loggerWarningMock,
+    heading: loggerHeadingMock,
+    blank: loggerBlankMock,
+    file: loggerFileMock,
+    dim: loggerDimMock,
+    debug: vi.fn(),
+  },
+  colors: {
+    yellow: (x: string) => x,
+    dim: (x: string) => x,
+    bold: (x: string) => x,
+    green: (x: string) => x,
+    cyan: (x: string) => x,
+  },
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  cloneRepo: cloneRepoMock,
+}));
+
+vi.mock('../../src/lib/github.js', () => ({
+  isGhInstalled: vi.fn().mockResolvedValue(false),
+  findDotfilesRepo: vi.fn().mockResolvedValue(null),
+  ghCloneRepo: vi.fn(),
+  repoExists: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../../src/lib/timemachine.js', () => ({
+  createPreApplySnapshot: createPreApplySnapshotMock,
+}));
+
+vi.mock('../../src/lib/merge.js', () => ({
+  smartMerge: vi.fn(async (_destination: string, content: string) => ({
+    content,
+    preservedBlocks: 0,
+  })),
+  isShellFile: vi.fn().mockReturnValue(false),
+  generateMergePreview: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  findPlaceholders: findPlaceholdersMock,
+  restoreContent: restoreContentMock,
+  restoreFiles: restoreSecretsMock,
+  getAllSecrets: getAllSecretsMock,
+  getSecretCount: getSecretCountMock,
+}));
+
+vi.mock('../../src/lib/secretBackends/index.js', () => ({
+  createResolver: vi.fn(),
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: vi.fn().mockResolvedValue({
+    security: {
+      secretBackend: 'local',
+    },
+  }),
+}));
+
+vi.mock('../../src/lib/platform.js', () => ({
+  IS_WINDOWS: false,
+}));
+
+describe('apply command behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vol.reset();
+    cloneSetup = null;
+    clonedDir = null;
+
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+
+    cloneRepoMock.mockImplementation(async (_url: string, dir: string) => {
+      clonedDir = dir;
+      vol.mkdirSync(dir, { recursive: true });
+      if (cloneSetup) {
+        cloneSetup(dir);
+      }
+    });
+
+    findPlaceholdersMock.mockReturnValue([]);
+    restoreContentMock.mockImplementation((content: string) => ({
+      restoredContent: content,
+      unresolved: [],
+    }));
+    restoreSecretsMock.mockResolvedValue({ totalRestored: 0, allUnresolved: [] });
+    getAllSecretsMock.mockResolvedValue({});
+    getSecretCountMock.mockResolvedValue(0);
+    createPreApplySnapshotMock.mockResolvedValue({ id: 'snapshot-test' });
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('applies only safe manifest entries in dry-run mode', async () => {
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          safe: createMockTrackedFile({
+            source: '~/.zshrc',
+            destination: 'files/shell/zshrc',
+          }),
+          unsafeSource: createMockTrackedFile({
+            source: '~/../etc/passwd',
+            destination: 'files/misc/passwd',
+          }),
+          unsafeDestination: createMockTrackedFile({
+            source: '~/.gitconfig',
+            destination: '../../evil',
+          }),
+        },
+      });
+
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), 'export SAFE=1');
+    };
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { dryRun: true });
+
+    expect(cloneRepoMock).toHaveBeenCalledWith(
+      'https://github.com/user/repo.git',
+      expect.any(String)
+    );
+    expect(createPreApplySnapshotMock).not.toHaveBeenCalled();
+    expect(loggerWarningMock).toHaveBeenCalledWith('Skipping unsafe manifest entry: ~/../etc/passwd');
+    expect(loggerWarningMock).toHaveBeenCalledWith('Skipping unsafe manifest entry: ~/.gitconfig');
+    expect(loggerInfoMock).toHaveBeenCalledWith('Would apply 1 files');
+
+    if (clonedDir) {
+      expect(vol.existsSync(clonedDir)).toBe(false);
+    }
+  });
+
+  it('creates a snapshot and writes files in replace mode', async () => {
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          safe: createMockTrackedFile({
+            source: '~/.zshrc',
+            destination: 'files/shell/zshrc',
+          }),
+        },
+      });
+
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), 'export NEW=1');
+    };
+
+    vol.writeFileSync(join(TEST_HOME, '.zshrc'), 'export OLD=1');
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true });
+
+    expect(createPreApplySnapshotMock).toHaveBeenCalledTimes(1);
+    expect(createPreApplySnapshotMock).toHaveBeenCalledWith(
+      [join(TEST_HOME, '.zshrc')],
+      'user/repo'
+    );
+    expect(vol.readFileSync(join(TEST_HOME, '.zshrc'), 'utf-8')).toBe('export NEW=1');
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Applied 1 files');
+
+    if (clonedDir) {
+      expect(vol.existsSync(clonedDir)).toBe(false);
+    }
+  });
+
+  it('throws when cloned repository has no tuck manifest', async () => {
+    cloneSetup = (_dir: string) => {
+      // Intentionally leave out .tuckmanifest.json
+    };
+
+    const { runApply } = await import('../../src/commands/apply.js');
+
+    await expect(runApply('user/repo', {})).rejects.toThrow('No tuck manifest found in repository');
+
+    if (clonedDir) {
+      expect(vol.existsSync(clonedDir)).toBe(false);
+    }
+  });
+});

--- a/tests/commands/cli-smoke.test.ts
+++ b/tests/commands/cli-smoke.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import {
+  initCommand,
+  addCommand,
+  removeCommand,
+  syncCommand,
+  pushCommand,
+  pullCommand,
+  restoreCommand,
+  statusCommand,
+  listCommand,
+  diffCommand,
+  configCommand,
+  applyCommand,
+  undoCommand,
+  scanCommand,
+  secretsCommand,
+  encryptionCommand,
+  doctorCommand,
+} from '../../src/commands/index.js';
+
+const buildProgram = (): Command => {
+  const program = new Command('tuck');
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+
+  program.addCommand(initCommand);
+  program.addCommand(addCommand);
+  program.addCommand(removeCommand);
+  program.addCommand(syncCommand);
+  program.addCommand(pushCommand);
+  program.addCommand(pullCommand);
+  program.addCommand(restoreCommand);
+  program.addCommand(statusCommand);
+  program.addCommand(listCommand);
+  program.addCommand(diffCommand);
+  program.addCommand(configCommand);
+  program.addCommand(applyCommand);
+  program.addCommand(undoCommand);
+  program.addCommand(scanCommand);
+  program.addCommand(secretsCommand);
+  program.addCommand(encryptionCommand);
+  program.addCommand(doctorCommand);
+
+  return program;
+};
+
+describe('CLI smoke', () => {
+  it('registers commands including doctor without duplicate names', () => {
+    const program = buildProgram();
+    const names = program.commands.map((command) => command.name());
+
+    expect(names).toContain('doctor');
+    expect(names).toContain('apply');
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('parses doctor help and apply help', async () => {
+    const program = buildProgram();
+
+    await expect(
+      program.parseAsync(['node', 'tuck', 'doctor', '--help'], { from: 'user' })
+    ).rejects.toMatchObject({ code: 'commander.helpDisplayed' });
+
+    await expect(
+      program.parseAsync(['node', 'tuck', 'apply', '--help'], { from: 'user' })
+    ).rejects.toMatchObject({ code: 'commander.helpDisplayed' });
+  });
+
+  it('rejects unknown commands', async () => {
+    const program = buildProgram();
+
+    await expect(
+      program.parseAsync(['node', 'tuck', 'does-not-exist'], { from: 'user' })
+    ).rejects.toMatchObject({ code: 'commander.unknownCommand' });
+  });
+});

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const runDoctorChecksMock = vi.fn();
+const getDoctorExitCodeMock = vi.fn();
+
+const loggerSuccessMock = vi.fn();
+const loggerWarningMock = vi.fn();
+const loggerErrorMock = vi.fn();
+const loggerInfoMock = vi.fn();
+const loggerDimMock = vi.fn();
+const loggerBlankMock = vi.fn();
+
+const promptsIntroMock = vi.fn();
+const promptsOutroMock = vi.fn();
+
+vi.mock('../../src/lib/doctor.js', () => ({
+  DOCTOR_CATEGORIES: ['env', 'repo', 'manifest', 'security', 'hooks'],
+  runDoctorChecks: runDoctorChecksMock,
+  getDoctorExitCode: getDoctorExitCodeMock,
+}));
+
+vi.mock('../../src/ui/index.js', () => ({
+  logger: {
+    success: loggerSuccessMock,
+    warning: loggerWarningMock,
+    error: loggerErrorMock,
+    info: loggerInfoMock,
+    dim: loggerDimMock,
+    blank: loggerBlankMock,
+  },
+  prompts: {
+    intro: promptsIntroMock,
+    outro: promptsOutroMock,
+  },
+}));
+
+describe('doctor command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  it('prints human output and sets exit code for failures', async () => {
+    runDoctorChecksMock.mockResolvedValue({
+      generatedAt: '2026-02-11T00:00:00.000Z',
+      tuckDir: '/test-home/.tuck',
+      summary: { passed: 1, warnings: 0, failed: 1 },
+      checks: [
+        {
+          id: 'repo.tuck-directory',
+          category: 'repo',
+          status: 'fail',
+          message: 'Missing tuck directory',
+          fix: 'Run tuck init',
+        },
+      ],
+    });
+    getDoctorExitCodeMock.mockReturnValue(1);
+
+    const { runDoctor } = await import('../../src/commands/doctor.js');
+
+    await runDoctor({ strict: true });
+
+    expect(promptsIntroMock).toHaveBeenCalledWith('tuck doctor');
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
+    expect(loggerDimMock).toHaveBeenCalledWith('  Fix: Run tuck init');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('prints JSON output when requested', async () => {
+    const jsonSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    runDoctorChecksMock.mockResolvedValue({
+      generatedAt: '2026-02-11T00:00:00.000Z',
+      tuckDir: '/test-home/.tuck',
+      summary: { passed: 2, warnings: 1, failed: 0 },
+      checks: [],
+    });
+    getDoctorExitCodeMock.mockReturnValue(2);
+
+    const { runDoctor } = await import('../../src/commands/doctor.js');
+
+    await runDoctor({ json: true, strict: true });
+
+    expect(jsonSpy).toHaveBeenCalledTimes(1);
+    expect(promptsIntroMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(2);
+
+    jsonSpy.mockRestore();
+  });
+
+  it('validates category option on command parse', async () => {
+    const { doctorCommand } = await import('../../src/commands/doctor.js');
+
+    await expect(
+      doctorCommand.parseAsync(['node', 'doctor', '--category', 'invalid'], { from: 'user' })
+    ).rejects.toThrow('Invalid category "invalid"');
+  });
+});

--- a/tests/commands/list.test.ts
+++ b/tests/commands/list.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+
+const promptsIntroMock = vi.fn();
+const promptsOutroMock = vi.fn();
+const promptsWarningMock = vi.fn();
+const promptsNoteMock = vi.fn();
+
+const loggerWarningMock = vi.fn();
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  getAllTrackedFiles: getAllTrackedFilesMock,
+}));
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: promptsIntroMock,
+    outro: promptsOutroMock,
+    log: {
+      warning: promptsWarningMock,
+    },
+    note: promptsNoteMock,
+  },
+  logger: {
+    warning: loggerWarningMock,
+  },
+  formatCount: vi.fn((count: number, label: string) => `${count} ${label}${count === 1 ? '' : 's'}`),
+  colors: {
+    bold: (x: string) => x,
+    dim: (x: string) => x,
+    cyan: (x: string) => x,
+  },
+}));
+
+describe('list command', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        category: 'shell',
+      },
+      gitconfig: {
+        source: '~/.gitconfig',
+        destination: 'files/git/gitconfig',
+        category: 'git',
+      },
+    });
+  });
+
+  it('prints grouped files in default mode', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { listCommand } = await import('../../src/commands/list.js');
+
+    await listCommand.parseAsync(['node', 'list'], { from: 'user' });
+
+    expect(promptsIntroMock).toHaveBeenCalledWith('tuck list');
+    expect(promptsOutroMock).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
+  it('prints JSON output when --json is passed', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { listCommand } = await import('../../src/commands/list.js');
+
+    await listCommand.parseAsync(['node', 'list', '--json'], { from: 'user' });
+
+    const output = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(output).toContain('"shell"');
+    expect(output).toContain('"source": "~/.zshrc"');
+
+    logSpy.mockRestore();
+  });
+
+  it('prints only paths when --paths is passed', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { listCommand } = await import('../../src/commands/list.js');
+
+    await listCommand.parseAsync(['node', 'list', '--paths'], { from: 'user' });
+
+    const lines = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(lines).toContain('~/.zshrc');
+    expect(lines).toContain('~/.gitconfig');
+
+    logSpy.mockRestore();
+  });
+
+  it('throws NotInitializedError when manifest is missing', async () => {
+    loadManifestMock.mockRejectedValueOnce(new Error('missing manifest'));
+    const { listCommand } = await import('../../src/commands/list.js');
+
+    await expect(listCommand.parseAsync(['node', 'list'], { from: 'user' })).rejects.toMatchObject({
+      code: 'NOT_INITIALIZED',
+    });
+  });
+
+  it('warns when category filter has no matches', async () => {
+    const { listCommand } = await import('../../src/commands/list.js');
+
+    await listCommand.parseAsync(['node', 'list', '--category', 'terminal'], { from: 'user' });
+
+    expect(loggerWarningMock).toHaveBeenCalledWith('No files found in category: terminal');
+  });
+});

--- a/tests/commands/pull.test.ts
+++ b/tests/commands/pull.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadManifestMock = vi.fn();
+const checkLocalModeMock = vi.fn();
+const showLocalModeWarningForPullMock = vi.fn();
+const pullMock = vi.fn();
+const fetchMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const getRemoteUrlMock = vi.fn();
+const getStatusMock = vi.fn();
+const getCurrentBranchMock = vi.fn();
+const loggerSuccessMock = vi.fn();
+const loggerInfoMock = vi.fn();
+const promptsIntroMock = vi.fn();
+const promptsOutroMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: promptsIntroMock,
+    outro: promptsOutroMock,
+    confirm: vi.fn().mockResolvedValue(true),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    log: {
+      error: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+    },
+  },
+  logger: {
+    success: loggerSuccessMock,
+    info: loggerInfoMock,
+  },
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  colors: {
+    dim: (x: string) => x,
+    yellow: (x: string) => x,
+  },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+}));
+
+vi.mock('../../src/lib/remoteChecks.js', () => ({
+  checkLocalMode: checkLocalModeMock,
+  showLocalModeWarningForPull: showLocalModeWarningForPullMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  pull: pullMock,
+  fetch: fetchMock,
+  hasRemote: hasRemoteMock,
+  getRemoteUrl: getRemoteUrlMock,
+  getStatus: getStatusMock,
+  getCurrentBranch: getCurrentBranchMock,
+}));
+
+describe('pull command', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    checkLocalModeMock.mockResolvedValue(false);
+    showLocalModeWarningForPullMock.mockResolvedValue(undefined);
+    fetchMock.mockResolvedValue(undefined);
+    pullMock.mockResolvedValue(undefined);
+    hasRemoteMock.mockResolvedValue(true);
+    getRemoteUrlMock.mockResolvedValue('https://github.com/example/dotfiles.git');
+    getCurrentBranchMock.mockResolvedValue('main');
+    getStatusMock.mockResolvedValue({
+      behind: 0,
+      ahead: 0,
+      modified: [],
+      staged: [],
+    });
+  });
+
+  it('throws NOT_INITIALIZED when manifest is missing', async () => {
+    loadManifestMock.mockRejectedValueOnce(new Error('missing manifest'));
+    const { pullCommand } = await import('../../src/commands/pull.js');
+
+    await expect(pullCommand.parseAsync(['node', 'pull', '--rebase'], { from: 'user' })).rejects.toMatchObject({
+      code: 'NOT_INITIALIZED',
+    });
+  });
+
+  it('pulls with rebase in non-interactive mode', async () => {
+    const { pullCommand } = await import('../../src/commands/pull.js');
+
+    await pullCommand.parseAsync(['node', 'pull', '--rebase'], { from: 'user' });
+
+    expect(fetchMock).toHaveBeenCalledWith('/test-home/.tuck');
+    expect(pullMock).toHaveBeenCalledWith('/test-home/.tuck', { rebase: true });
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Pulled successfully!');
+  });
+
+  it('runs interactive flow when no flags are provided', async () => {
+    const { pullCommand } = await import('../../src/commands/pull.js');
+
+    await pullCommand.parseAsync(['node', 'pull'], { from: 'user' });
+
+    expect(promptsIntroMock).toHaveBeenCalledWith('tuck pull');
+    expect(fetchMock).toHaveBeenCalledWith('/test-home/.tuck');
+  });
+
+  it('throws when in local-only mode', async () => {
+    checkLocalModeMock.mockResolvedValueOnce(true);
+    const { pullCommand } = await import('../../src/commands/pull.js');
+
+    await expect(pullCommand.parseAsync(['node', 'pull', '--rebase'], { from: 'user' })).rejects.toMatchObject({
+      code: 'GIT_ERROR',
+    });
+  });
+});

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { runRemove } from '../../src/commands/remove.js';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { TEST_TUCK_DIR } from '../setup.js';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+
+describe('remove command manifest safety', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+  });
+
+  it('rejects unsafe repository destinations before deletion', async () => {
+    const manifest = createMockManifest();
+    manifest.files['unsafe-destination'] = createMockTrackedFile({
+      source: '~/.zshrc',
+      destination: 'files/../../outside',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+
+    await expect(runRemove(['~/.zshrc'], { delete: true })).rejects.toThrow(
+      'Unsafe manifest destination'
+    );
+  });
+
+  it('rejects unsafe source paths from manifest entries', async () => {
+    const manifest = createMockManifest();
+    manifest.files['unsafe-source'] = createMockTrackedFile({
+      source: '/etc/passwd',
+      destination: 'files/shell/zshrc',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+
+    await expect(runRemove(['/etc/passwd'], { delete: true })).rejects.toThrow('Unsafe path');
+  });
+});

--- a/tests/commands/restore.test.ts
+++ b/tests/commands/restore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'path';
 import { NotInitializedError } from '../../src/errors.js';
 
 const loadManifestMock = vi.fn();
@@ -139,7 +140,7 @@ describe('restore command behavior', () => {
 
     expect(copyFileOrDirMock.mock.calls.length + createSymlinkMock.mock.calls.length).toBe(1);
     expect(validatePathWithinRootMock).toHaveBeenCalledWith(
-      '/test-home/.tuck/files/shell/zshrc',
+      join('/test-home/.tuck', 'files', 'shell', 'zshrc'),
       '/test-home/.tuck',
       'restore source'
     );

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -7,6 +7,7 @@ const detectDotfilesMock = vi.fn();
 const isIgnoredMock = vi.fn();
 const shouldExcludeFromBinMock = vi.fn();
 const trackFilesWithProgressMock = vi.fn();
+const preparePathsForTrackingMock = vi.fn();
 
 const loggerInfoMock = vi.fn();
 const loggerWarnMock = vi.fn();
@@ -85,6 +86,10 @@ vi.mock('../../src/lib/fileTracking.js', () => ({
   trackFilesWithProgress: trackFilesWithProgressMock,
 }));
 
+vi.mock('../../src/lib/trackPipeline.js', () => ({
+  preparePathsForTracking: preparePathsForTrackingMock,
+}));
+
 describe('scan command behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -108,6 +113,17 @@ describe('scan command behavior', () => {
       errors: [],
       sensitiveFiles: [],
     });
+    preparePathsForTrackingMock.mockResolvedValue([
+      {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        category: 'shell',
+        filename: 'zshrc',
+        isDir: false,
+        fileCount: 1,
+        sensitive: false,
+      },
+    ]);
     promptsSelectMock.mockResolvedValue('preview');
     promptsConfirmMock.mockResolvedValue(false);
   });
@@ -148,6 +164,7 @@ describe('scan command behavior', () => {
 
     await runScan({});
 
+    expect(preparePathsForTrackingMock).toHaveBeenCalledTimes(1);
     expect(trackFilesWithProgressMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { detectFileChanges } from '../../src/commands/status.js';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { TEST_TUCK_DIR } from '../setup.js';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+
+describe('status command manifest safety', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+  });
+
+  it('rejects unsafe source paths from manifest entries', async () => {
+    const manifest = createMockManifest();
+    manifest.files['unsafe-source'] = createMockTrackedFile({
+      source: '~/../etc/passwd',
+      destination: 'files/shell/zshrc',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+
+    await expect(detectFileChanges(TEST_TUCK_DIR)).rejects.toThrow('path traversal');
+  });
+
+  it('rejects unsafe destination paths from manifest entries', async () => {
+    const manifest = createMockManifest();
+    manifest.files['unsafe-destination'] = createMockTrackedFile({
+      source: '~/.zshrc',
+      destination: 'files/../../outside',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+
+    await expect(detectFileChanges(TEST_TUCK_DIR)).rejects.toThrow('Unsafe manifest destination');
+  });
+});

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'path';
 import { NotInitializedError } from '../../src/errors.js';
 
 const loadManifestMock = vi.fn();
@@ -201,7 +202,7 @@ describe('sync command behavior', () => {
     expect(copyFileOrDirMock).toHaveBeenCalledTimes(1);
     expect(updateFileInManifestMock).toHaveBeenCalledTimes(1);
     expect(validatePathWithinRootMock).toHaveBeenCalledWith(
-      '/test-home/.tuck/files/shell/zshrc',
+      join('/test-home/.tuck', 'files', 'shell', 'zshrc'),
       '/test-home/.tuck',
       'sync destination'
     );

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -64,6 +64,13 @@ vi.mock('../../src/lib/paths.js', () => ({
   expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
   pathExists: pathExistsMock,
   collapsePath: vi.fn((p: string) => p),
+  getDestinationPathFromSource: vi.fn(
+    (tuckDir: string, category: string, sourcePath: string) =>
+      `${tuckDir}/files/${category}/${String(sourcePath).replace(/^~\//, '')}`
+  ),
+  detectCategory: vi.fn(() => 'misc'),
+  sanitizeFilename: vi.fn((path: string) => path.split('/').pop() || 'file'),
+  isDirectory: vi.fn().mockResolvedValue(false),
   validateSafeSourcePath: validateSafeSourcePathMock,
   validateSafeManifestDestination: validateSafeManifestDestinationMock,
   validatePathWithinRoot: validatePathWithinRootMock,

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -1,329 +1,190 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { vol } from 'memfs';
-import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
-import { initTestTuck, createTestDotfile } from '../utils/testHelpers.js';
-import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
-import path from 'path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotInitializedError } from '../../src/errors.js';
 
-// Mock simple-git
-const mockGit = {
-  init: vi.fn().mockResolvedValue(undefined),
-  add: vi.fn().mockResolvedValue(undefined),
-  commit: vi.fn().mockResolvedValue({ commit: 'abc123' }),
-  push: vi.fn().mockResolvedValue(undefined),
-  pull: vi.fn().mockResolvedValue(undefined),
-  fetch: vi.fn().mockResolvedValue(undefined),
-  status: vi.fn().mockResolvedValue({
-    isClean: () => true,
-    modified: [],
-    deleted: [],
-    not_added: [],
-    files: [],
-  }),
-  log: vi.fn().mockResolvedValue({ latest: { hash: 'abc123' } }),
-  checkIsRepo: vi.fn().mockResolvedValue(true),
-  raw: vi.fn().mockResolvedValue(''),
-  getRemotes: vi.fn().mockResolvedValue([{ name: 'origin', refs: { fetch: 'https://github.com/test/dotfiles.git' } }]),
-};
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+const updateFileInManifestMock = vi.fn();
+const removeFileFromManifestMock = vi.fn();
+const getTrackedFileBySourceMock = vi.fn();
+const pathExistsMock = vi.fn();
+const copyFileOrDirMock = vi.fn();
+const getFileChecksumMock = vi.fn();
+const deleteFileOrDirMock = vi.fn();
+const loadTuckignoreMock = vi.fn();
+const isIgnoredMock = vi.fn();
+const runPreSyncHookMock = vi.fn();
+const runPostSyncHookMock = vi.fn();
+const stageAllMock = vi.fn();
+const commitMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const pushMock = vi.fn();
+const loggerInfoMock = vi.fn();
 
-vi.mock('simple-git', () => ({
-  simpleGit: vi.fn(() => mockGit),
-  default: vi.fn(() => mockGit),
-}));
-
-// Mock UI
 vi.mock('../../src/ui/index.js', () => ({
   prompts: {
     intro: vi.fn(),
     outro: vi.fn(),
-    confirm: vi.fn().mockResolvedValue(true),
-    select: vi.fn(),
-    text: vi.fn().mockResolvedValue('sync changes'),
-    multiselect: vi.fn().mockResolvedValue([]),
+    confirm: vi.fn().mockResolvedValue(false),
+    confirmDangerous: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('abort'),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
     log: {
       info: vi.fn(),
       success: vi.fn(),
-      warn: vi.fn(),
+      warning: vi.fn(),
       error: vi.fn(),
       step: vi.fn(),
       message: vi.fn(),
     },
-    note: vi.fn(),
-    cancel: vi.fn(),
-    spinner: vi.fn(() => ({
-      start: vi.fn(),
-      stop: vi.fn(),
-      message: '',
-    })),
   },
   logger: {
-    info: vi.fn(),
-    success: vi.fn(),
+    info: loggerInfoMock,
+    warning: vi.fn(),
     warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
+    success: vi.fn(),
+    file: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    dim: vi.fn(),
   },
-  banner: vi.fn(),
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  colors: {
+    dim: (x: string) => x,
+  },
 }));
 
-describe('sync command', () => {
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  pathExists: pathExistsMock,
+  collapsePath: vi.fn((p: string) => p),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  getAllTrackedFiles: getAllTrackedFilesMock,
+  updateFileInManifest: updateFileInManifestMock,
+  removeFileFromManifest: removeFileFromManifestMock,
+  getTrackedFileBySource: getTrackedFileBySourceMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  stageAll: stageAllMock,
+  commit: commitMock,
+  getStatus: vi.fn().mockResolvedValue({ behind: 0 }),
+  push: pushMock,
+  hasRemote: hasRemoteMock,
+  fetch: vi.fn(),
+  pull: vi.fn(),
+}));
+
+vi.mock('../../src/lib/files.js', () => ({
+  copyFileOrDir: copyFileOrDirMock,
+  getFileChecksum: getFileChecksumMock,
+  deleteFileOrDir: deleteFileOrDirMock,
+  checkFileSizeThreshold: vi.fn().mockResolvedValue({ warn: false, block: false, size: 10 }),
+  formatFileSize: vi.fn((n: number) => `${n} B`),
+  SIZE_BLOCK_THRESHOLD: 100 * 1024 * 1024,
+}));
+
+vi.mock('../../src/lib/tuckignore.js', () => ({
+  addToTuckignore: vi.fn(),
+  loadTuckignore: loadTuckignoreMock,
+  isIgnored: isIgnoredMock,
+}));
+
+vi.mock('../../src/lib/hooks.js', () => ({
+  runPreSyncHook: runPreSyncHookMock,
+  runPostSyncHook: runPostSyncHookMock,
+}));
+
+vi.mock('../../src/lib/detect.js', () => ({
+  detectDotfiles: vi.fn().mockResolvedValue([]),
+  DETECTION_CATEGORIES: {},
+}));
+
+vi.mock('../../src/lib/fileTracking.js', () => ({
+  trackFilesWithProgress: vi.fn().mockResolvedValue({
+    succeeded: 0,
+    failed: 0,
+    errors: [],
+    sensitiveFiles: [],
+  }),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  scanForSecrets: vi.fn().mockResolvedValue({ totalSecrets: 0, results: [] }),
+  isSecretScanningEnabled: vi.fn().mockResolvedValue(false),
+  shouldBlockOnSecrets: vi.fn().mockResolvedValue(true),
+  processSecretsForRedaction: vi.fn(),
+  redactFile: vi.fn(),
+}));
+
+vi.mock('../../src/commands/secrets.js', () => ({
+  displayScanResults: vi.fn(),
+}));
+
+vi.mock('../../src/lib/audit.js', () => ({
+  logForceSecretBypass: vi.fn(),
+}));
+
+describe('sync command behavior', () => {
   beforeEach(() => {
-    vol.reset();
     vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    loadTuckignoreMock.mockResolvedValue(new Set());
+    getAllTrackedFilesMock.mockResolvedValue({});
+    pathExistsMock.mockResolvedValue(true);
+    isIgnoredMock.mockResolvedValue(false);
+    getFileChecksumMock.mockResolvedValue('new-checksum');
+    hasRemoteMock.mockResolvedValue(false);
+    commitMock.mockResolvedValue('abc123def456');
   });
 
-  afterEach(() => {
-    vol.reset();
+  it('throws NotInitializedError when manifest is missing', async () => {
+    loadManifestMock.mockRejectedValueOnce(new Error('missing manifest'));
+    const { runSync } = await import('../../src/commands/sync.js');
+
+    await expect(runSync()).rejects.toBeInstanceOf(NotInitializedError);
   });
 
-  describe('change detection', () => {
-    it('should detect modified tracked files', async () => {
-      const manifest = createMockManifest({
-        files: {
-          'zshrc': createMockTrackedFile({
-            source: '~/.zshrc',
-            destination: 'files/zshrc',
-            checksum: 'original-checksum',
-          }),
-        },
-      });
-
-      await initTestTuck({ manifest });
-
-      // Create the tracked file in tuck
-      vol.mkdirSync(path.join(TEST_TUCK_DIR, 'files'), { recursive: true });
-      vol.writeFileSync(
-        path.join(TEST_TUCK_DIR, 'files/zshrc'),
-        'original content'
-      );
-
-      // Create the source file with different content
-      await createTestDotfile('.zshrc', 'modified content');
-
-      // Read both files
-      const sourceContent = vol.readFileSync(
-        path.join(TEST_HOME, '.zshrc'),
-        'utf-8'
-      );
-      const trackedContent = vol.readFileSync(
-        path.join(TEST_TUCK_DIR, 'files/zshrc'),
-        'utf-8'
-      );
-
-      expect(sourceContent).not.toBe(trackedContent);
+  it('logs no changes when tracked files are unchanged', async () => {
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        checksum: 'same',
+      },
     });
+    getFileChecksumMock.mockResolvedValue('same');
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
 
-    it('should detect deleted source files', async () => {
-      const manifest = createMockManifest({
-        files: {
-          'zshrc': createMockTrackedFile({
-            source: '~/.zshrc',
-            destination: 'files/zshrc',
-          }),
-        },
-      });
+    await runSyncCommand('sync: noop', { noCommit: true, noHooks: true, scan: false, pull: false });
 
-      await initTestTuck({ manifest });
-
-      // Create the tracked file in tuck but NOT the source
-      vol.mkdirSync(path.join(TEST_TUCK_DIR, 'files'), { recursive: true });
-      vol.writeFileSync(
-        path.join(TEST_TUCK_DIR, 'files/zshrc'),
-        'content'
-      );
-
-      // Source file doesn't exist
-      const sourceExists = vol.existsSync(path.join(TEST_HOME, '.zshrc'));
-      expect(sourceExists).toBe(false);
-    });
-
-    it('should detect new files in source locations', async () => {
-      await initTestTuck();
-
-      // Create new dotfile that isn't tracked
-      await createTestDotfile('.newconfig', 'new config content');
-
-      const fileExists = vol.existsSync(path.join(TEST_HOME, '.newconfig'));
-      expect(fileExists).toBe(true);
-    });
+    expect(loggerInfoMock).toHaveBeenCalledWith('No changes detected');
+    expect(copyFileOrDirMock).not.toHaveBeenCalled();
   });
 
-  describe('file synchronization', () => {
-    it('should update tracked file with source changes', async () => {
-      const manifest = createMockManifest({
-        files: {
-          'zshrc': createMockTrackedFile({
-            source: '~/.zshrc',
-            destination: 'files/zshrc',
-          }),
-        },
-      });
-
-      await initTestTuck({ manifest });
-
-      // Create source file with new content
-      await createTestDotfile('.zshrc', 'new content');
-
-      // Create tracked file location
-      vol.mkdirSync(path.join(TEST_TUCK_DIR, 'files'), { recursive: true });
-
-      // Simulate sync by copying source to tracked
-      const sourceContent = vol.readFileSync(
-        path.join(TEST_HOME, '.zshrc'),
-        'utf-8'
-      );
-      vol.writeFileSync(
-        path.join(TEST_TUCK_DIR, 'files/zshrc'),
-        sourceContent as string
-      );
-
-      // Verify sync
-      const trackedContent = vol.readFileSync(
-        path.join(TEST_TUCK_DIR, 'files/zshrc'),
-        'utf-8'
-      );
-      expect(trackedContent).toBe('new content');
+  it('syncs modified files and updates manifest when changes exist', async () => {
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        checksum: 'old',
+      },
     });
-  });
+    getFileChecksumMock.mockResolvedValue('new');
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
 
-  describe('pull functionality', () => {
-    it('should support --no-pull option', () => {
-      // Verify the option type
-      const options = {
-        pull: false,
-        scan: true,
-      };
+    await runSyncCommand('sync: update', { noCommit: true, noHooks: true, scan: false, pull: false });
 
-      expect(options.pull).toBe(false);
-    });
-
-    it('should pull by default', () => {
-      const options = {
-        pull: true,
-        scan: true,
-      };
-
-      expect(options.pull).toBe(true);
-    });
-  });
-
-  describe('scan functionality', () => {
-    it('should support --no-scan option', () => {
-      const options = {
-        pull: true,
-        scan: false,
-      };
-
-      expect(options.scan).toBe(false);
-    });
-
-    it('should scan by default', () => {
-      const options = {
-        pull: true,
-        scan: true,
-      };
-
-      expect(options.scan).toBe(true);
-    });
-  });
-
-  describe('commit behavior', () => {
-    it('should support custom commit message', () => {
-      const options = {
-        message: 'custom: update dotfiles',
-      };
-
-      expect(options.message).toBe('custom: update dotfiles');
-    });
-
-    it('should support --no-commit option', () => {
-      const options = {
-        noCommit: true,
-      };
-
-      expect(options.noCommit).toBe(true);
-    });
-  });
-
-  describe('push behavior', () => {
-    it('should push after commit by default when autoPush is true', () => {
-      const config = {
-        repository: {
-          autoPush: true,
-        },
-      };
-
-      expect(config.repository.autoPush).toBe(true);
-    });
-
-    it('should not push when autoPush is false', () => {
-      const config = {
-        repository: {
-          autoPush: false,
-        },
-      };
-
-      expect(config.repository.autoPush).toBe(false);
-    });
-  });
-
-  describe('all-in-one workflow', () => {
-    it('should handle complete sync workflow', async () => {
-      // Initialize tuck with a tracked file
-      const manifest = createMockManifest({
-        files: {
-          'zshrc': createMockTrackedFile({
-            source: '~/.zshrc',
-            destination: 'files/zshrc',
-          }),
-        },
-      });
-
-      await initTestTuck({ manifest });
-
-      // Set up files
-      vol.mkdirSync(path.join(TEST_TUCK_DIR, 'files'), { recursive: true });
-      await createTestDotfile('.zshrc', 'shell config');
-      vol.writeFileSync(
-        path.join(TEST_TUCK_DIR, 'files/zshrc'),
-        'shell config'
-      );
-
-      // Verify initial state
-      expect(vol.existsSync(TEST_TUCK_DIR)).toBe(true);
-      expect(vol.existsSync(path.join(TEST_HOME, '.zshrc'))).toBe(true);
-      expect(vol.existsSync(path.join(TEST_TUCK_DIR, 'files/zshrc'))).toBe(true);
-    });
-
-    it('should detect multiple file categories', async () => {
-      const manifest = createMockManifest({
-        files: {
-          'zshrc': createMockTrackedFile({
-            source: '~/.zshrc',
-            destination: 'files/zshrc',
-            category: 'shell',
-          }),
-          'gitconfig': createMockTrackedFile({
-            source: '~/.gitconfig',
-            destination: 'files/gitconfig',
-            category: 'git',
-          }),
-          'vimrc': createMockTrackedFile({
-            source: '~/.vimrc',
-            destination: 'files/vimrc',
-            category: 'editor',
-          }),
-        },
-      });
-
-      const categories = new Set(
-        Object.values(manifest.files).map((f) => f.category)
-      );
-
-      expect(categories.size).toBe(3);
-      expect(categories.has('shell')).toBe(true);
-      expect(categories.has('git')).toBe(true);
-      expect(categories.has('editor')).toBe(true);
-    });
+    expect(copyFileOrDirMock).toHaveBeenCalledTimes(1);
+    expect(updateFileInManifestMock).toHaveBeenCalledTimes(1);
+    expect(stageAllMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/backup-restore-cycle.test.ts
+++ b/tests/integration/backup-restore-cycle.test.ts
@@ -1,236 +1,66 @@
-/**
- * Backup and Restore Cycle Integration Tests
- *
- * Tests the complete backup and restore workflow.
- */
-
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { vol } from 'memfs';
 import { join } from 'path';
 import { TEST_HOME, TEST_BACKUPS_DIR } from '../utils/testHelpers.js';
-import { initTestTuck, createTestDotfile } from '../utils/testHelpers.js';
+import { initTestTuck } from '../utils/testHelpers.js';
+import {
+  createBackup,
+  restoreBackup,
+  listBackups,
+  cleanOldBackups,
+  getBackupSize,
+} from '../../src/lib/backup.js';
 
-describe('Backup and Restore Cycle', () => {
+describe('Backup and Restore Cycle Integration', () => {
   beforeEach(() => {
     vol.reset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-11T09:00:00.000Z'));
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vol.reset();
   });
 
-  // ============================================================================
-  // Backup Creation
-  // ============================================================================
+  it('creates and restores a backup for an actively edited dotfile', async () => {
+    await initTestTuck();
 
-  describe('Backup Creation', () => {
-    it('should create backup before modifying files', async () => {
-      await initTestTuck({
-        files: {
-          '.zshrc': 'original content',
-        },
-      });
+    const sourcePath = join(TEST_HOME, '.zshrc');
+    vol.writeFileSync(sourcePath, 'export PATH=$PATH:/original');
 
-      // Create backup directory
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
+    const backup = await createBackup(sourcePath);
+    vol.writeFileSync(sourcePath, 'export PATH=$PATH:/modified');
+    vi.setSystemTime(new Date('2026-02-11T09:00:10.000Z'));
 
-      // Simulate backup
-      const backupPath = join(TEST_BACKUPS_DIR, 'zshrc-backup');
-      vol.writeFileSync(backupPath, 'original content');
+    await restoreBackup(backup.backupPath, sourcePath);
 
-      expect(vol.existsSync(backupPath)).toBe(true);
-    });
-
-    it('should preserve file content in backup', async () => {
-      await initTestTuck();
-
-      const originalContent = 'important configuration\nexport PATH=$PATH:/custom/bin';
-      createTestDotfile('.important-rc', originalContent);
-
-      // Create backup
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
-      const backupPath = join(TEST_BACKUPS_DIR, 'important-rc-backup');
-      vol.writeFileSync(backupPath, originalContent);
-
-      const backedUpContent = vol.readFileSync(backupPath, 'utf-8');
-      expect(backedUpContent).toBe(originalContent);
-    });
-
-    it('should organize backups by date', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
-
-      const today = new Date().toISOString().slice(0, 10);
-      const todayBackups = join(TEST_BACKUPS_DIR, today);
-      vol.mkdirSync(todayBackups, { recursive: true });
-
-      vol.writeFileSync(join(todayBackups, 'zshrc-backup'), 'content');
-
-      expect(vol.existsSync(todayBackups)).toBe(true);
-    });
+    expect(vol.readFileSync(sourcePath, 'utf-8')).toBe('export PATH=$PATH:/original');
   });
 
-  // ============================================================================
-  // Restore Operations
-  // ============================================================================
+  it('surfaces backups through listing and size calculations', async () => {
+    await initTestTuck();
 
-  describe('Restore Operations', () => {
-    it('should restore file from backup', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
+    const sourcePath = join(TEST_HOME, '.gitconfig');
+    vol.writeFileSync(sourcePath, '[user]\n  name = Test');
+    await createBackup(sourcePath);
 
-      // Create original file
-      const originalPath = join(TEST_HOME, '.zshrc');
-      const backupPath = join(TEST_BACKUPS_DIR, 'zshrc-backup');
+    const backups = await listBackups();
+    const size = await getBackupSize();
 
-      vol.writeFileSync(backupPath, 'backed up content');
-      vol.writeFileSync(originalPath, 'current content');
-
-      // Simulate restore
-      const backupContent = vol.readFileSync(backupPath, 'utf-8');
-      vol.writeFileSync(originalPath, backupContent);
-
-      expect(vol.readFileSync(originalPath, 'utf-8')).toBe('backed up content');
-    });
-
-    it('should backup current file before restore', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
-
-      const currentContent = 'current important content';
-      const originalPath = join(TEST_HOME, '.zshrc');
-      vol.writeFileSync(originalPath, currentContent);
-
-      // Backup current before restore
-      const preRestoreBackup = join(TEST_BACKUPS_DIR, 'pre-restore-backup');
-      vol.writeFileSync(preRestoreBackup, currentContent);
-
-      expect(vol.readFileSync(preRestoreBackup, 'utf-8')).toBe(currentContent);
-    });
-
-    it('should handle missing backup gracefully', async () => {
-      await initTestTuck();
-
-      const missingBackup = join(TEST_BACKUPS_DIR, 'nonexistent');
-
-      expect(vol.existsSync(missingBackup)).toBe(false);
-    });
+    expect(backups.length).toBeGreaterThan(0);
+    expect(backups[0].path).toContain('2026-02-11');
+    expect(size).toBeGreaterThan(0);
   });
 
-  // ============================================================================
-  // Backup Cleanup
-  // ============================================================================
+  it('removes backups outside retention policy', async () => {
+    await initTestTuck();
+    vol.mkdirSync(join(TEST_BACKUPS_DIR, '2026-01-01'), { recursive: true });
+    vol.writeFileSync(join(TEST_BACKUPS_DIR, '2026-01-01', 'old.txt'), 'old');
 
-  describe('Backup Cleanup', () => {
-    it('should list all backups', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
+    const deleted = await cleanOldBackups(7);
 
-      // Create multiple dated backup directories
-      const dates = ['2024-01-01', '2024-01-02', '2024-01-03'];
-      dates.forEach((date) => {
-        const dateDir = join(TEST_BACKUPS_DIR, date);
-        vol.mkdirSync(dateDir, { recursive: true });
-        vol.writeFileSync(join(dateDir, 'backup.txt'), 'content');
-      });
-
-      // List directories
-      const backupDirs = vol.readdirSync(TEST_BACKUPS_DIR);
-      expect(backupDirs).toHaveLength(3);
-    });
-
-    it('should calculate total backup size', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
-
-      const dateDir = join(TEST_BACKUPS_DIR, '2024-01-01');
-      vol.mkdirSync(dateDir, { recursive: true });
-
-      vol.writeFileSync(join(dateDir, 'file1.txt'), 'a'.repeat(100));
-      vol.writeFileSync(join(dateDir, 'file2.txt'), 'b'.repeat(200));
-
-      // Calculate size manually
-      const file1Size = vol.statSync(join(dateDir, 'file1.txt')).size;
-      const file2Size = vol.statSync(join(dateDir, 'file2.txt')).size;
-
-      expect(file1Size + file2Size).toBe(300);
-    });
-
-    it('should delete old backups', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
-
-      // Create old backup directory
-      const oldDir = join(TEST_BACKUPS_DIR, '2020-01-01');
-      vol.mkdirSync(oldDir, { recursive: true });
-      vol.writeFileSync(join(oldDir, 'old.txt'), 'old content');
-
-      // Delete old backup
-      vol.rmdirSync(oldDir, { recursive: true });
-
-      expect(vol.existsSync(oldDir)).toBe(false);
-    });
-  });
-
-  // ============================================================================
-  // Full Cycle Tests
-  // ============================================================================
-
-  describe('Full Backup-Restore Cycle', () => {
-    it('should complete full backup and restore cycle', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
-
-      // 1. Create original file
-      const filePath = join(TEST_HOME, '.myconfig');
-      const originalContent = 'original configuration';
-      vol.writeFileSync(filePath, originalContent);
-
-      // 2. Create backup
-      const backupPath = join(TEST_BACKUPS_DIR, 'myconfig-backup');
-      vol.writeFileSync(backupPath, originalContent);
-
-      // 3. Modify original
-      vol.writeFileSync(filePath, 'modified configuration');
-      expect(vol.readFileSync(filePath, 'utf-8')).toBe('modified configuration');
-
-      // 4. Restore from backup
-      const backupContent = vol.readFileSync(backupPath, 'utf-8');
-      vol.writeFileSync(filePath, backupContent);
-
-      // 5. Verify restoration
-      expect(vol.readFileSync(filePath, 'utf-8')).toBe(originalContent);
-    });
-
-    it('should handle multiple restore points', async () => {
-      await initTestTuck();
-      vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
-
-      const filePath = join(TEST_HOME, '.evolving');
-
-      // Version 1
-      vol.writeFileSync(filePath, 'version 1');
-      vol.writeFileSync(join(TEST_BACKUPS_DIR, 'v1-backup'), 'version 1');
-
-      // Version 2
-      vol.writeFileSync(filePath, 'version 2');
-      vol.writeFileSync(join(TEST_BACKUPS_DIR, 'v2-backup'), 'version 2');
-
-      // Version 3
-      vol.writeFileSync(filePath, 'version 3');
-      vol.writeFileSync(join(TEST_BACKUPS_DIR, 'v3-backup'), 'version 3');
-
-      // Restore to version 1
-      const v1Content = vol.readFileSync(join(TEST_BACKUPS_DIR, 'v1-backup'), 'utf-8');
-      vol.writeFileSync(filePath, v1Content);
-
-      expect(vol.readFileSync(filePath, 'utf-8')).toBe('version 1');
-
-      // Restore to version 2
-      const v2Content = vol.readFileSync(join(TEST_BACKUPS_DIR, 'v2-backup'), 'utf-8');
-      vol.writeFileSync(filePath, v2Content);
-
-      expect(vol.readFileSync(filePath, 'utf-8')).toBe('version 2');
-    });
+    expect(deleted).toBe(1);
+    expect(vol.existsSync(join(TEST_BACKUPS_DIR, '2026-01-01'))).toBe(false);
   });
 });

--- a/tests/lib/backup.test.ts
+++ b/tests/lib/backup.test.ts
@@ -37,7 +37,7 @@ describe('backup', () => {
     const result = await createBackup(sourcePath);
 
     expect(result.originalPath).toBe(sourcePath);
-    expect(result.backupPath).toContain('/.tuck-backups/2026-02-11/');
+    expect(result.backupPath.replace(/\\/g, '/')).toContain('/.tuck-backups/2026-02-11/');
     expect(vol.existsSync(result.backupPath)).toBe(true);
     expect(vol.readFileSync(result.backupPath, 'utf-8')).toBe('export PATH=/usr/local/bin');
   });
@@ -63,7 +63,7 @@ describe('backup', () => {
 
     const result = await createBackup(sourcePath);
 
-    expect(result.backupPath).toContain('/.custom-backups/2026-02-11/');
+    expect(result.backupPath.replace(/\\/g, '/')).toContain('/.custom-backups/2026-02-11/');
     expect(vol.existsSync(result.backupPath)).toBe(true);
   });
 

--- a/tests/lib/backup.test.ts
+++ b/tests/lib/backup.test.ts
@@ -1,225 +1,137 @@
-/**
- * Backup module unit tests
- *
- * Note: The backup module uses fs-extra which has complex filesystem interactions.
- * These tests verify behavioral patterns using memfs directly.
- */
-
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { vol } from 'memfs';
 import { join } from 'path';
-import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
-
-const TEST_BACKUPS_DIR = '/test-home/.tuck-backups';
+import { TEST_HOME, TEST_BACKUPS_DIR } from '../utils/testHelpers.js';
+import {
+  createBackup,
+  createMultipleBackups,
+  listBackups,
+  getBackupsByDate,
+  restoreBackup,
+  deleteBackup,
+  cleanOldBackups,
+  getBackupSize,
+} from '../../src/lib/backup.js';
 
 describe('backup', () => {
   beforeEach(() => {
     vol.reset();
     vol.mkdirSync(TEST_HOME, { recursive: true });
-    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
     vol.mkdirSync(TEST_BACKUPS_DIR, { recursive: true });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-11T10:30:00.000Z'));
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vol.reset();
   });
 
-  // ============================================================================
-  // Backup Creation Patterns
-  // ============================================================================
+  it('creates a backup for a file and returns metadata', async () => {
+    const sourcePath = join(TEST_HOME, '.zshrc');
+    vol.writeFileSync(sourcePath, 'export PATH=/usr/local/bin');
 
-  describe('Backup Creation Patterns', () => {
-    it('should create backup directory structure', () => {
-      const dateDir = join(TEST_BACKUPS_DIR, '2024-01-15');
-      vol.mkdirSync(dateDir, { recursive: true });
+    const result = await createBackup(sourcePath);
 
-      expect(vol.existsSync(dateDir)).toBe(true);
-    });
-
-    it('should preserve file content in backup', () => {
-      const sourcePath = join(TEST_HOME, '.zshrc');
-      const content = 'export PATH=$PATH:/usr/local/bin';
-      vol.writeFileSync(sourcePath, content);
-
-      const backupPath = join(TEST_BACKUPS_DIR, 'zshrc_backup');
-      vol.writeFileSync(backupPath, content);
-
-      expect(vol.readFileSync(backupPath, 'utf-8')).toBe(content);
-    });
-
-    it('should generate timestamped backup names', () => {
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(11, 19);
-      const backupName = `zshrc_${timestamp}`;
-
-      expect(backupName).toMatch(/^zshrc_\d{2}-\d{2}-\d{2}$/);
-    });
-
-    it('should organize backups by date', () => {
-      const today = new Date().toISOString().slice(0, 10);
-      const dateDir = join(TEST_BACKUPS_DIR, today);
-      vol.mkdirSync(dateDir, { recursive: true });
-
-      vol.writeFileSync(join(dateDir, 'backup1.txt'), 'content1');
-      vol.writeFileSync(join(dateDir, 'backup2.txt'), 'content2');
-
-      const files = vol.readdirSync(dateDir);
-      expect(files).toHaveLength(2);
-    });
+    expect(result.originalPath).toBe(sourcePath);
+    expect(result.backupPath).toContain('/.tuck-backups/2026-02-11/');
+    expect(vol.existsSync(result.backupPath)).toBe(true);
+    expect(vol.readFileSync(result.backupPath, 'utf-8')).toBe('export PATH=/usr/local/bin');
   });
 
-  // ============================================================================
-  // Backup Listing Patterns
-  // ============================================================================
-
-  describe('Backup Listing Patterns', () => {
-    it('should list backup directories by date', () => {
-      const dates = ['2024-01-01', '2024-01-02', '2024-01-03'];
-      dates.forEach((date) => {
-        const dir = join(TEST_BACKUPS_DIR, date);
-        vol.mkdirSync(dir, { recursive: true });
-        vol.writeFileSync(join(dir, 'backup.txt'), 'content');
-      });
-
-      const backupDirs = vol.readdirSync(TEST_BACKUPS_DIR);
-      expect(backupDirs).toHaveLength(3);
-      expect(backupDirs).toContain('2024-01-01');
-      expect(backupDirs).toContain('2024-01-02');
-      expect(backupDirs).toContain('2024-01-03');
-    });
-
-    it('should return empty for no backups', () => {
-      const emptyDir = join(TEST_BACKUPS_DIR, 'empty');
-      vol.mkdirSync(emptyDir, { recursive: true });
-
-      const files = vol.readdirSync(emptyDir);
-      expect(files).toHaveLength(0);
-    });
-
-    it('should sort backups newest first', () => {
-      const dates = ['2024-01-03', '2024-01-01', '2024-01-02'];
-      dates.forEach((date) => {
-        vol.mkdirSync(join(TEST_BACKUPS_DIR, date), { recursive: true });
-      });
-
-      const sorted = vol.readdirSync(TEST_BACKUPS_DIR).sort().reverse();
-      expect(sorted[0]).toBe('2024-01-03');
-      expect(sorted[2]).toBe('2024-01-01');
-    });
+  it('throws when source path does not exist', async () => {
+    await expect(createBackup(join(TEST_HOME, '.missing'))).rejects.toThrow(
+      'Source path does not exist'
+    );
   });
 
-  // ============================================================================
-  // Restore Patterns
-  // ============================================================================
+  it('creates multiple backups in one call', async () => {
+    const sourceA = join(TEST_HOME, '.zshrc');
+    const sourceB = join(TEST_HOME, '.gitconfig');
+    vol.writeFileSync(sourceA, 'zsh');
+    vol.writeFileSync(sourceB, 'git');
 
-  describe('Restore Patterns', () => {
-    it('should restore file from backup', () => {
-      const backupPath = join(TEST_BACKUPS_DIR, 'zshrc_backup');
-      const targetPath = join(TEST_HOME, '.zshrc');
-      const content = 'restored content';
+    const results = await createMultipleBackups([sourceA, sourceB]);
 
-      vol.writeFileSync(backupPath, content);
-
-      // Simulate restore
-      const backupContent = vol.readFileSync(backupPath, 'utf-8');
-      vol.writeFileSync(targetPath, backupContent as string);
-
-      expect(vol.readFileSync(targetPath, 'utf-8')).toBe(content);
-    });
-
-    it('should backup current before restore', () => {
-      const targetPath = join(TEST_HOME, '.zshrc');
-      const preRestoreBackup = join(TEST_BACKUPS_DIR, 'pre-restore');
-
-      vol.writeFileSync(targetPath, 'current content');
-
-      // Backup current
-      const current = vol.readFileSync(targetPath, 'utf-8');
-      vol.writeFileSync(preRestoreBackup, current as string);
-
-      expect(vol.readFileSync(preRestoreBackup, 'utf-8')).toBe('current content');
-    });
+    expect(results).toHaveLength(2);
+    expect(vol.existsSync(results[0].backupPath)).toBe(true);
+    expect(vol.existsSync(results[1].backupPath)).toBe(true);
   });
 
-  // ============================================================================
-  // Cleanup Patterns
-  // ============================================================================
+  it('lists backups sorted by newest date first', async () => {
+    const oldDir = join(TEST_BACKUPS_DIR, '2026-02-09');
+    const newDir = join(TEST_BACKUPS_DIR, '2026-02-11');
+    vol.mkdirSync(oldDir, { recursive: true });
+    vol.mkdirSync(newDir, { recursive: true });
+    vol.writeFileSync(join(oldDir, 'old_backup'), 'old');
+    vol.writeFileSync(join(newDir, 'new_backup'), 'new');
 
-  describe('Cleanup Patterns', () => {
-    it('should delete backup directory', () => {
-      const backupDir = join(TEST_BACKUPS_DIR, '2020-01-01');
-      vol.mkdirSync(backupDir, { recursive: true });
-      vol.writeFileSync(join(backupDir, 'old.txt'), 'old');
+    const backups = await listBackups();
 
-      vol.rmdirSync(backupDir, { recursive: true });
-
-      expect(vol.existsSync(backupDir)).toBe(false);
-    });
-
-    it('should calculate backup size', () => {
-      const dateDir = join(TEST_BACKUPS_DIR, '2024-01-15');
-      vol.mkdirSync(dateDir, { recursive: true });
-
-      vol.writeFileSync(join(dateDir, 'file1.txt'), 'a'.repeat(100));
-      vol.writeFileSync(join(dateDir, 'file2.txt'), 'b'.repeat(200));
-
-      const file1Size = vol.statSync(join(dateDir, 'file1.txt')).size;
-      const file2Size = vol.statSync(join(dateDir, 'file2.txt')).size;
-
-      expect(file1Size + file2Size).toBe(300);
-    });
-
-    it('should identify old backups by date', () => {
-      const cutoffDate = new Date('2024-01-10');
-      const oldDate = new Date('2024-01-05');
-      const newDate = new Date('2024-01-15');
-
-      expect(oldDate < cutoffDate).toBe(true);
-      expect(newDate > cutoffDate).toBe(true);
-    });
+    expect(backups).toHaveLength(2);
+    expect(backups[0].path).toContain('2026-02-11');
+    expect(backups[1].path).toContain('2026-02-09');
   });
 
-  // ============================================================================
-  // Error Handling Patterns
-  // ============================================================================
+  it('gets backups by date', async () => {
+    const dateDir = join(TEST_BACKUPS_DIR, '2026-02-11');
+    vol.mkdirSync(dateDir, { recursive: true });
+    vol.writeFileSync(join(dateDir, 'zsh_backup'), 'content');
 
-  describe('Error Handling Patterns', () => {
-    it('should handle missing source file', () => {
-      const missingPath = join(TEST_HOME, 'nonexistent');
-      expect(vol.existsSync(missingPath)).toBe(false);
-    });
+    const backups = await getBackupsByDate(new Date('2026-02-11T00:00:00.000Z'));
 
-    it('should handle missing backup', () => {
-      const missingBackup = join(TEST_BACKUPS_DIR, 'nonexistent');
-      expect(vol.existsSync(missingBackup)).toBe(false);
-    });
-
-    it('should handle permission errors gracefully', () => {
-      // Permission errors would be caught at a higher level
-      // This documents the expected pattern
-    });
+    expect(backups).toHaveLength(1);
+    expect(backups[0]).toContain('zsh_backup');
   });
 
-  // ============================================================================
-  // Multiple File Backups
-  // ============================================================================
+  it('restores from backup and creates a pre-restore snapshot', async () => {
+    const targetPath = join(TEST_HOME, '.zshrc');
+    const backupPath = join(TEST_BACKUPS_DIR, 'restore_source');
+    vol.writeFileSync(targetPath, 'current value');
+    vol.writeFileSync(backupPath, 'restored value');
 
-  describe('Multiple File Backups', () => {
-    it('should backup multiple files', () => {
-      const files = ['.zshrc', '.bashrc', '.gitconfig'];
-      const dateDir = join(TEST_BACKUPS_DIR, '2024-01-15');
-      vol.mkdirSync(dateDir, { recursive: true });
+    await restoreBackup(backupPath, targetPath);
 
-      files.forEach((file) => {
-        const sourcePath = join(TEST_HOME, file);
-        const backupPath = join(dateDir, file.replace('.', ''));
+    expect(vol.readFileSync(targetPath, 'utf-8')).toBe('restored value');
 
-        vol.writeFileSync(sourcePath, `content of ${file}`);
-        const content = vol.readFileSync(sourcePath, 'utf-8');
-        vol.writeFileSync(backupPath, content as string);
-      });
+    const datedDir = join(TEST_BACKUPS_DIR, '2026-02-11');
+    const snapshots = vol.existsSync(datedDir) ? vol.readdirSync(datedDir) : [];
+    expect(snapshots.length).toBeGreaterThan(0);
+  });
 
-      const backups = vol.readdirSync(dateDir);
-      expect(backups).toHaveLength(3);
-    });
+  it('deletes a backup path when requested', async () => {
+    const backupPath = join(TEST_BACKUPS_DIR, 'to_delete');
+    vol.writeFileSync(backupPath, 'temp');
+    expect(vol.existsSync(backupPath)).toBe(true);
+
+    await deleteBackup(backupPath);
+
+    expect(vol.existsSync(backupPath)).toBe(false);
+  });
+
+  it('cleans old backups based on retention window', async () => {
+    const oldDir = join(TEST_BACKUPS_DIR, '2026-01-01');
+    const recentDir = join(TEST_BACKUPS_DIR, '2026-02-10');
+    vol.mkdirSync(oldDir, { recursive: true });
+    vol.mkdirSync(recentDir, { recursive: true });
+    vol.writeFileSync(join(oldDir, 'old.txt'), 'old');
+    vol.writeFileSync(join(recentDir, 'new.txt'), 'new');
+
+    const deleted = await cleanOldBackups(7);
+
+    expect(deleted).toBe(1);
+    expect(vol.existsSync(oldDir)).toBe(false);
+    expect(vol.existsSync(recentDir)).toBe(true);
+  });
+
+  it('calculates total backup size', async () => {
+    const dateDir = join(TEST_BACKUPS_DIR, '2026-02-11');
+    vol.mkdirSync(dateDir, { recursive: true });
+    vol.writeFileSync(join(dateDir, 'a.txt'), 'a'.repeat(10));
+    vol.writeFileSync(join(dateDir, 'b.txt'), 'b'.repeat(20));
+
+    const size = await getBackupSize();
+
+    expect(size).toBe(30);
   });
 });

--- a/tests/lib/doctor.test.ts
+++ b/tests/lib/doctor.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { runDoctorChecks, getDoctorExitCode } from '../../src/lib/doctor.js';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { clearConfigCache } from '../../src/lib/config.js';
+import { initTestTuck, TEST_HOME, TEST_TUCK_DIR } from '../utils/testHelpers.js';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+
+vi.mock('../../src/lib/git.js', () => ({
+  getStatus: vi.fn().mockResolvedValue({
+    isRepo: true,
+    branch: 'main',
+    ahead: 0,
+    behind: 0,
+    staged: [],
+    modified: [],
+    untracked: [],
+    deleted: [],
+    hasChanges: false,
+  }),
+}));
+
+describe('doctor checks', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    clearConfigCache();
+  });
+
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+    clearConfigCache();
+  });
+
+  it('reports healthy status for a valid initialized repository', async () => {
+    await initTestTuck();
+
+    const report = await runDoctorChecks();
+
+    expect(report.summary.failed).toBe(0);
+    expect(report.summary.warnings).toBe(0);
+    expect(report.checks.some((check) => check.id === 'repo.tuck-directory' && check.status === 'pass')).toBe(true);
+    expect(report.checks.some((check) => check.id === 'repo.manifest-loadable' && check.status === 'pass')).toBe(true);
+    expect(getDoctorExitCode(report)).toBe(0);
+  });
+
+  it('fails when tuck directory is missing', async () => {
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+
+    const report = await runDoctorChecks();
+
+    expect(report.summary.failed).toBeGreaterThan(0);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'repo.tuck-directory',
+          status: 'fail',
+        }),
+      ])
+    );
+    expect(getDoctorExitCode(report)).toBe(1);
+  });
+
+  it('fails manifest checks when unsafe destinations exist', async () => {
+    await initTestTuck();
+
+    const manifest = createMockManifest({
+      files: {
+        zshrc: createMockTrackedFile({
+          source: '~/.zshrc',
+          destination: '../../evil',
+        }),
+      },
+    });
+
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+    clearManifestCache();
+
+    const report = await runDoctorChecks({ category: 'manifest' });
+
+    expect(report.summary.failed).toBeGreaterThan(0);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'manifest.path-safety',
+          status: 'fail',
+        }),
+      ])
+    );
+  });
+
+  it('returns strict warning exit code when warnings are present without failures', async () => {
+    await initTestTuck({
+      config: {
+        security: {
+          scanSecrets: false,
+        },
+      },
+    });
+
+    const report = await runDoctorChecks({ category: 'security' });
+
+    expect(report.summary.failed).toBe(0);
+    expect(report.summary.warnings).toBeGreaterThan(0);
+    expect(getDoctorExitCode(report, true)).toBe(2);
+  });
+});

--- a/tests/lib/fileTracking.test.ts
+++ b/tests/lib/fileTracking.test.ts
@@ -88,4 +88,30 @@ describe('fileTracking symlink strategy', () => {
 
     logSpy.mockRestore();
   });
+
+  it('supports custom destination names while preserving source subdirectories', async () => {
+    await initTestTuck();
+    createTestDotfile('.aws/config', 'region = us-east-1');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await trackFilesWithProgress(
+      [{ path: '~/.aws/config', category: 'misc', name: 'work-config' }],
+      TEST_TUCK_DIR,
+      {
+        strategy: 'copy',
+        showCategory: false,
+        delayBetween: 0,
+      }
+    );
+
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+
+    const aws = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.aws/config');
+    expect(aws).not.toBeNull();
+    expect(aws!.file.destination).toBe('files/misc/.aws/work-config');
+
+    logSpy.mockRestore();
+  });
 });

--- a/tests/lib/fileTracking.test.ts
+++ b/tests/lib/fileTracking.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { trackFilesWithProgress } from '../../src/lib/fileTracking.js';
+import { clearManifestCache, getTrackedFileBySource, loadManifest } from '../../src/lib/manifest.js';
+import { initTestTuck, createTestDotfile, TEST_TUCK_DIR } from '../utils/testHelpers.js';
+
+describe('fileTracking symlink strategy', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+  });
+
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+    vi.restoreAllMocks();
+  });
+
+  it('stores a real file in repo and replaces source with symlink to repo file', async () => {
+    await initTestTuck();
+    const sourcePath = createTestDotfile('.zshrc', 'export TRACKING_TEST=1');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await trackFilesWithProgress(
+      [{ path: '~/.zshrc', category: 'shell' }],
+      TEST_TUCK_DIR,
+      {
+        strategy: 'symlink',
+        showCategory: false,
+        delayBetween: 0,
+      }
+    );
+
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.zshrc');
+    expect(tracked).not.toBeNull();
+
+    const repoPath = join(TEST_TUCK_DIR, tracked!.file.destination);
+    expect(vol.lstatSync(repoPath).isSymbolicLink()).toBe(false);
+    expect(vol.readFileSync(repoPath, 'utf-8')).toBe('export TRACKING_TEST=1');
+
+    expect(vol.lstatSync(sourcePath).isSymbolicLink()).toBe(true);
+    expect(vol.readlinkSync(sourcePath)).toBe(repoPath);
+
+    vol.writeFileSync(sourcePath, 'export TRACKING_TEST=2');
+    expect(vol.readFileSync(repoPath, 'utf-8')).toBe('export TRACKING_TEST=2');
+
+    logSpy.mockRestore();
+  });
+
+  it('avoids destination collisions for same basenames in different directories', async () => {
+    await initTestTuck();
+    createTestDotfile('.aws/config', 'region = us-east-1');
+    createTestDotfile('.kube/config', 'apiVersion: v1');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await trackFilesWithProgress(
+      [
+        { path: '~/.aws/config', category: 'misc' },
+        { path: '~/.kube/config', category: 'misc' },
+      ],
+      TEST_TUCK_DIR,
+      {
+        strategy: 'copy',
+        showCategory: false,
+        delayBetween: 0,
+      }
+    );
+
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toBe(0);
+
+    const aws = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.aws/config');
+    const kube = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.kube/config');
+    expect(aws).not.toBeNull();
+    expect(kube).not.toBeNull();
+    expect(aws!.file.destination).toBe('files/misc/.aws/config');
+    expect(kube!.file.destination).toBe('files/misc/.kube/config');
+
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    const destinations = Object.values(manifest.files).map((file) => file.destination);
+    expect(new Set(destinations).size).toBe(destinations.length);
+
+    logSpy.mockRestore();
+  });
+});

--- a/tests/lib/files-extended.test.ts
+++ b/tests/lib/files-extended.test.ts
@@ -126,6 +126,17 @@ describe('files-extended', () => {
     it('should throw for non-existent files', async () => {
       await expect(getFileInfo(join(TEST_HOME, 'nonexistent'))).rejects.toThrow();
     });
+
+    it('should correctly identify symbolic links', async () => {
+      const targetPath = join(TEST_HOME, 'target.txt');
+      const symlinkPath = join(TEST_HOME, 'link.txt');
+      vol.writeFileSync(targetPath, 'target content');
+      vol.symlinkSync(targetPath, symlinkPath);
+
+      const info = await getFileInfo(symlinkPath);
+
+      expect(info.isSymlink).toBe(true);
+    });
   });
 
   // ============================================================================

--- a/tests/lib/github-instructions.test.ts
+++ b/tests/lib/github-instructions.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getClassicTokenInstructions, getFineGrainedTokenInstructions } from '../../src/lib/github.js';
+
+describe('github token setup instructions', () => {
+  it('does not recommend insecure credential.helper store for fine-grained tokens', () => {
+    const instructions = getFineGrainedTokenInstructions('dotfiles');
+    expect(instructions).not.toContain('credential.helper store');
+    expect(instructions).toContain('credential.helper osxkeychain');
+    expect(instructions).toContain('credential.helper libsecret');
+    expect(instructions).toContain('credential.helper manager-core');
+    expect(instructions).toContain('gh auth setup-git');
+  });
+
+  it('does not recommend insecure credential.helper store for classic tokens', () => {
+    const instructions = getClassicTokenInstructions();
+    expect(instructions).not.toContain('credential.helper store');
+    expect(instructions).toContain('credential.helper osxkeychain');
+    expect(instructions).toContain('credential.helper libsecret');
+    expect(instructions).toContain('credential.helper manager-core');
+    expect(instructions).toContain('gh auth setup-git');
+  });
+});

--- a/tests/lib/paths-extended.test.ts
+++ b/tests/lib/paths-extended.test.ts
@@ -28,6 +28,7 @@ import {
   getRelativePath,
   isPathWithinHome,
   validateSafeSourcePath,
+  validateSafeDestinationPath,
   generateFileId,
 } from '../../src/lib/paths.js';
 import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
@@ -174,6 +175,12 @@ describe('paths-extended', () => {
       const tuckDir = getTuckDir(customDir);
       expect(tuckDir).toBe(customDir);
     });
+
+    it('should reject custom directory paths outside home', () => {
+      if (process.platform !== 'win32') {
+        expect(() => getTuckDir('/etc/tuck')).toThrow('custom tuck directory must be within home');
+      }
+    });
   });
 
   describe('getManifestPath', () => {
@@ -293,6 +300,21 @@ describe('paths-extended', () => {
       if (process.platform !== 'win32') {
         expect(() => validateSafeSourcePath('/etc/passwd')).toThrow(
           'absolute paths outside home directory'
+        );
+      }
+    });
+  });
+
+  describe('validateSafeDestinationPath', () => {
+    it('should accept destination paths in home directory', () => {
+      expect(() => validateSafeDestinationPath('~/.tuck/files/zshrc')).not.toThrow();
+      expect(() => validateSafeDestinationPath(join(TEST_HOME, '.tuck', 'files', 'gitconfig'))).not.toThrow();
+    });
+
+    it('should throw for destination paths outside allowed roots', () => {
+      if (process.platform !== 'win32') {
+        expect(() => validateSafeDestinationPath('/etc/malicious')).toThrow(
+          'destination must be within allowed roots'
         );
       }
     });

--- a/tests/lib/paths.test.ts
+++ b/tests/lib/paths.test.ts
@@ -125,9 +125,25 @@ describe('paths', () => {
       );
     });
 
+    it('should support custom destination names without dropping home-relative directories', () => {
+      expect(getRelativeDestinationFromSource('misc', '~/.aws/config', 'aws-config')).toBe(
+        'files/misc/.aws/aws-config'
+      );
+    });
+
     it('should build absolute destination paths from source paths', () => {
       const destination = getDestinationPathFromSource(`${TEST_HOME}/.tuck`, 'shell', '~/.zshrc');
       expect(destination.replace(/\\/g, '/')).toBe(`${TEST_HOME}/.tuck/files/shell/.zshrc`);
+    });
+
+    it('should build absolute destination paths from source paths with custom names', () => {
+      const destination = getDestinationPathFromSource(
+        `${TEST_HOME}/.tuck`,
+        'shell',
+        '~/.zshrc',
+        'zprofile'
+      );
+      expect(destination.replace(/\\/g, '/')).toBe(`${TEST_HOME}/.tuck/files/shell/zprofile`);
     });
   });
 });

--- a/tests/lib/paths.test.ts
+++ b/tests/lib/paths.test.ts
@@ -5,6 +5,9 @@ import {
   expandPath,
   collapsePath,
   detectCategory,
+  getDestinationPathFromSource,
+  getHomeRelativeSourcePath,
+  getRelativeDestinationFromSource,
   sanitizeFilename,
   generateFileId,
 } from '../../src/lib/paths.js';
@@ -104,6 +107,27 @@ describe('paths', () => {
     it('should handle nested paths', () => {
       const id = generateFileId('~/.config/nvim');
       expect(id).toBe('config_nvim');
+    });
+  });
+
+  describe('home-relative destinations', () => {
+    it('should derive home-relative source paths', () => {
+      expect(getHomeRelativeSourcePath('~/.aws/config')).toBe('.aws/config');
+      expect(getHomeRelativeSourcePath('~/.kube/config')).toBe('.kube/config');
+    });
+
+    it('should build unique destinations from source paths', () => {
+      expect(getRelativeDestinationFromSource('misc', '~/.aws/config')).toBe(
+        'files/misc/.aws/config'
+      );
+      expect(getRelativeDestinationFromSource('misc', '~/.kube/config')).toBe(
+        'files/misc/.kube/config'
+      );
+    });
+
+    it('should build absolute destination paths from source paths', () => {
+      const destination = getDestinationPathFromSource(`${TEST_HOME}/.tuck`, 'shell', '~/.zshrc');
+      expect(destination.replace(/\\/g, '/')).toBe(`${TEST_HOME}/.tuck/files/shell/.zshrc`);
     });
   });
 });

--- a/tests/lib/patterns.test.ts
+++ b/tests/lib/patterns.test.ts
@@ -288,6 +288,47 @@ b3BlbnNzaC1rZXktdjEAAAAA
       expect(custom.description).toBe('Custom description');
       expect(custom.placeholder).toBe('MY_SECRET');
     });
+
+    it('should enforce global flag for custom patterns', () => {
+      const custom = createCustomPattern('case-insensitive', 'Case', 'secret_[a-z]+', {
+        flags: 'i',
+      });
+
+      expect(custom.pattern.flags.includes('g')).toBe(true);
+      expect(custom.pattern.flags.includes('i')).toBe(true);
+    });
+
+    it('should reject nested quantified groups', () => {
+      expect(() => createCustomPattern('redos-1', 'Unsafe', '(a+)+$')).toThrow(
+        'Unsafe custom regex pattern rejected'
+      );
+    });
+
+    it('should reject unbounded quantifier on alternation group', () => {
+      expect(() => createCustomPattern('redos-2', 'Unsafe', '(a|aa)+$')).toThrow(
+        'Unsafe custom regex pattern rejected'
+      );
+    });
+
+    it('should reject backreferences', () => {
+      expect(() => createCustomPattern('redos-3', 'Unsafe', '([a-z]+)\\1')).toThrow(
+        'Unsafe custom regex pattern rejected'
+      );
+    });
+
+    it('should reject lookbehind assertions', () => {
+      expect(() => createCustomPattern('redos-4', 'Unsafe', '(?<=token=)[A-Za-z0-9]+')).toThrow(
+        'Unsafe custom regex pattern rejected'
+      );
+    });
+
+    it('should reject unsupported regex flags', () => {
+      expect(() =>
+        createCustomPattern('bad-flags', 'Bad Flags', 'SECRET_\\w+', {
+          flags: 'gv',
+        })
+      ).toThrow('Unsupported regex flag');
+    });
   });
 
   // ============================================================================

--- a/tests/lib/scanner.test.ts
+++ b/tests/lib/scanner.test.ts
@@ -130,6 +130,41 @@ MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn
       expect(matches.some((m) => m.patternId === 'custom-test')).toBe(true);
     });
 
+    it('should enforce global matching for custom patterns without g flag', () => {
+      const content = 'CUSTOM_SECRET=abc123xyz';
+      const customPatterns = [
+        {
+          id: 'custom-no-global',
+          name: 'Custom without global flag',
+          pattern: /CUSTOM_SECRET=([a-z0-9]+)/,
+          severity: 'high' as const,
+          description: 'Custom pattern',
+          placeholder: 'CUSTOM_SECRET',
+        },
+      ];
+
+      const matches = scanContent(content, { customPatterns });
+      expect(matches.some((m) => m.patternId === 'custom-no-global')).toBe(true);
+    });
+
+    it('should reject unsafe custom patterns during scanning', () => {
+      const content = 'aaaaa!';
+      const customPatterns = [
+        {
+          id: 'custom-unsafe',
+          name: 'Unsafe custom pattern',
+          pattern: /(a+)+$/,
+          severity: 'high' as const,
+          description: 'Unsafe pattern',
+          placeholder: 'UNSAFE',
+        },
+      ];
+
+      expect(() => scanContent(content, { customPatterns })).toThrow(
+        'Unsafe custom regex pattern rejected'
+      );
+    });
+
     it('should support excluding patterns', () => {
       const content = 'AKIAIOSFODNN7EXAMPLE';
       const matches = scanContent(content, {

--- a/tests/security/path-traversal.test.ts
+++ b/tests/security/path-traversal.test.ts
@@ -1,10 +1,3 @@
-/**
- * Path Traversal Security Tests
- *
- * These tests verify that tuck properly prevents path traversal attacks
- * that could allow reading/writing files outside the intended directories.
- */
-
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { vol } from 'memfs';
 import { join } from 'path';
@@ -12,6 +5,7 @@ import {
   expandPath,
   isPathWithinHome,
   validateSafeSourcePath,
+  validateSafeDestinationPath,
   getTuckDir,
 } from '../../src/lib/paths.js';
 import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
@@ -27,223 +21,76 @@ describe('Path Traversal Security', () => {
     vol.reset();
   });
 
-  // ============================================================================
-  // Path Expansion Security
-  // ============================================================================
-
-  describe('expandPath - prevents traversal', () => {
-    it('should expand ~ to home directory safely', () => {
+  describe('expandPath', () => {
+    it('expands home-relative paths deterministically', () => {
       const result = expandPath('~/.zshrc');
-      expect(result).not.toContain('..');
-      expect(result).toContain(TEST_HOME.replace('/test-home', ''));
-    });
-
-    it('should handle multiple ~ characters', () => {
-      const result = expandPath('~/~/.zshrc');
-      // Should not double-expand
-      expect(result).not.toMatch(/~~+/);
-    });
-
-    it('should not expand ~ in middle of path', () => {
-      const result = expandPath('/some/path/~/file');
-      expect(result).toContain('~');
+      expect(result.replace(/\\/g, '/')).toBe('/test-home/.zshrc');
     });
   });
-
-  // ============================================================================
-  // isPathWithinHome Security
-  // ============================================================================
 
   describe('isPathWithinHome', () => {
-    it('should return true for paths within home', () => {
+    it('returns true for normal home-scoped paths', () => {
       expect(isPathWithinHome('~/.zshrc')).toBe(true);
-      expect(isPathWithinHome('~/.config/nvim')).toBe(true);
-      expect(isPathWithinHome('~/Documents/file.txt')).toBe(true);
+      expect(isPathWithinHome('~/.config/nvim/init.lua')).toBe(true);
+      expect(isPathWithinHome(join(TEST_HOME, '.gitconfig'))).toBe(true);
     });
 
-    it('should return false for paths outside home', () => {
-      expect(isPathWithinHome('/etc/passwd')).toBe(false);
-      expect(isPathWithinHome('/usr/local/bin/script')).toBe(false);
-      expect(isPathWithinHome('/tmp/malicious')).toBe(false);
-    });
-
-    it('should detect path traversal attempts', () => {
-      // These should be outside home even though they start with ~
-      expect(isPathWithinHome('~/../../../etc/passwd')).toBe(false);
+    it('returns false for traversal and external absolute paths', () => {
+      expect(isPathWithinHome('~/../etc/passwd')).toBe(false);
       expect(isPathWithinHome('~/../../root/.ssh/id_rsa')).toBe(false);
+      if (process.platform !== 'win32') {
+        expect(isPathWithinHome('/etc/passwd')).toBe(false);
+      }
     });
 
-    it('should handle encoded path traversal', () => {
-      // URL-encoded traversal attempts
-      '~/%2e%2e/etc/passwd';
-      '~/..%00/etc/passwd';
-      // These should be caught when normalized
-      // The actual behavior depends on path normalization
-    });
-
-    it('should reject Windows-style path traversal on all platforms', () => {
-      expect(isPathWithinHome('~\\..\\..\\etc\\passwd')).toBe(false);
+    it('rejects windows drive and UNC paths on every platform', () => {
+      expect(isPathWithinHome('C:\\Windows\\System32\\config\\SAM')).toBe(false);
+      expect(isPathWithinHome('\\\\server\\share\\secret')).toBe(false);
     });
   });
 
-  // ============================================================================
-  // validateSafeSourcePath Security
-  // ============================================================================
-
   describe('validateSafeSourcePath', () => {
-    it('should allow valid home paths', () => {
+    it('allows safe source paths', () => {
       expect(() => validateSafeSourcePath('~/.zshrc')).not.toThrow();
-      expect(() => validateSafeSourcePath('~/.config/nvim/init.lua')).not.toThrow();
-      expect(() => validateSafeSourcePath('~/Documents/notes.txt')).not.toThrow();
+      expect(() => validateSafeSourcePath('~/.config/alacritty/alacritty.yml')).not.toThrow();
     });
 
-    it('should reject absolute paths outside home', () => {
-      expect(() => validateSafeSourcePath('/etc/passwd')).toThrow('Unsafe path');
-      expect(() => validateSafeSourcePath('/root/.bashrc')).toThrow('Unsafe path');
-      expect(() => validateSafeSourcePath('/var/log/syslog')).toThrow('Unsafe path');
-    });
-
-    it('should reject path traversal with ../', () => {
+    it('throws for traversal attempts', () => {
       expect(() => validateSafeSourcePath('~/../etc/passwd')).toThrow('path traversal');
-      expect(() => validateSafeSourcePath('~/.config/../../../etc/shadow')).toThrow(
-        'path traversal'
-      );
-    });
-
-    it('should reject path traversal with ..\\', () => {
       expect(() => validateSafeSourcePath('~\\..\\etc\\passwd')).toThrow('path traversal');
     });
 
-    it('should handle nested traversal attempts', () => {
-      expect(() => validateSafeSourcePath('~/.config/../../..')).toThrow();
-    });
-
-    it('should reject symbolic traversal patterns', () => {
-      // Even if the path looks innocent, the resolved path matters
-      '~/.../.../etc/passwd';
-      // This depends on filesystem behavior
+    it('throws for absolute paths outside home', () => {
+      if (process.platform !== 'win32') {
+        expect(() => validateSafeSourcePath('/var/log/syslog')).toThrow('Unsafe path');
+      }
     });
   });
 
-  // ============================================================================
-  // Malicious Manifest Simulation
-  // ============================================================================
+  describe('validateSafeDestinationPath', () => {
+    it('allows home-scoped destinations', () => {
+      expect(() => validateSafeDestinationPath('~/.tuck/files/shell/zshrc')).not.toThrow();
+      expect(() => validateSafeDestinationPath(join(TEST_HOME, '.tuck', 'files', 'gitconfig'))).not.toThrow();
+    });
 
-  describe('Malicious Manifest Protection', () => {
-    const maliciousSourcePaths = [
-      // Direct system file access
-      '/etc/passwd',
-      '/etc/shadow',
-      '/root/.ssh/id_rsa',
-      '/var/log/auth.log',
-
-      // Traversal from home
-      '~/../etc/passwd',
-      '~/../../root/.bashrc',
-      '~/.config/../../../etc/sudoers',
-
-      // Null byte injection (legacy attack)
-      '~/.config\x00/../../etc/passwd',
-
-      // Windows paths (should be rejected on all platforms)
-      'C:\\Windows\\System32\\config\\SAM',
-      '\\\\server\\share\\sensitive',
-    ];
-
-    maliciousSourcePaths.forEach((maliciousPath) => {
-      it(`should reject malicious path: ${maliciousPath.slice(0, 40)}...`, () => {
-        // Either isPathWithinHome returns false OR validateSafeSourcePath throws
-        const withinHome = isPathWithinHome(maliciousPath);
-
-        if (withinHome) {
-          // If somehow it passed the home check, validation should catch it
-          expect(() => validateSafeSourcePath(maliciousPath)).toThrow();
-        } else {
-          expect(withinHome).toBe(false);
-        }
-      });
+    it('rejects destinations outside allowed roots', () => {
+      if (process.platform !== 'win32') {
+        expect(() => validateSafeDestinationPath('/etc/malicious')).toThrow(
+          'destination must be within allowed roots'
+        );
+      }
     });
   });
-
-  // ============================================================================
-  // Symlink Attack Prevention
-  // ============================================================================
-
-  describe('Symlink Attack Prevention', () => {
-    it('should not resolve symlinks that escape home directory', async () => {
-      // Create a symlink that points outside home
-      // In a real attack, ~/.config/evil -> /etc
-      // tuck should not follow this symlink to access /etc files
-      // Note: This test documents expected behavior
-      // The actual implementation should:
-      // 1. Resolve symlinks before checking paths
-      // 2. OR reject symlinks entirely
-      // 3. OR validate the final resolved path
-    });
-
-    it('should handle circular symlinks safely', async () => {
-      // Circular symlinks could cause infinite loops
-      // The implementation should have recursion limits
-    });
-  });
-
-  // ============================================================================
-  // getTuckDir Security
-  // ============================================================================
 
   describe('getTuckDir', () => {
-    it('should return home-based path by default', () => {
-      const tuckDir = getTuckDir();
-      expect(isPathWithinHome(tuckDir)).toBe(true);
+    it('returns a home-scoped default directory', () => {
+      expect(isPathWithinHome(getTuckDir())).toBe(true);
     });
 
-    it('should validate custom directory paths', () => {
-      // Custom paths should still be validated
-      const customDir = getTuckDir('~/.my-tuck');
-      expect(isPathWithinHome(customDir)).toBe(true);
-    });
-
-    it('should reject custom paths outside home', () => {
-      // This tests whether getTuckDir properly validates custom paths
-      // Current implementation may not validate - this documents the risk
-      getTuckDir('/etc/tuck');
-      // Ideally this should throw or return a safe default
-    });
-  });
-
-  // ============================================================================
-  // Path Normalization Edge Cases
-  // ============================================================================
-
-  describe('Path Normalization Edge Cases', () => {
-    it('should handle paths with multiple slashes', () => {
-      const path = '~///.zshrc';
-      const expanded = expandPath(path);
-      expect(expanded).not.toContain('//');
-    });
-
-    it('should handle paths with trailing slashes', () => {
-      const path = '~/.config/';
-      const expanded = expandPath(path);
-      expect(isPathWithinHome(expanded)).toBe(true);
-    });
-
-    it('should handle empty path components', () => {
-      const path = '~/./config/./nvim';
-      const expanded = expandPath(path);
-      expect(isPathWithinHome(expanded)).toBe(true);
-    });
-
-    it('should handle unicode in paths', () => {
-      const path = '~/.config/app-\u00e9';
-      const expanded = expandPath(path);
-      expect(isPathWithinHome(expanded)).toBe(true);
-    });
-
-    it('should handle very long paths', () => {
-      const longComponent = 'a'.repeat(255);
-      const path = `~/.config/${longComponent}`;
-      expect(() => expandPath(path)).not.toThrow();
+    it('rejects custom directories outside home', () => {
+      if (process.platform !== 'win32') {
+        expect(() => getTuckDir('/etc/tuck')).toThrow('custom tuck directory must be within home');
+      }
     });
   });
 });

--- a/tests/security/path-traversal.test.ts
+++ b/tests/security/path-traversal.test.ts
@@ -8,6 +8,7 @@ import {
   validateSafeDestinationPath,
   validatePathWithinRoot,
   validateSafeManifestDestination,
+  getSafeRepoPathFromDestination,
   getTuckDir,
 } from '../../src/lib/paths.js';
 import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
@@ -110,6 +111,19 @@ describe('Path Traversal Security', () => {
       expect(() => validateSafeManifestDestination('backup/zshrc')).toThrow(
         'destination must be inside'
       );
+    });
+  });
+
+  describe('getSafeRepoPathFromDestination', () => {
+    it('resolves valid destinations inside tuck root', () => {
+      const repoPath = getSafeRepoPathFromDestination(TEST_TUCK_DIR, 'files/shell/zshrc');
+      expect(repoPath.replace(/\\/g, '/')).toBe('/test-home/.tuck/files/shell/zshrc');
+    });
+
+    it('rejects destinations that attempt root escape', () => {
+      expect(() =>
+        getSafeRepoPathFromDestination(TEST_TUCK_DIR, 'files/../../outside')
+      ).toThrow('path traversal');
     });
   });
 

--- a/tests/security/permissions.test.ts
+++ b/tests/security/permissions.test.ts
@@ -1,20 +1,14 @@
-/**
- * Permissions Security Tests
- *
- * These tests verify that tuck properly respects file permissions
- * and does not expose sensitive files or escalate privileges.
- */
-
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { vol } from 'memfs';
 import { join } from 'path';
 import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
-import { pathExists, isReadable, isWritable } from '../../src/lib/paths.js';
+import { isReadable, isWritable } from '../../src/lib/paths.js';
 import {
   getFilePermissions,
   setFilePermissions,
   getFileInfo,
   copyFileOrDir,
+  createSymlink,
 } from '../../src/lib/files.js';
 
 describe('Permissions Security', () => {
@@ -28,287 +22,76 @@ describe('Permissions Security', () => {
     vol.reset();
   });
 
-  // ============================================================================
-  // Permission Checking Tests
-  // ============================================================================
+  it('detects readable and writable files correctly', async () => {
+    const filePath = join(TEST_HOME, 'rw.txt');
+    vol.writeFileSync(filePath, 'content');
 
-  describe('Permission Checking', () => {
-    it('should correctly detect readable files', async () => {
-      const filePath = join(TEST_HOME, 'readable.txt');
-      vol.writeFileSync(filePath, 'content');
-
-      const readable = await isReadable(filePath);
-      expect(readable).toBe(true);
-    });
-
-    it('should correctly detect writable files', async () => {
-      const filePath = join(TEST_HOME, 'writable.txt');
-      vol.writeFileSync(filePath, 'content');
-
-      const writable = await isWritable(filePath);
-      expect(writable).toBe(true);
-    });
-
-    it('should return false for non-existent files', async () => {
-      const readable = await isReadable(join(TEST_HOME, 'nonexistent.txt'));
-      const writable = await isWritable(join(TEST_HOME, 'nonexistent.txt'));
-
-      expect(readable).toBe(false);
-      expect(writable).toBe(false);
-    });
+    expect(await isReadable(filePath)).toBe(true);
+    expect(await isWritable(filePath)).toBe(true);
   });
 
-  // ============================================================================
-  // Sensitive File Detection
-  // ============================================================================
-
-  describe('Sensitive File Detection', () => {
-    const sensitivePatterns = [
-      '.ssh/id_rsa',
-      '.ssh/id_ed25519',
-      '.ssh/id_ecdsa',
-      '.gnupg/secring.gpg',
-      '.gnupg/private-keys-v1.d',
-      '.aws/credentials',
-      '.netrc',
-      '.npmrc', // Can contain auth tokens
-    ];
-
-    sensitivePatterns.forEach((pattern) => {
-      it(`should identify ${pattern} as potentially sensitive`, () => {
-        // This tests that the detect module marks these as sensitive
-        // Implementation detail: detect.ts should set sensitive: true
-        // Note: This is a behavioral expectation
-        // The actual implementation should warn about these files
-      });
-    });
+  it('reports non-existent files as not readable/writable', async () => {
+    const missing = join(TEST_HOME, 'missing.txt');
+    expect(await isReadable(missing)).toBe(false);
+    expect(await isWritable(missing)).toBe(false);
   });
 
-  // ============================================================================
-  // Permission Preservation Tests
-  // ============================================================================
+  it('returns structured file metadata for valid files', async () => {
+    const filePath = join(TEST_HOME, 'info.txt');
+    vol.writeFileSync(filePath, 'abc');
 
-  describe('Permission Preservation', () => {
-    it('should retrieve file permissions', async () => {
-      const filePath = join(TEST_HOME, 'test.txt');
-      vol.writeFileSync(filePath, 'content');
+    const info = await getFileInfo(filePath);
 
-      const permissions = await getFilePermissions(filePath);
-
-      // Should return a valid permission string
-      expect(permissions).toMatch(/^[0-7]{3}$/);
-    });
-
-    it('should handle permission setting gracefully', async () => {
-      const filePath = join(TEST_HOME, 'test.txt');
-      vol.writeFileSync(filePath, 'content');
-
-      // Should not throw even if setting permissions fails (Windows)
-      await expect(setFilePermissions(filePath, '644')).resolves.not.toThrow();
-    });
-
-    it('should preserve executable bit on scripts', async () => {
-      const scriptPath = join(TEST_HOME, 'script.sh');
-      vol.writeFileSync(scriptPath, '#!/bin/bash\necho "hello"');
-
-      // When copying, executable bit should be preserved
-      // This is a behavioral expectation for the copy implementation
-    });
+    expect(info.path).toBe(filePath);
+    expect(info.isDirectory).toBe(false);
+    expect(info.isSymlink).toBe(false);
+    expect(info.size).toBe(3);
+    expect(info.permissions).toMatch(/^[0-7]{3}$/);
   });
 
-  // ============================================================================
-  // getFileInfo Security Tests
-  // ============================================================================
-
-  describe('getFileInfo', () => {
-    it('should return file info for valid files', async () => {
-      const filePath = join(TEST_HOME, 'info-test.txt');
-      vol.writeFileSync(filePath, 'content');
-
-      const info = await getFileInfo(filePath);
-
-      expect(info).toHaveProperty('path');
-      expect(info).toHaveProperty('isDirectory');
-      expect(info).toHaveProperty('isSymlink');
-      expect(info).toHaveProperty('size');
-      expect(info).toHaveProperty('permissions');
-    });
-
-    it('should throw for non-existent files', async () => {
-      await expect(getFileInfo(join(TEST_HOME, 'nonexistent.txt'))).rejects.toThrow();
-    });
-
-    it('should detect directories correctly', async () => {
-      const dirPath = join(TEST_HOME, 'test-dir');
-      vol.mkdirSync(dirPath);
-
-      const info = await getFileInfo(dirPath);
-      expect(info.isDirectory).toBe(true);
-    });
+  it('throws file errors for invalid metadata targets', async () => {
+    await expect(getFileInfo(join(TEST_HOME, 'does-not-exist'))).rejects.toThrow();
   });
 
-  // ============================================================================
-  // Symlink Security Tests
-  // ============================================================================
+  it('copies files inside home safely', async () => {
+    const source = join(TEST_HOME, 'source.txt');
+    const destination = join(TEST_HOME, '.tuck', 'files', 'shell', 'source.txt');
+    vol.writeFileSync(source, 'copy me');
 
-  describe('Symlink Security', () => {
-    it('should detect symlinks', async () => {
-      // Note: memfs has limited symlink support
-      // This tests the expected behavior
-    });
+    const result = await copyFileOrDir(source, destination);
 
-    it('should not follow symlinks outside allowed directories', async () => {
-      // Symlinks that escape to system directories should be rejected
-      // This is a behavioral expectation
-    });
-
-    it('should handle circular symlinks gracefully', async () => {
-      // Circular symlinks should not cause infinite loops
-      // Implementation should have recursion limits
-    });
+    expect(result.fileCount).toBe(1);
+    expect(vol.existsSync(destination)).toBe(true);
+    expect(vol.readFileSync(destination, 'utf-8')).toBe('copy me');
   });
 
-  // ============================================================================
-  // Copy Permission Tests
-  // ============================================================================
+  it('rejects copy destinations outside safe roots', async () => {
+    const source = join(TEST_HOME, 'source.txt');
+    vol.writeFileSync(source, 'x');
 
-  describe('Copy Permissions', () => {
-    it('should copy files with appropriate permissions', async () => {
-      const sourcePath = join(TEST_HOME, 'source.txt');
-      const destPath = join(TEST_HOME, 'dest.txt');
-
-      vol.writeFileSync(sourcePath, 'content');
-
-      await copyFileOrDir(sourcePath, destPath);
-
-      const exists = await pathExists(destPath);
-      expect(exists).toBe(true);
-    });
-
-    it.skip('should not create world-writable files', async () => {
-      // Note: Skipped because memfs doesn't properly simulate Unix permissions.
-      // On real filesystem, this test would verify files aren't world-writable.
-      const sourcePath = join(TEST_HOME, 'source.txt');
-      const destPath = join(TEST_HOME, 'dest.txt');
-
-      vol.writeFileSync(sourcePath, 'secret content');
-
-      await copyFileOrDir(sourcePath, destPath);
-
-      const permissions = await getFilePermissions(destPath);
-      // Should not be world-writable (x77)
-      const worldWritable = parseInt(permissions, 8) & 0o002;
-      expect(worldWritable).toBe(0);
-    });
+    if (process.platform !== 'win32') {
+      await expect(copyFileOrDir(source, '/etc/malicious')).rejects.toThrow('Unsafe destination');
+    }
   });
 
-  // ============================================================================
-  // Directory Traversal Prevention
-  // ============================================================================
+  it('rejects symlink destinations outside safe roots', async () => {
+    const source = join(TEST_HOME, 'target.txt');
+    vol.writeFileSync(source, 'target');
 
-  describe('Directory Traversal Prevention', () => {
-    it('should not access files outside tuck directory', async () => {
-      // Create a file outside tuck directory
-      const outsidePath = '/etc/passwd';
-
-      // Any operation should fail or be rejected
-      await pathExists(outsidePath);
-      // In test environment, this should return false or be handled safely
-    });
-
-    it.skip('should validate destination paths for copy', async () => {
-      // TODO: Implement destination path validation in copyFileOrDir
-      // Currently copyFileOrDir doesn't validate that destination is safe.
-      // This test documents the expected security behavior.
-      const sourcePath = join(TEST_HOME, 'source.txt');
-      vol.writeFileSync(sourcePath, 'content');
-
-      // Attempting to copy to system directory should fail
-      await expect(copyFileOrDir(sourcePath, '/etc/malicious')).rejects.toThrow();
-    });
+    if (process.platform !== 'win32') {
+      await expect(createSymlink(source, '/etc/link-target')).rejects.toThrow('Unsafe destination');
+    }
   });
 
-  // ============================================================================
-  // Backup Permission Tests
-  // ============================================================================
+  it('exposes and applies permission helpers without crashing', async () => {
+    const filePath = join(TEST_HOME, 'permissions.txt');
+    vol.writeFileSync(filePath, 'secret');
 
-  describe('Backup Permissions', () => {
-    it('should create backup directories with restrictive permissions', async () => {
-      // Backup directories should not be world-readable
-      // They may contain sensitive configuration
-    });
+    const before = await getFilePermissions(filePath);
+    expect(before).toMatch(/^[0-7]{3}$/);
 
-    it('should preserve original permissions in backups', async () => {
-      // When restoring, original permissions should be maintained
-    });
-  });
-
-  // ============================================================================
-  // SSH Key Protection
-  // ============================================================================
-
-  describe('SSH Key Protection', () => {
-    it('should warn when SSH private keys might be tracked', async () => {
-      const sshDir = join(TEST_HOME, '.ssh');
-      vol.mkdirSync(sshDir, { recursive: true });
-      vol.writeFileSync(
-        join(sshDir, 'id_rsa'),
-        '-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----'
-      );
-
-      // The detect module should mark this as sensitive
-      // and warn the user about tracking private keys
-    });
-
-    it('should allow tracking SSH config (not keys)', async () => {
-      const sshConfig = join(TEST_HOME, '.ssh', 'config');
-      vol.mkdirSync(join(TEST_HOME, '.ssh'), { recursive: true });
-      vol.writeFileSync(sshConfig, 'Host example\n  HostName example.com');
-
-      // SSH config should be allowed (it doesn't contain secrets)
-      // This is a behavioral expectation
-    });
-  });
-
-  // ============================================================================
-  // Umask Respect
-  // ============================================================================
-
-  describe('Umask Respect', () => {
-    it('should respect system umask when creating files', async () => {
-      // New files should respect the system umask
-      // This prevents creating files more permissive than intended
-    });
-
-    it('should not create setuid/setgid files', async () => {
-      // Copied/created files should never have setuid/setgid bits
-      const filePath = join(TEST_HOME, 'test.txt');
-      vol.writeFileSync(filePath, 'content');
-
-      const permissions = await getFilePermissions(filePath);
-      const permInt = parseInt(permissions, 8);
-
-      // Check no special bits (setuid: 4000, setgid: 2000, sticky: 1000)
-      expect(permInt & 0o7000).toBe(0);
-    });
-  });
-
-  // ============================================================================
-  // Environment Variable Protection
-  // ============================================================================
-
-  describe('Environment Variable Protection', () => {
-    it('should not expose secrets through environment', () => {
-      // Sensitive operations should not leak through env vars
-      // Check that no sensitive data appears in process.env
-
-      for (const key of Object.keys(process.env)) {
-        const value = process.env[key] || '';
-
-        // Should not contain obvious secrets
-        expect(value).not.toMatch(/-----BEGIN.*PRIVATE KEY-----/);
-        expect(value).not.toMatch(/ghp_[A-Za-z0-9]{36}/);
-      }
-    });
+    await expect(setFilePermissions(filePath, '644')).resolves.not.toThrow();
+    const after = await getFilePermissions(filePath);
+    expect(after).toMatch(/^[0-7]{3}$/);
   });
 });

--- a/tests/security/redos.test.ts
+++ b/tests/security/redos.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { vol } from 'memfs';
 import { scanContent } from '../../src/lib/secrets/scanner.js';
-import { ALL_SECRET_PATTERNS } from '../../src/lib/secrets/patterns.js';
+import { ALL_SECRET_PATTERNS, createCustomPattern } from '../../src/lib/secrets/patterns.js';
 import { TEST_HOME } from '../setup.js';
 
 // Helper to measure execution time
@@ -220,6 +220,12 @@ describe('ReDoS Security', () => {
           }
         }
       }
+    });
+
+    it('rejects unsafe user-supplied custom patterns before scanning', () => {
+      expect(() => createCustomPattern('evil', 'evil', '(a+)+$')).toThrow(
+        'Unsafe custom regex pattern rejected'
+      );
     });
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -71,6 +71,10 @@ vi.mock('fs-extra', async () => {
       const { vol } = await import('memfs');
       vol.mkdirSync(dir, { recursive: true });
     },
+    pathExists: async (targetPath: string) => {
+      const { vol } = await import('memfs');
+      return vol.existsSync(targetPath);
+    },
   };
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,11 +15,17 @@ export default defineConfig({
         '**/*.test.ts',
       ],
       include: ['src/**/*.ts'],
+      thresholds: {
+        statements: 40,
+        branches: 75,
+        functions: 34,
+        lines: 40,
+      },
     },
     testTimeout: 10000,
     mockReset: true,
     restoreMocks: true,
-    // Rely on mock and setup resets to prevent state leakage; avoid per-file worker isolation for performance
-    isolate: false,
+    // Isolate test files to prevent mock leakage between suites.
+    isolate: true,
   },
 });


### PR DESCRIPTION
## Summary
- fix symlink tracking direction so repo remains source of truth and avoid destination collisions
- add shared tracking preparation pipeline across add/init/scan/sync with secret and size checks
- harden manifest path handling in diff/status/remove/sync against traversal and unsafe destinations
- improve platform/security behavior (Windows tuck dir handling, timemachine backup path safety, regex safety checks)
- align config/install/docs and expand tests for new behavior

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint