### PR TITLE
Repo-scoped / arbitrary-path tracking

### DIFF
--- a/docs/REPO-SCOPED-PLAN.md
+++ b/docs/REPO-SCOPED-PLAN.md
@@ -1,0 +1,106 @@
+I have everything I need. I've verified all the load-bearing facts: the exact `resolveWriteTarget` signature/branches, `validateSafeDestinationPath` defaulting to `[homedir()]` (the critical gotcha designs 1 and 2 missed but design 3 caught), the `copyFileOrDir`/`createSymlink` call into `validateSafeDestinationPath`, `getRemoteUrl`/`getRemotes` already existing in git.ts, `findGitRoot`/`slugifyPath`/`repoScopeKey` in context.ts, and the `FileState` exhaustive switch. Now I'll synthesize the final design and plan.
+
+The most important correctness finding from reading the real code: **all three designs claim restore writes go only through `resolveWriteTarget`, but in fact `copyFileOrDir`/`createSymlink` independently call `validateSafeDestinationPath(expandedDest)` which defaults to `[homedir()]`.** A repo target outside `$HOME` is rejected there regardless of `resolveWriteTarget`. Only design 3 caught this. Any working plan MUST thread `allowedRoots()` into those two functions' calls. This is the single load-bearing detail that decides whether the feature works at all.
+
+---
+
+# SYNTHESIZED DESIGN: repo-scoped tracking for tuck
+
+## Decisions (the hard problem, resolved)
+
+**1. Manifest shape (committed, machine-independent).** Add three fields to `trackedFileSchema`:
+- `scope: z.enum(['home','repo']).optional()` — **`.optional()`, NOT `.default('home')`.** Decisive: I reject designs 2 & 3's `.default('home')`. A default rewrites every legacy entry's bytes on the next `saveManifest` (adding `"scope":"home"` to all of them), producing noisy diffs in committed dotfiles repos and breaking the "loads byte-identical" promise. `.optional()` leaves legacy entries untouched; `file.scope !== 'repo'` is the home test everywhere. This matches how the codebase actually treats absence (the `file.bundle ?? 'default'` pattern in apply.ts:312).
+- `repoKey: z.string().optional()` — stable cross-machine repo identity. Never an absolute path.
+- `repoRelative: z.string().optional()` — POSIX repo-root-relative path (e.g. `.vscode/settings.json`).
+- A `.superRefine`: if `scope==='repo'` then `repoKey` and `repoRelative` are required & non-empty; `repoRelative` must pass no-`..`/not-absolute. If `scope` is absent/`'home'`, both must be absent. A malicious half-formed entry fails at `loadManifest`, not at write time.
+- `source` is kept for repo files as a **display string** `"<repoKey>:<repoRelative>"` so `generateFileId`/`getTrackedFileBySource`/logging keep working; resolution never does `expandPath(source)` for repo files.
+- `destination` stays under `files/`, namespaced as `files/repos/<repoKey>/<repoRelative>` so `validateSafeManifestDestination`/`getSafeRepoPathFromDestination`/`computeFileState`'s `join(tuckDir, destination)` work unchanged.
+
+**2. Per-machine remapping (the core).** `repoKey → absolute root` is stored **machine-local, off-repo** at `join(getStateDir(), 'repos.json')` (XDG_STATE_HOME / Library/Application Support — same off-repo pattern as snapshots/audit/keystore, never inside tuckDir, never committed). New `src/lib/repoScope.ts` owns it, validated by a new `src/schemas/repos.schema.ts` (parsed, never `as`-cast, mirroring context.ts's untrusted-JSON discipline). Live location of a repo file = `join(resolveRepoRoot(repoKey), repoRelative)`. Unknown `repoKey` on a machine → resolves to `null` → **skipped, never guessed** (new `'unknown-repo'` FileState; explicit `tuck repo link`).
+
+**3. repoKey derivation.** `deriveRepoKey(repoRoot)` = `slugify(basename(repoRoot)) + '-' + sha256(canonicalRemoteUrl).slice(0,8)` where the hash input is the canonicalized `origin` URL (via existing `getRemoteUrl`, strip scheme/`.git`/trailing slash, lowercase host) — this is what makes machine A and machine B derive the **same** key. No remote → fall back to first-commit hash (`git rev-list --max-parents=0 HEAD`), then to `basename` + short random with a warning. `--repo-key <label>` is the explicit override/escape hatch. **Never embed the absolute path in the committed key** (this is exactly the cross-machine bug in context.ts:208's `repoScopeKey`, which I deliberately do not reuse for the portable key).
+
+**4. Path guard (do NOT weaken home confinement).** `validateSafeSourcePath` is untouched and still gates home scope. Add a sibling `validateSafeRepoSourcePath(repoRoot, repoRelative)`: rejects absolute/`..`/UNC `repoRelative` (reuse the normalized-split checks from `validateSafeManifestDestination`), then `validatePathWithinRoot(resolve(repoRoot, repoRelative), repoRoot)`. Symmetric to home confinement, but the allowed root is the registered repo root. The repo root comes ONLY from the machine-local registry, so a hostile manifest can only *name* a key — an unknown key is skipped; a known key still confines the write inside that bound repo.
+
+**5. Sandbox composition (the decisive part — and the bug all designs but one missed).** Two changes, both required:
+- Extend `resolveWriteTarget(source, repo?)` with an optional `repo?: { repoKey; repoRelative; repoRoot }`. **When `isSandbox()`**, rebase by *stable identity*: `target = resolve(root, 'repos', repoKey, repoRelative)` — the real (possibly out-of-home) `repoRoot` is used ONLY to compute the tail, never to place the file; the existing final `validatePathWithinRoot(target, root)` backstop holds, so an out-of-home repo can never escape `--root`. **When NOT sandboxed**, `target = resolve(repoRoot, repoRelative)` (the genuine repo on this machine), confined by `validateSafeRepoSourcePath` upstream.
+- **Critical, load-bearing:** `resolveWriteTarget` is NOT the only guard on the write path. `copyFileOrDir`/`createSymlink` independently call `validateSafeDestinationPath(expandedDest)` which **defaults to `[homedir()]`** and will reject any out-of-home repo target. So `allowedRoots()` must change to return `[homedir(), ...ctx.repoRoots]` when **not** sandboxed (and `[getWriteRoot()]` when sandboxed, since rebased repo writes already land under it), and **every** `copyFileOrDir`/`createSymlink` call that can target a repo file MUST pass `allowedRoots()`. The known repo roots are loaded into the write context in the `index.ts` preAction hook (`setKnownRepoRoots(...)` right after `setWriteContext`).
+
+**6. Single resolver.** `resolveLiveTarget(file)` in `repoScope.ts`: home → `expandPath(file.source)`; repo → `resolveRepoRoot(repoKey)` then `join(root, repoRelative)`, or `null`. Used by stateModel, restore, apply, sync. One choke point, decided once at add time, never re-inferred from cwd.
+
+**7. `add` is the only constructor of repo entries**, gated behind explicit `--repo` (auto-detect prompts interactively, but `--json`/`--yes` require explicit `--repo` so home files are never silently re-scoped). v1 restricts repo scope to **copy strategy** (no symlinking working-tree files).
+
+I reject design 1's reuse of `repoScopeKey` for identity (path-embedded = cross-machine-broken) and adopt design 2/3's remote-URL-canonicalized key. I adopt design 3's `allowedRoots()`/`validateSafeDestinationPath` threading (the only design that's actually buildable). I adopt design 1's `.optional()` (no default) for true byte-identical backward compat.
+
+---
+
+# IMPLEMENTATION PLAN (ordered, test-first, independently committable)
+
+**Step 0 — Branch.** `git checkout -b feat/repo-scoped-tracking` off `development`. Run `pnpm lint && pnpm typecheck && pnpm test` once to capture a green baseline.
+
+**Step 1 — Manifest schema + backward-compat.**
+- Test first: extend `tests/lib/manifest.test.ts` — (a) a legacy manifest (no `scope`) parses and re-saves byte-identical (no injected `scope` key); (b) a valid repo entry parses; (c) `scope:'repo'` with missing `repoKey`/`repoRelative` fails parse; (d) `repoRelative:"../x"` fails; (e) home entry with stray `repoKey` fails.
+- Change: `src/schemas/manifest.schema.ts` — add `scope`/`repoKey`/`repoRelative` as `.optional()` + `.superRefine`. No version bump, no `migrateBundles` change.
+- Proof: the byte-identical re-save test is the load-bearing one.
+
+**Step 2 — repos.json schema + machine-local registry.**
+- Test first: new `tests/lib/repoScope.test.ts` — `loadReposRegistry()` returns empty when absent; `bindRepo`/`resolveRepoRoot` round-trip via a temp `XDG_STATE_HOME`; malformed `repos.json` parses to empty (never throws); `resolveRepoRoot(unknown)` → `null`.
+- Change: new `src/schemas/repos.schema.ts` (`{version:'1', repos: Record<key,{root,remoteUrl?,boundAt}>}`); new `src/lib/repoScope.ts` with `getReposRegistryPath` (uses `getStateDir`), `loadReposRegistry`, `bindRepo` (`ensureDir` + `atomicWriteFile`), `resolveRepoRoot`; move/share `findGitRoot` here (re-export from context.ts to avoid a second copy).
+- Proof: round-trip + malformed-safe tests.
+
+**Step 3 — repoKey derivation + canonical remote URL.**
+- Test first: in `tests/lib/repoScope.test.ts` — `canonicalRemoteUrl('git@github.com:u/r.git') === canonicalRemoteUrl('https://github.com/u/r')`; `deriveRepoKey` is deterministic for the same remote; `--repo-key` override wins; no-remote falls back to first-commit hash.
+- Change: add `canonicalRemoteUrl`, `deriveRepoKey(repoRoot, opts?)` to `repoScope.ts` (uses existing `getRemoteUrl` from git.ts + `git rev-list --max-parents=0 HEAD`). Reuse `slugifyPath` (export it from context.ts or lift to `repoScope.ts`).
+- Proof: SSH/HTTPS-equivalence test.
+
+**Step 4 — Path guard for repo sources.**
+- Test first: extend `tests/lib/paths.test.ts` / `tests/security/*` — `validateSafeRepoSourcePath(root, '.vscode/settings.json')` passes for a root outside `$HOME` (e.g. `/tmp/foo`); rejects `..`, absolute, `\\`-UNC; confirm `validateSafeSourcePath` behavior is unchanged (existing tests stay green).
+- Change: add `validateSafeRepoSourcePath` to `src/lib/paths.ts`; add `getRepoScopedDestination(repoKey, repoRelative)` returning `files/repos/<key>/<rel>` (POSIX, runs through `validateSafeManifestDestination`).
+- Proof: out-of-home root passes; traversal rejected.
+
+**Step 5 — `resolveWriteTarget(source, repo?)` + `allowedRoots()` + write context repo roots.**
+- Test first: extend `tests/lib/writeContext.test.ts` — sandbox: `resolveWriteTarget('ignored', {repoKey:'k', repoRelative:'a/b', repoRoot:'/srv/out/of/home'})` → `<root>/repos/k/a/b`, and a hostile `repoRoot:'/'` + `repoRelative:'etc/passwd'` still lands under `<root>/repos/...` (no escape); non-sandbox: returns `resolve(repoRoot, repoRelative)`; `allowedRoots()` returns `[homedir(), ...knownRepoRoots]` when not sandboxed and `[getWriteRoot()]` when sandboxed; calling 1-arg `resolveWriteTarget(source)` is byte-identical to today (existing tests must stay green).
+- Change: `src/lib/writeContext.ts` — add optional `repo` param + branch; add `repoRoots: string[]` to `WriteContext` + `setKnownRepoRoots`; update `allowedRoots()`. Wire `setKnownRepoRoots(Object.values(loadReposRegistry().repos).map(r=>resolve(r.root)))` into `src/index.ts` preAction hook right after `setWriteContext`.
+- Proof: the hostile-`repoRoot`-in-sandbox containment test.
+
+**Step 6 — Thread `allowedRoots()` into the copy/symlink write path (the load-bearing fix).**
+- Test first: new `tests/lib/files-repo-dest.test.ts` — with `setKnownRepoRoots(['/tmp/repoX'])`, `copyFileOrDir(src, '/tmp/repoX/sub/file')` succeeds; without it, it still rejects (defaults to home). Same for `createSymlink`.
+- Change: `src/lib/files.ts` — `copyFileOrDir`/`createSymlink` call `validateSafeDestinationPath(expandedDest, allowedRoots())` (import from writeContext). This is safe for all existing home callers because `allowedRoots()` already includes `homedir()`.
+- Proof: out-of-home repo dest accepted only when bound.
+
+**Step 7 — `resolveLiveTarget` + stateModel `unknown-repo`.**
+- Test first: extend `tests/lib/stateModel.test.ts` — repo entry with bound key classifies normally (ok/drift/missing); repo entry with unbound key → `'unknown-repo'`; home entries unchanged. Add exhaustiveness: the new state must appear in `summarizeStateModel` and the `STATE_LABEL` map (TS strict catches a miss at compile time).
+- Change: add `resolveLiveTarget(file)` to `repoScope.ts`; `stateModel.ts` `computeFileState` uses it (async), adds `'unknown-repo'` to `FileState` union + `summarizeStateModel`; `verify.ts` `STATE_LABEL` gets the new entry; `fixMissingRepo` skips files whose live target is `null`.
+- Proof: unbound-key classification + exhaustive-switch compile.
+
+**Step 8 — `tuck add --repo` constructs repo entries.**
+- Test first: `tests/commands/add-repo.test.ts` (integration, temp git repo outside the temp `$HOME`) — `add --repo` writes a manifest entry with `scope:'repo'`, correct `repoKey`/`repoRelative`, `destination` under `files/repos/`, copies the live file into the repo dir, and calls `bindRepo`; rejects a path outside the detected root; `--json`/`--yes` without `--repo` stays home-scoped.
+- Change: `add.ts` (`--repo [dir]`, `--repo-key`), `src/types.ts` `AddOptions`; a repo-aware branch in `trackPipeline.ts` (`validateSafeRepoSourcePath` instead of `validateSafeSourcePath`, secret-scan on the absolute path, `destination=getRepoScopedDestination(...)`); extend `PreparedTrackFile` + `FileToTrack` + `trackFilesWithProgress`/`addFileToManifest` call to carry `scope`/`repoKey`/`repoRelative`. Restrict repo scope to copy strategy.
+- Proof: the manifest-shape assertion + `bindRepo` call.
+
+**Step 9 — restore uses the resolver + sandbox repo writes.**
+- Test first: extend `tests/commands/` restore tests — restore of a repo file on a machine where the repo is bound to a *different* path writes to that path; unbound key → skipped with a warning (and `skipped[]` in `--json`); under `--root`, the repo file lands under `<root>/repos/<key>/...`.
+- Change: `restore.ts` — `prepareFilesToRestore`/`restoreFilesInternal` branch on `file.scope`: home keeps `validateSafeSourcePath` + `resolveWriteTarget(source)`; repo uses `validateSafeRepoSourcePath` + `resolveLiveTarget` + `resolveWriteTarget(live, {repoKey,repoRelative,repoRoot})`. Add `--repo-root <dir>` opt-in for binding on restore.
+- Proof: cross-path restore + sandbox containment.
+
+**Step 10 — apply + sync repo-awareness.**
+- Test first: apply test — cloned manifest with a repo entry whose key is bound locally writes to the local checkout; unbound → skipped + listed in JSON envelope (never guessed). sync test — `detectChanges` uses `resolveLiveTarget`; unbound repo entry is skipped, NOT reported as `deleted`.
+- Change: `apply.ts` `prepareFilesToApply` (write destination via `resolveLiveTarget`; `repoPath` read stays `join(repoDir, destination)`; pass `repo` ctx into the four `resolveWriteTarget` call sites); `sync.ts` `detectChanges` (and the secret-scan source paths) via `resolveLiveTarget`.
+- Proof: unbound-not-deleted (the regression the design flags as the main sync hazard).
+
+**Step 11 — `tuck repo` command.**
+- Test first: `tests/commands/repo.test.ts` — `repo link <key> <path>` binds; `repo list` shows bindings; `repo unlink` removes; `link` rejects a non-existent / non-git path.
+- Change: new `src/commands/repo.ts` (`link`/`list`/`unlink`, `--json`), register in `src/index.ts` + `src/commands/index.ts`.
+- Proof: link→resolve round-trip.
+
+**Step 12 — docs + `.gitignore` guard.**
+- Change: `CLAUDE.md` (repo scope section: tracks config files inside repos, not whole repos; `repos.json` is machine-local; `tuck repo link` on new machines), `README`/`docs/` as present. Confirm `repos.json` lives under `getStateDir()` (already gitignored by being off-repo) — no manifest/`.tuckrc` leak of absolute paths.
+- Proof: `grep` test/CI assertion that no committed artifact contains an absolute `repoRoot` (a small unit test asserting the manifest entry has no absolute-path fields).
+
+**Final gate:** `pnpm lint && pnpm typecheck && pnpm test`, plus a manual two-dir end-to-end: `add --repo` in `/tmp/repoA`, copy manifest, `repo link` to `/tmp/repoB`, `restore`, `verify` (expect `ok`), and the same under `--root /tmp/sandbox` (expect writes under `/tmp/sandbox/repos/<key>/...`, nothing in `/tmp/repoB`).
+
+---
+
+Relevant files (all absolute): manifest schema `/Users/pranavkarra/Developer/tuck/src/schemas/manifest.schema.ts`; new `/Users/pranavkarra/Developer/tuck/src/schemas/repos.schema.ts`; new `/Users/pranavkarra/Developer/tuck/src/lib/repoScope.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/paths.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/writeContext.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/files.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/stateModel.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/state.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/fileTracking.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/trackPipeline.ts`; `/Users/pranavkarra/Developer/tuck/src/lib/git.ts` (reuse `getRemoteUrl`); `/Users/pranavkarra/Developer/tuck/src/commands/add.ts`; `/Users/pranavkarra/Developer/tuck/src/commands/restore.ts`; `/Users/pranavkarra/Developer/tuck/src/commands/apply.ts`; `/Users/pranavkarra/Developer/tuck/src/commands/sync.ts`; `/Users/pranavkarra/Developer/tuck/src/commands/verify.ts`; new `/Users/pranavkarra/Developer/tuck/src/commands/repo.ts`; `/Users/pranavkarra/Developer/tuck/src/index.ts`; `/Users/pranavkarra/Developer/tuck/src/types.ts`; `/Users/pranavkarra/Developer/tuck/src/commands/context.ts` (export `findGitRoot`/`slugifyPath`).
+
+The single most important correctness note for whoever executes this: **`copyFileOrDir`/`createSymlink` in `/Users/pranavkarra/Developer/tuck/src/lib/files.ts:249,328` call `validateSafeDestinationPath(expandedDest)` with the default `[homedir()]` root.** Without Step 6 threading `allowedRoots()`, every out-of-home repo restore silently fails at that guard even though `resolveWriteTarget` would have allowed it. Two designs omitted this; it is non-optional.

--- a/docs/REPO-SCOPED.md
+++ b/docs/REPO-SCOPED.md
@@ -1,0 +1,80 @@
+# Repo-scoped tracking
+
+tuck started as a `$HOME` dotfiles manager. Repo-scoped tracking generalizes it
+to **any config file, anywhere** — including files that live *inside* a git
+repository (a project's `.vscode/settings.json`, a `CLAUDE.md`, a
+`.cursorrules`, an `.aider.conf.yml`). You track them once, sync them in your
+tuck repo, and materialize them on another machine **even when that repo lives
+at a different absolute path there**.
+
+## The model
+
+A repo-scoped file is identified by a **stable, machine-independent key**, not
+an absolute path:
+
+- `repoKey` — derived from the repo's canonical remote URL (so `git@github…`
+  and `https://github…` for the same repo produce the *same* key on every
+  machine), falling back to the first-commit hash, then a random suffix. Set it
+  explicitly with `--repo-key <label>`.
+- `repoRelative` — the file's path relative to the repo root
+  (e.g. `.vscode/settings.json`).
+
+The committed manifest stores **only** `(repoKey, repoRelative)` — never an
+absolute path. Each machine keeps its own **machine-local registry**
+(`repos.json` under the state dir, e.g. `~/Library/Application Support/tuck/`,
+never committed) mapping `repoKey → absolute repo root`. So the same shared
+manifest resolves to `/Users/you/work/app` on one machine and
+`/home/you/projects/app` on another.
+
+## Track a file in a repo
+
+```sh
+# auto-detect the enclosing git repo and track a file inside it
+tuck add ./.vscode/settings.json --repo
+
+# or point at the repo explicitly / pin the key
+tuck add ~/work/app/CLAUDE.md --repo ~/work/app --repo-key app
+```
+
+This records a `scope: "repo"` entry, copies the file into
+`~/.tuck/files/repos/<repoKey>/…`, and binds `repoKey → repo root` on this
+machine. (Repo scope is copy-only — tuck won't symlink a working-tree file.)
+
+## Use it on another machine
+
+After cloning your tuck repo onto a new machine, repo-scoped files show up as
+**`unknown-repo`** in `tuck verify` until you tell tuck where that repo lives:
+
+```sh
+tuck repo list                         # see bindings / which repos are known
+tuck repo link app ~/projects/app      # bind repoKey -> this machine's path
+tuck restore                           # now materializes the repo-scoped files
+tuck verify --exit-code                # 0 when everything is in sync
+```
+
+`tuck restore --repo-root <dir>` binds-and-restores in one step. An unbound
+repo file is always **skipped** (and listed in `--json` output) — tuck never
+guesses a path.
+
+```
+tuck repo link <key> <path>    bind a repoKey to its root on this machine
+tuck repo list                 list all bindings (--json supported)
+tuck repo unlink <key>         remove a binding
+```
+
+## Composes with the sandbox
+
+Repo-scoped writes honor `--root`/`TUCK_TARGET_ROOT` (see
+[SANDBOXING.md](./SANDBOXING.md)): under a sandbox root, a repo file is
+re-based to `<root>/repos/<repoKey>/<repoRelative>` by **stable identity** — the
+real (possibly out-of-home) repo path is never used to place the file, so a
+repo outside `$HOME` can never let a write escape the sandbox. An agent can
+`tuck apply user/dotfiles --root /tmp/fakehome --yes` and preview repo-scoped
+files safely.
+
+## Safety
+
+- The home-confinement guard for ordinary dotfiles is unchanged; repo files are
+  confined to their bound repo root instead (no `..` escape, no absolute paths).
+- The machine-local `repos.json` lives outside the tuck repo and is never
+  committed, so absolute machine paths never leak into shared dotfiles.

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -15,6 +15,21 @@ import {
 
 type FileToAdd = PreparedTrackFile;
 
+/** Whether the caller asked for repo-scoped tracking (`--repo [dir]`). */
+const isRepoScopeRequested = (options: AddOptions): boolean =>
+  options.repo !== undefined && options.repo !== false;
+
+/**
+ * Repo-scoped tracking is COPY-ONLY: the live file stays inside its repo
+ * checkout (it can't be symlinked into the tuck repo without breaking the
+ * checkout). Reject `--symlink --repo` up front with a clear message.
+ */
+const assertRepoScopeCompatible = (options: AddOptions): void => {
+  if (isRepoScopeRequested(options) && options.symlink) {
+    throw new Error('--symlink cannot be combined with --repo: repo-scoped files are copy-only');
+  }
+};
+
 const addFiles = async (
   filesToAdd: FileToAdd[],
   tuckDir: string,
@@ -25,8 +40,11 @@ const addFiles = async (
   }
 
   const filesToTrack: FileToTrack[] = filesToAdd.map((f) => {
+    const isRepo = f.scope === 'repo';
     const trackedFile: FileToTrack = {
-      path: f.source,
+      // For repo files the live absolute path is what we copy FROM; for home
+      // files the (home-relative) source doubles as the path.
+      path: isRepo ? (f.liveSource ?? f.source) : f.source,
       category: f.category,
     };
 
@@ -38,11 +56,22 @@ const addFiles = async (
       trackedFile.bundle = options.bundle;
     }
 
+    if (isRepo) {
+      trackedFile.scope = 'repo';
+      trackedFile.repoKey = f.repoKey;
+      trackedFile.repoRelative = f.repoRelative;
+      trackedFile.repoRoot = f.repoRoot;
+      trackedFile.remoteUrl = f.remoteUrl;
+      trackedFile.source = f.source;
+      trackedFile.destination = f.destination;
+    }
+
     return trackedFile;
   });
 
   await trackFilesWithProgress(filesToTrack, tuckDir, {
     showCategory: true,
+    // Repo scope is always copy; --symlink is rejected upstream for repo adds.
     strategy: options.symlink ? 'symlink' : undefined,
     actionVerb: 'Tracking',
   });
@@ -132,6 +161,8 @@ export const addFilesFromPaths = async (
     throw new NotInitializedError();
   }
 
+  assertRepoScopeCompatible(options);
+
   const candidates: TrackPathCandidate[] = paths.map((path) => ({
     path,
     category: options.category,
@@ -144,6 +175,8 @@ export const addFilesFromPaths = async (
     force: options.force,
     secretHandling: 'strict',
     forceBypassCommand: 'tuck add --force',
+    repo: options.repo,
+    repoKey: options.repoKey,
   });
 
   if (filesToAdd.length === 0) {
@@ -163,6 +196,8 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
   } catch {
     throw new NotInitializedError();
   }
+
+  assertRepoScopeCompatible(options);
 
   if (paths.length === 0) {
     if (isJsonMode() || options.yes) {
@@ -203,6 +238,8 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
     force: options.force,
     secretHandling: isJsonMode() || options.yes ? 'strict' : 'interactive',
     forceBypassCommand: 'tuck add --force',
+    repo: options.repo,
+    repoKey: options.repoKey,
   });
 
   if (filesToAdd.length === 0) {
@@ -246,6 +283,11 @@ export const addCommand = new Command('add')
   .option('-c, --category <name>', 'Category to organize under')
   .option('-n, --name <name>', 'Custom name for the file in manifest')
   .option('--symlink', 'Copy into tuck repo, then replace source path with a symlink')
+  .option(
+    '--repo [dir]',
+    'Track as repo-scoped (file lives in a git repo; auto-detects the root from the path when no dir is given)'
+  )
+  .option('--repo-key <key>', 'Explicit stable repo identity (advanced; default derives from the remote)')
   .option('-f, --force', 'Skip secret scanning (not recommended)')
   .option('-b, --bundle <name>', 'Bundle to assign the file to (defaults to "default")')
   .option('--json', 'Emit JSON envelope to stdout (non-interactive)')

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -13,16 +13,17 @@ import {
   validateSafeSourcePath,
   validateSafeManifestDestination,
   validatePathWithinRoot,
+  validateSafeRepoSourcePath,
   getTuckDir,
 } from '../lib/paths.js';
-import { resolveWriteTarget } from '../lib/writeContext.js';
+import { resolveWriteTarget, setKnownRepoRoots, type RepoWriteTarget } from '../lib/writeContext.js';
+import { resolveLiveTarget, resolveRepoRoot, bindRepo } from '../lib/repoScope.js';
 import { cloneRepo } from '../lib/git.js';
 import { isGhInstalled, ghCloneRepo, repoExists } from '../lib/github.js';
 import { createPreApplySnapshot } from '../lib/timemachine.js';
 import { smartMerge, isShellFile, generateMergePreview } from '../lib/merge.js';
 import { CATEGORIES } from '../constants.js';
-import type { TuckManifest } from '../types.js';
-import { tuckManifestSchema } from '../schemas/manifest.schema.js';
+import { tuckManifestSchema, type TuckManifestOutput } from '../schemas/manifest.schema.js';
 import { findPlaceholders, restoreContent, restoreFiles as restoreSecrets, getAllSecrets, getSecretCount } from '../lib/secrets/index.js';
 import { createResolver } from '../lib/secretBackends/index.js';
 import { loadConfig } from '../lib/config.js';
@@ -81,13 +82,22 @@ export interface ApplyOptions {
   json?: boolean;
   /** Scope applied files to a single bundle. */
   bundle?: string;
+  /** Bind an as-yet-unknown repo to this root before applying repo-scoped files. */
+  repoRoot?: string;
 }
 
 interface ApplyFile {
   source: string;
+  /** Absolute LIVE write target on this machine (home path or repo checkout path). */
   destination: string;
   category: string;
+  /** Path to the file's committed copy inside the cloned tuck repo (READ side). */
   repoPath: string;
+  /**
+   * Repo-write descriptor for resolveWriteTarget. Present only for repo-scoped
+   * files; absent for home-scoped files (which route through the home logic).
+   */
+  repoTarget?: RepoWriteTarget;
 }
 
 interface ApplyResult {
@@ -96,6 +106,8 @@ interface ApplyResult {
     path: string;
     placeholders: string[];
   }>;
+  /** repo-scoped sources skipped because their repo is unbound on this machine. */
+  skippedUnboundRepos: string[];
 }
 
 const execFileAsync = promisify(execFile);
@@ -280,7 +292,7 @@ const cloneSource = async (
 /**
  * Read the manifest from a cloned repository
  */
-const readClonedManifest = async (repoDir: string): Promise<TuckManifest | null> => {
+const readClonedManifest = async (repoDir: string): Promise<TuckManifestOutput | null> => {
   const manifestPath = join(repoDir, '.tuckmanifest.json');
 
   if (!(await fsPathExists(manifestPath))) {
@@ -297,14 +309,62 @@ const readClonedManifest = async (repoDir: string): Promise<TuckManifest | null>
 };
 
 /**
- * Prepare the list of files to apply
+ * On a fresh machine the repo-scoped entries in the cloned manifest are not yet
+ * bound to any local checkout. `--repo-root <dir>` binds the repoKey(s) present
+ * in the manifest to that directory so the apply can place the files there.
+ *
+ * The single-repo case (the common one) binds the lone unbound repoKey to the
+ * given root. When several distinct unbound repoKeys are present we bind them
+ * all to the same root only if there is exactly one — otherwise we cannot safely
+ * guess which key the root belongs to and leave the rest unbound (skipped).
+ */
+const bindReposFromOption = async (
+  manifest: TuckManifestOutput,
+  repoRoot: string
+): Promise<void> => {
+  const unboundKeys = new Set<string>();
+  for (const file of Object.values(manifest.files)) {
+    if (file.scope === 'repo' && file.repoKey) {
+      if ((await resolveRepoRoot(file.repoKey)) === null) {
+        unboundKeys.add(file.repoKey);
+      }
+    }
+  }
+  // Only bind when the target is unambiguous (a single unbound repo).
+  if (unboundKeys.size === 1) {
+    const [key] = [...unboundKeys];
+    await bindRepo(key, repoRoot);
+  }
+};
+
+/**
+ * Register every bound repo root with the write context so out-of-home repo
+ * writes pass the copy/symlink guard (`allowedRoots()`).
+ */
+const registerKnownRepoRoots = async (manifest: TuckManifestOutput): Promise<void> => {
+  const roots: string[] = [];
+  for (const file of Object.values(manifest.files)) {
+    if (file.scope === 'repo' && file.repoKey) {
+      const root = await resolveRepoRoot(file.repoKey);
+      if (root) roots.push(root);
+    }
+  }
+  if (roots.length > 0) setKnownRepoRoots(roots);
+};
+
+/**
+ * Prepare the list of files to apply. Repo-scoped files are resolved to their
+ * LIVE checkout location on this machine; an unbound repo (no local checkout) is
+ * skipped — never guessed, never written to a wrong path — and reported back so
+ * callers can surface it.
  */
 const prepareFilesToApply = async (
   repoDir: string,
-  manifest: TuckManifest,
+  manifest: TuckManifestOutput,
   bundle?: string
-): Promise<ApplyFile[]> => {
+): Promise<{ files: ApplyFile[]; skipped: string[] }> => {
   const files: ApplyFile[] = [];
+  const skipped: string[] = [];
 
   for (const [_id, file] of Object.entries(manifest.files)) {
     // Scope to a single bundle when requested. Treat missing/legacy bundle
@@ -312,8 +372,35 @@ const prepareFilesToApply = async (
     if (bundle && (file.bundle ?? 'default') !== bundle) {
       continue;
     }
+
+    const isRepoScoped = file.scope === 'repo';
+
     try {
-      validateSafeSourcePath(file.source);
+      if (isRepoScoped) {
+        // Repo-scoped: source is a "<repoKey>:<repoRelative>" pseudo-path that is
+        // NOT home-confined. Validate the repoRelative is a safe in-repo path.
+        if (!file.repoKey || !file.repoRelative) {
+          throw new Error('repo-scoped entry missing repoKey/repoRelative');
+        }
+        const root = await resolveRepoRoot(file.repoKey);
+        if (root) {
+          // Bound: confine the joined target within the actual repo root.
+          validateSafeRepoSourcePath(root, file.repoRelative);
+        } else {
+          // Unbound: only the structural shape of repoRelative is verifiable
+          // (no absolute, no "..") — there is no root to confine against yet.
+          const norm = file.repoRelative.replace(/\\/g, '/');
+          if (
+            norm.startsWith('/') ||
+            /^[A-Za-z]:[\\/]/.test(file.repoRelative) ||
+            norm.split('/').includes('..')
+          ) {
+            throw new Error(`Unsafe repo-relative path detected: ${file.repoRelative}`);
+          }
+        }
+      } else {
+        validateSafeSourcePath(file.source);
+      }
       validateSafeManifestDestination(file.destination);
     } catch {
       logger.warning(`Skipping unsafe manifest entry: ${file.source}`);
@@ -329,17 +416,41 @@ const prepareFilesToApply = async (
       continue;
     }
 
-    if (await fsPathExists(repoFilePath)) {
-      files.push({
-        source: file.source,
-        destination: expandPath(file.source),
-        category: file.category,
-        repoPath: repoFilePath,
-      });
+    if (!(await fsPathExists(repoFilePath))) {
+      continue;
     }
+
+    // Resolve the LIVE write location. Home files → expandPath(source). Repo files
+    // → the bound checkout path, or null when the repo is unbound on this machine.
+    const liveTarget = await resolveLiveTarget(file);
+
+    if (liveTarget === null) {
+      // Unbound repo — skip and report it. Never guess a destination.
+      skipped.push(file.source);
+      continue;
+    }
+
+    let repoTarget: RepoWriteTarget | undefined;
+    if (isRepoScoped) {
+      const root = await resolveRepoRoot(file.repoKey!);
+      // resolveLiveTarget already returned non-null → the repo is bound.
+      repoTarget = {
+        repoKey: file.repoKey!,
+        repoRelative: file.repoRelative!,
+        repoRoot: root!,
+      };
+    }
+
+    files.push({
+      source: file.source,
+      destination: liveTarget,
+      category: file.category,
+      repoPath: repoFilePath,
+      repoTarget,
+    });
   }
 
-  return files;
+  return { files, skipped };
 };
 
 /**
@@ -390,6 +501,7 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
   const result: ApplyResult = {
     appliedCount: 0,
     filesWithPlaceholders: [],
+    skippedUnboundRepos: [],
   };
 
   // Get tuck directory for secret resolution
@@ -420,8 +532,9 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
           `${collapsePath(file.destination)} (${mergeResult.preservedBlocks} blocks preserved)`
         );
       } else {
-        // Confine the write under --root (no-op when not sandboxed).
-        const writeTarget = resolveWriteTarget(file.destination);
+        // Confine the write under --root (no-op when not sandboxed). Repo files
+        // route through their repo descriptor so the target is the local checkout.
+        const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
         await ensureDir(dirname(writeTarget));
         await writeFile(writeTarget, mergeResult.content, 'utf-8');
         logger.file('merge', collapsePath(file.destination));
@@ -436,7 +549,7 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
         }
       } else {
         const fileExists = await pathExists(file.destination);
-        const writeTarget = resolveWriteTarget(file.destination);
+        const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
         // Write file content directly instead of copying (to preserve resolved secrets)
         await ensureDir(dirname(writeTarget));
         await writeFile(writeTarget, fileContent, 'utf-8');
@@ -458,6 +571,7 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
   const result: ApplyResult = {
     appliedCount: 0,
     filesWithPlaceholders: [],
+    skippedUnboundRepos: [],
   };
 
   // Get tuck directory for secret resolution
@@ -486,7 +600,7 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       }
     } else {
       const fileExists = await pathExists(file.destination);
-      const writeTarget = resolveWriteTarget(file.destination);
+      const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
       // Write file content directly instead of copying (to preserve resolved secrets)
       await ensureDir(dirname(writeTarget));
       await writeFile(writeTarget, fileContent, 'utf-8');
@@ -680,8 +794,20 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
       return;
     }
 
+    // --repo-root: bind the (single) unbound repo present before resolving files.
+    if (options.repoRoot) {
+      await bindReposFromOption(manifest, options.repoRoot);
+    }
+    await registerKnownRepoRoots(manifest);
+
     // Prepare files to apply
-    const files = await prepareFilesToApply(repoDir, manifest, options.bundle);
+    const { files, skipped } = await prepareFilesToApply(repoDir, manifest, options.bundle);
+
+    if (skipped.length > 0) {
+      prompts.log.warning(
+        `Skipping ${skipped.length} repo-scoped file(s) for repos not linked on this machine:\n  ${skipped.join('\n  ')}`
+      );
+    }
 
     if (files.length === 0) {
       const scope = options.bundle ? ` in bundle "${options.bundle}"` : '';
@@ -855,16 +981,29 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
       throw new Error('No tuck manifest found in repository');
     }
 
+    // --repo-root: bind the (single) unbound repo present in the manifest so its
+    // files can be placed in the freshly-linked checkout on this machine.
+    if (options.repoRoot) {
+      await bindReposFromOption(manifest, options.repoRoot);
+    }
+    // Register bound repo roots so out-of-home repo writes pass the copy guard.
+    await registerKnownRepoRoots(manifest);
+
     // Prepare files to apply
-    const files = await prepareFilesToApply(repoDir, manifest, options.bundle);
+    const { files, skipped } = await prepareFilesToApply(repoDir, manifest, options.bundle);
 
     if (files.length === 0) {
       if (isJsonMode()) {
-        emitJsonOk({ applied: 0, source });
+        emitJsonOk({ applied: 0, source, skipped });
         return;
       }
       const scope = options.bundle ? ` in bundle "${options.bundle}"` : '';
       logger.warning(`No files to apply${scope}`);
+      if (skipped.length > 0) {
+        logger.warning(
+          `Skipped ${skipped.length} repo-scoped file(s) for unlinked repos: ${skipped.join(', ')}`
+        );
+      }
       return;
     }
 
@@ -901,11 +1040,14 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
       applyResult = await applyWithReplace(files, options.dryRun || false);
     }
 
+    const allSkipped = [...skipped, ...applyResult.skippedUnboundRepos];
+
     if (isJsonMode()) {
       emitJsonOk({
         applied: applyResult.appliedCount,
         source,
         dryRun: !!options.dryRun,
+        skipped: allSkipped,
       });
       return;
     }
@@ -916,6 +1058,12 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
       logger.info(`Would apply ${applyResult.appliedCount} files`);
     } else {
       logger.success(`Applied ${applyResult.appliedCount} files`);
+    }
+
+    if (allSkipped.length > 0) {
+      logger.warning(
+        `Skipped ${allSkipped.length} repo-scoped file(s) for unlinked repos: ${allSkipped.join(', ')}`
+      );
     }
 
     // Show placeholder warnings
@@ -958,6 +1106,10 @@ export const applyCommand = new Command('apply')
   .option('-y, --yes', 'Assume yes to all prompts')
   .option('--json', 'Emit JSON envelope to stdout')
   .option('-b, --bundle <name>', 'Only apply files in the named bundle')
+  .option(
+    '--repo-root <dir>',
+    'Bind an as-yet-unlinked repo to this checkout before applying repo-scoped files'
+  )
   .action(async (source: string, options: ApplyOptions) => {
     // Determine if we should run interactive mode
     const isInteractive = !options.force && !options.yes && !options.json && process.stdout.isTTY;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,3 +17,4 @@ export { encryptionCommand } from './encryption.js';
 export { doctorCommand } from './doctor.js';
 export { bundleCommand } from './bundle.js';
 export { verifyCommand } from './verify.js';
+export { repoCommand } from './repo.js';

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -1,0 +1,134 @@
+/**
+ * `tuck repo` — manage the MACHINE-LOCAL repoKey -> root bindings.
+ *
+ * Repo-scoped tracked files are identified in the (committed) manifest by
+ * `(repoKey, repoRelative)` only — never an absolute path. To resolve such an
+ * entry to a concrete file on THIS machine, tuck consults a per-machine,
+ * off-repo registry (`repos.json` under the state dir) that maps each repoKey
+ * to that machine's absolute repo root. This command is the user-facing way to
+ * create, inspect, and remove those bindings.
+ *
+ *   tuck repo link <repoKey> <path>   verify <path> exists + lives inside a git
+ *                                     repo, then bind <repoKey> to the repo ROOT
+ *   tuck repo list                    show every binding on this machine
+ *   tuck repo unlink <repoKey>        remove a binding
+ *
+ * link refuses to bind a key to a phantom path or to a directory that is not
+ * inside a git repo — a binding must always point at a real repo root, since
+ * everything resolved through it is written there.
+ */
+
+import { Command } from 'commander';
+import { resolve } from 'path';
+import { pathExists, expandPath, collapsePath } from '../lib/paths.js';
+import {
+  bindRepo,
+  unbindRepo,
+  findGitRoot,
+  loadReposRegistry,
+} from '../lib/repoScope.js';
+import { logger, colors as c } from '../ui/index.js';
+import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { TuckError } from '../errors.js';
+
+const linkAction = async (
+  repoKey: string,
+  path: string,
+  opts: { json?: boolean }
+): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck repo link');
+
+  const abs = resolve(expandPath(path));
+
+  // A binding must point at a real repo root. Verify the path exists, then walk
+  // up to the enclosing git repo root — refuse if either check fails so we
+  // never bind a key to a phantom or non-repo directory.
+  if (!(await pathExists(abs))) {
+    throw new TuckError(`Path does not exist: ${collapsePath(abs)}`, 'REPO_PATH_NOT_FOUND', [
+      'Pass the path to an existing git repository on this machine.',
+    ]);
+  }
+
+  const repoRoot = await findGitRoot(abs);
+  if (!repoRoot) {
+    throw new TuckError(`Not inside a git repository: ${collapsePath(abs)}`, 'REPO_NOT_A_GIT_REPO', [
+      'Run this from within a git repo, or pass the path to one.',
+      'Initialize a repo first with `git init`.',
+    ]);
+  }
+
+  await bindRepo(repoKey, repoRoot);
+
+  if (isJsonMode()) {
+    emitJsonOk({ repoKey, root: repoRoot });
+    return;
+  }
+  logger.success(`Linked ${c.cyan(repoKey)} → ${c.dim(repoRoot)}`);
+};
+
+const listAction = async (opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck repo list');
+
+  const reg = await loadReposRegistry();
+  const repos = Object.entries(reg.repos).map(([repoKey, binding]) => ({
+    repoKey,
+    root: binding.root,
+    ...(binding.remoteUrl ? { remoteUrl: binding.remoteUrl } : {}),
+    boundAt: binding.boundAt,
+  }));
+
+  if (isJsonMode()) {
+    emitJsonOk({ repos });
+    return;
+  }
+
+  if (repos.length === 0) {
+    logger.info('No repos linked on this machine.');
+    logger.dim('Link one with: tuck repo link <repoKey> <path>');
+    return;
+  }
+  console.log();
+  for (const r of repos) {
+    console.log(`  ${c.cyan(r.repoKey)}  ${c.dim('→')}  ${r.root}`);
+  }
+};
+
+const unlinkAction = async (repoKey: string, opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck repo unlink');
+
+  const removed = await unbindRepo(repoKey);
+
+  if (isJsonMode()) {
+    emitJsonOk({ repoKey, removed });
+    return;
+  }
+  if (removed) {
+    logger.success(`Unlinked ${c.cyan(repoKey)}`);
+  } else {
+    logger.info(`No binding found for ${c.cyan(repoKey)}.`);
+  }
+};
+
+export const repoCommand = new Command('repo')
+  .description('Manage machine-local repo bindings (repoKey → absolute root)')
+  .addCommand(
+    new Command('link')
+      .description('Bind a repoKey to a git repository on this machine')
+      .argument('<repoKey>', 'Stable, cross-machine repo identity')
+      .argument('<path>', 'Path inside the target git repository')
+      .option('--json', 'Emit JSON envelope')
+      .action(linkAction)
+  )
+  .addCommand(
+    new Command('list')
+      .description('List all repo bindings on this machine')
+      .option('--json', 'Emit JSON envelope')
+      .action(listAction)
+  )
+  .addCommand(
+    new Command('unlink')
+      .description('Remove a repo binding from this machine')
+      .argument('<repoKey>', 'The repoKey to unbind')
+      .option('--json', 'Emit JSON envelope')
+      .action(unlinkAction)
+  );

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -11,9 +11,16 @@ import {
   validateSafeSourcePath,
   validateSafeManifestDestination,
   validatePathWithinRoot,
+  validateSafeRepoSourcePath,
 } from '../lib/paths.js';
 import { loadManifest, getAllTrackedFiles, getTrackedFileBySource } from '../lib/manifest.js';
-import { resolveWriteTarget } from '../lib/writeContext.js';
+import { resolveWriteTarget, setKnownRepoRoots } from '../lib/writeContext.js';
+import {
+  resolveLiveTarget,
+  resolveRepoRoot,
+  bindRepo,
+  loadReposRegistry,
+} from '../lib/repoScope.js';
 import { loadConfig } from '../lib/config.js';
 import { copyFileOrDir, createSymlink } from '../lib/files.js';
 import { createBackup } from '../lib/backup.js';
@@ -83,12 +90,20 @@ interface FileToRestore {
   destination: string;
   category: string;
   existsAtTarget: boolean;
+  /** Tracking scope — absent/'home' resolves against $HOME; 'repo' against a bound repo root. */
+  scope?: 'home' | 'repo';
+  /** Stable cross-machine repo identity (repo-scoped files only). */
+  repoKey?: string;
+  /** POSIX path relative to the repo root (repo-scoped files only). */
+  repoRelative?: string;
 }
 
 interface RestoreResult {
   restoredCount: number;
   secretsRestored: number;
   unresolvedPlaceholders: string[];
+  /** Sources of repo-scoped files skipped because their repoKey is unbound on this machine. */
+  skipped: string[];
 }
 
 const prepareFilesToRestore = async (
@@ -109,33 +124,50 @@ const prepareFilesToRestore = async (
         throw new FileNotFoundError(`Not tracked: ${path}`);
       }
 
-      validateSafeSourcePath(tracked.file.source);
+      // Repo-scoped files live under a (per-machine) repo root that may be
+      // outside $HOME, so home-confinement does not apply; their live location
+      // is resolved later via the repo registry. Home files keep the existing
+      // home-confinement guard. The manifest destination is always confined.
+      const isRepo = tracked.file.scope === 'repo';
+      if (!isRepo) {
+        validateSafeSourcePath(tracked.file.source);
+      }
       validateSafeManifestDestination(tracked.file.destination);
       const repositoryPath = join(tuckDir, tracked.file.destination);
       validatePathWithinRoot(repositoryPath, tuckDir, 'restore source');
 
+      const liveTarget = await resolveLiveTarget(tracked.file);
       filesToRestore.push({
         id: tracked.id,
         source: tracked.file.source,
         destination: repositoryPath,
         category: tracked.file.category,
-        existsAtTarget: await pathExists(expandedPath),
+        existsAtTarget: liveTarget ? await pathExists(liveTarget) : false,
+        scope: tracked.file.scope,
+        repoKey: tracked.file.repoKey,
+        repoRelative: tracked.file.repoRelative,
       });
     }
   } else {
     // Restore all files
     for (const [id, file] of Object.entries(allFiles)) {
-      validateSafeSourcePath(file.source);
+      const isRepo = file.scope === 'repo';
+      if (!isRepo) {
+        validateSafeSourcePath(file.source);
+      }
       validateSafeManifestDestination(file.destination);
       const repositoryPath = join(tuckDir, file.destination);
       validatePathWithinRoot(repositoryPath, tuckDir, 'restore source');
-      const targetPath = expandPath(file.source);
+      const liveTarget = await resolveLiveTarget(file);
       filesToRestore.push({
         id,
         source: file.source,
         destination: repositoryPath,
         category: file.category,
-        existsAtTarget: await pathExists(targetPath),
+        existsAtTarget: liveTarget ? await pathExists(liveTarget) : false,
+        scope: file.scope,
+        repoKey: file.repoKey,
+        repoRelative: file.repoRelative,
       });
     }
   }
@@ -161,15 +193,57 @@ const restoreFilesInternal = async (
   // Run pre-restore hook
   await runPreRestoreHook(tuckDir, hookOptions);
 
+  // Register the machine's bound repo roots so copyFileOrDir/createSymlink will
+  // accept out-of-home repo write destinations (validated against allowedRoots).
+  // `extra` lets us guarantee a just-bound root is registered even before the
+  // registry round-trip is observable.
+  const refreshKnownRepoRoots = async (...extra: string[]): Promise<void> => {
+    const reg = await loadReposRegistry();
+    const roots = Object.values(reg.repos).map((r) => r.root);
+    setKnownRepoRoots([...roots, ...extra]);
+  };
+  await refreshKnownRepoRoots();
+
   let restoredCount = 0;
   const restoredPaths: string[] = [];
+  const skipped: string[] = [];
 
   for (const file of files) {
-    validateSafeSourcePath(file.source);
     validatePathWithinRoot(file.destination, tuckDir, 'restore source');
-    // Resolve + confine the write target (redirected under --root in sandbox
-    // mode; identical to expandPath when not sandboxed). Never escapes the root.
-    const targetPath = resolveWriteTarget(file.source);
+
+    // Resolve + confine the write target. Home files (scope absent/'home')
+    // resolve against $HOME (redirected under --root in sandbox mode). Repo
+    // files resolve against their per-machine bound root via the repo registry.
+    let targetPath: string;
+    if (file.scope === 'repo') {
+      // Resolve the repo's live root. If unbound, either bind it to an explicit
+      // --repo-root, or skip (never guess where the repo lives on this machine).
+      let repoRoot = file.repoKey ? await resolveRepoRoot(file.repoKey) : null;
+      if (!repoRoot && options.repoRoot && file.repoKey) {
+        await bindRepo(file.repoKey, options.repoRoot);
+        await refreshKnownRepoRoots(options.repoRoot);
+        repoRoot = (await resolveRepoRoot(file.repoKey)) ?? options.repoRoot;
+      }
+      if (!repoRoot || !file.repoKey || !file.repoRelative) {
+        logger.warning(
+          `Skipping repo-scoped file (repo not bound on this machine): ${file.source}`
+        );
+        skipped.push(file.source);
+        continue;
+      }
+      // Repo files live under a root that may be outside $HOME; confine to the
+      // repo root and reject unsafe repoRelative paths (absolute / traversal).
+      validateSafeRepoSourcePath(repoRoot, file.repoRelative);
+      // Compose through resolveWriteTarget so it still rebases under --root.
+      targetPath = resolveWriteTarget(file.source, {
+        repoKey: file.repoKey,
+        repoRelative: file.repoRelative,
+        repoRoot,
+      });
+    } else {
+      validateSafeSourcePath(file.source);
+      targetPath = resolveWriteTarget(file.source);
+    }
 
     // Check if source exists in repository
     if (!(await pathExists(file.destination))) {
@@ -232,6 +306,7 @@ const restoreFilesInternal = async (
     restoredCount,
     secretsRestored,
     unresolvedPlaceholders,
+    skipped,
   };
 };
 
@@ -463,6 +538,7 @@ export const runRestoreCommand = async (paths: string[], options: RestoreOptions
       restored: result.restoredCount,
       secretsRestored: result.secretsRestored,
       unresolvedPlaceholders: result.unresolvedPlaceholders,
+      skipped: result.skipped,
       total: files.length,
       dryRun: !!options.dryRun,
     });
@@ -477,6 +553,11 @@ export const runRestoreCommand = async (paths: string[], options: RestoreOptions
     displaySecretSummary(result);
     logger.success(`Restored ${result.restoredCount} file${result.restoredCount !== 1 ? 's' : ''}`);
   }
+  if (result.skipped.length > 0) {
+    logger.warning(
+      `Skipped ${result.skipped.length} repo-scoped file${result.skipped.length !== 1 ? 's' : ''} (repo not bound on this machine)`
+    );
+  }
 };
 
 export const restoreCommand = new Command('restore')
@@ -490,6 +571,10 @@ export const restoreCommand = new Command('restore')
   .option('--no-hooks', 'Skip execution of pre/post restore hooks')
   .option('--trust-hooks', 'Trust and run hooks without confirmation (use with caution)')
   .option('--no-secrets', 'Skip restoring secrets (keep placeholders as-is)')
+  .option(
+    '--repo-root <dir>',
+    'Bind an as-yet-unknown repo-scoped repo to this directory before restoring its files'
+  )
   .option('--json', 'Emit JSON envelope to stdout (suppresses interactive UI)')
   .option('-y, --yes', 'Auto-confirm prompts (required with --json for full automation)')
   .option('--plan', 'Print the operation plan and exit without restoring')

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -29,6 +29,7 @@ import {
 } from '../lib/mergeConflicts.js';
 import { resolveConflictsInteractively } from '../ui/merge.js';
 import { createSnapshot } from '../lib/timemachine.js';
+import { resolveLiveTarget } from '../lib/repoScope.js';
 import { isJsonMode } from '../lib/jsonOutput.js';
 import {
   copyFileOrDir,
@@ -77,7 +78,12 @@ const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
   const changes: FileChange[] = [];
 
   for (const [, file] of Object.entries(files)) {
-    validateSafeSourcePath(file.source);
+    // Home-scoped sources are confined to $HOME; repo-scoped sources live under a
+    // (possibly out-of-home) repo root, so they are validated by their repoRelative
+    // safety in the manifest schema, not by validateSafeSourcePath.
+    if (file.scope !== 'repo') {
+      validateSafeSourcePath(file.source);
+    }
     validateSafeManifestDestination(file.destination);
 
     // Skip if in .tuckignore
@@ -85,7 +91,18 @@ const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
       continue;
     }
 
-    const sourcePath = expandPath(file.source);
+    // Resolve the LIVE location on THIS machine. For home files this is
+    // expandPath(source); for repo files it is the bound repo root joined with
+    // repoRelative, or null when the repo is not bound here.
+    const sourcePath = await resolveLiveTarget(file);
+
+    // CRITICAL: an unbound repo file (null live target) must be SKIPPED — never
+    // reported as 'deleted'. Treating it as deleted would drop the committed copy
+    // and remove it from the shared manifest just because this machine hasn't
+    // linked the repo.
+    if (sourcePath === null) {
+      continue;
+    }
 
     // Check if source still exists
     if (!(await pathExists(sourcePath))) {
@@ -123,6 +140,27 @@ const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
 };
 
 /**
+ * Map the modified changes to their LIVE source paths on this machine, resolving
+ * repo-scoped entries through the repo registry (so the secret scanner reads the
+ * real checkout, not a "key:rel" pseudo-path). Unbound repo files resolve to null
+ * and are dropped from the result.
+ */
+const resolveModifiedLivePaths = async (
+  tuckDir: string,
+  changes: FileChange[]
+): Promise<string[]> => {
+  const trackedFiles = await getAllTrackedFiles(tuckDir);
+  const paths: string[] = [];
+  for (const change of changes) {
+    if (change.status !== 'modified') continue;
+    const entry = Object.values(trackedFiles).find((f) => f.source === change.source);
+    const live = entry ? await resolveLiveTarget(entry) : expandPath(change.source);
+    if (live !== null) paths.push(live);
+  }
+  return paths;
+};
+
+/**
  * Snapshot every tracked file's source path before a potentially destructive
  * pull. Failures here are non-fatal — we'd rather attempt the pull and warn
  * than block sync entirely on a backup hiccup.
@@ -130,7 +168,12 @@ const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
 const snapshotBeforePull = async (tuckDir: string, reason: string): Promise<void> => {
   try {
     const tracked = await getAllTrackedFiles(tuckDir);
-    const sources = Object.values(tracked).map((f) => expandPath(f.source));
+    // Resolve LIVE paths; drop unbound repo files (null) so we never snapshot a
+    // bogus "key:rel" pseudo-path for a repo this machine hasn't linked.
+    const resolved = await Promise.all(
+      Object.values(tracked).map((f) => resolveLiveTarget(f))
+    );
+    const sources = resolved.filter((p): p is string => p !== null);
     if (sources.length === 0) return;
     await createSnapshot(sources, reason);
   } catch (error) {
@@ -354,13 +397,32 @@ const syncFiles = async (
 
   // Process each change
   for (const change of changes) {
-    validateSafeSourcePath(change.source);
     if (!change.destination) {
       throw new Error(`Unsafe manifest entry detected: missing destination for ${change.source}`);
     }
     validateSafeManifestDestination(change.destination);
 
-    const sourcePath = expandPath(change.source);
+    // Look up the tracked entry so we can resolve a repo-scoped live path and
+    // only home-confine genuine home-scoped sources.
+    const trackedFiles = await getAllTrackedFiles(tuckDir);
+    const trackedEntry = Object.values(trackedFiles).find((f) => f.source === change.source);
+    if (trackedEntry?.scope !== 'repo') {
+      validateSafeSourcePath(change.source);
+    }
+
+    // Resolve the live path from the tracked entry (repo root + repoRelative for
+    // repo files, expandPath for home files). Falls back to expandPath when the
+    // entry is unexpectedly absent.
+    const sourcePath = trackedEntry
+      ? await resolveLiveTarget(trackedEntry)
+      : expandPath(change.source);
+
+    // An unbound repo source (null) can't be synced — skip it defensively. In
+    // practice detectChanges already filters these out before we get here.
+    if (sourcePath === null) {
+      continue;
+    }
+
     const destPath = join(tuckDir, change.destination);
     validatePathWithinRoot(destPath, tuckDir, 'sync destination');
 
@@ -453,10 +515,9 @@ const scanAndHandleSecrets = async (
     return true;
   }
 
-  // Get paths of modified files (not deleted)
-  const modifiedPaths = changes
-    .filter((c) => c.status === 'modified')
-    .map((c) => expandPath(c.source));
+  // Get LIVE paths of modified files (not deleted), resolving repo-scoped
+  // entries through the repo registry.
+  const modifiedPaths = await resolveModifiedLivePaths(tuckDir, changes);
 
   if (modifiedPaths.length === 0) {
     return true;
@@ -928,9 +989,7 @@ const scanChangesForSecretsOrThrow = async (
 
   if (!(await isSecretScanningEnabled(tuckDir))) return;
 
-  const modifiedPaths = changes
-    .filter((c) => c.status === 'modified')
-    .map((c) => expandPath(c.source));
+  const modifiedPaths = await resolveModifiedLivePaths(tuckDir, changes);
   if (modifiedPaths.length === 0) return;
 
   const summary = await scanForSecrets(modifiedPaths, tuckDir);

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -41,6 +41,7 @@ const STATE_LABEL: Record<FileStateEntry['state'], string> = {
   'missing-live': 'missing on system (run `tuck restore`)',
   'missing-repo': 'missing in repo (run `tuck verify --fix`)',
   'missing-both': 'missing everywhere (manifest references a vanished file)',
+  'unknown-repo': 'repo not linked on this machine (run `tuck repo link`)',
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { resolve as resolvePath } from 'path';
 import { contextCommand } from './commands/context.js';
 import { mcpCommand } from './commands/mcp.js';
 import { presetCommand } from './commands/preset.js';
+import { repoCommand } from './commands/repo.js';
 
 const program = new Command();
 
@@ -79,6 +80,7 @@ program.addCommand(verifyCommand);
 program.addCommand(contextCommand);
 program.addCommand(mcpCommand);
 program.addCommand(presetCommand);
+program.addCommand(repoCommand);
 
 // Best-effort EARLY detection so the error handler can emit JSON even for
 // failures that occur before any command action runs (e.g. during parsing).

--- a/src/lib/fileTracking.ts
+++ b/src/lib/fileTracking.ts
@@ -13,9 +13,10 @@ import { copyFileOrDir, createSymlink, deleteFileOrDir, getFileChecksum, getFile
 import { loadConfig } from './config.js';
 import { CATEGORIES } from '../constants.js';
 import { ensureDir } from 'fs-extra';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import type { FileStrategy } from '../types.js';
 import { toPosixPath } from './platform.js';
+import { bindRepo } from './repoScope.js';
 
 export interface FileToTrack {
   path: string;
@@ -23,6 +24,25 @@ export interface FileToTrack {
   name?: string;
   /** Bundle to assign the tracked file to. Defaults to "default". */
   bundle?: string;
+  /**
+   * Repo-scoped tracking metadata. When `scope === 'repo'` the file lives inside
+   * a git repo whose absolute path differs per machine; it is stored by stable
+   * (repoKey, repoRelative) and the precomputed repo-scoped `destination`/`source`
+   * are used verbatim instead of being derived from a home-relative path.
+   */
+  scope?: 'home' | 'repo';
+  /** Stable cross-machine repo identity (repo scope only). */
+  repoKey?: string;
+  /** POSIX path relative to the repo root (repo scope only). */
+  repoRelative?: string;
+  /** Absolute repo root on THIS machine (repo scope only). */
+  repoRoot?: string;
+  /** Canonicalized remote URL, recorded in the binding when known. */
+  remoteUrl?: string;
+  /** Manifest source identity to store verbatim (repo scope only). */
+  source?: string;
+  /** Relative manifest destination to store verbatim (repo scope only). */
+  destination?: string;
 }
 
 export interface FileTrackingOptions {
@@ -153,13 +173,20 @@ export const trackFilesWithProgress = async (
 
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
+    const isRepo = file.scope === 'repo';
     const expandedPath = expandPath(file.path);
     const indexStr = chalk.dim(`[${i + 1}/${total}]`);
     const category = file.category || detectCategory(expandedPath);
     const categoryInfo = CATEGORIES[category];
     const icon = categoryInfo?.icon || '○';
-    const sourcePath = collapsePath(file.path);
-    const relativeDestination = getRelativeDestinationFromSource(category, expandedPath, file.name);
+    // Repo-scoped files store a stable `<repoKey>:<repoRelative>` source and a
+    // precomputed, namespaced destination; home-scoped files derive both from
+    // the home-relative path.
+    const sourcePath = isRepo ? (file.source ?? file.path) : collapsePath(file.path);
+    const relativeDestination =
+      isRepo && file.destination
+        ? file.destination
+        : getRelativeDestinationFromSource(category, expandedPath, file.name);
     const normalizedDestination = toPosixPath(relativeDestination);
     const existingSource = trackedDestinations.get(normalizedDestination);
 
@@ -178,14 +205,17 @@ export const trackFilesWithProgress = async (
         );
       }
 
-      // Get destination path
-      const destination = getDestinationPathFromSource(tuckDir, category, expandedPath, file.name);
+      // Get destination path (absolute, inside the tuck repo).
+      const destination = isRepo && file.destination
+        ? join(tuckDir, file.destination)
+        : getDestinationPathFromSource(tuckDir, category, expandedPath, file.name);
 
-      // Ensure category directory exists
+      // Ensure destination directory exists
       await ensureDir(dirname(destination));
 
-      // Copy or symlink based on strategy
-      if (strategy === 'symlink') {
+      // Copy or symlink based on strategy. Repo-scoped tracking is copy-only:
+      // the live file stays put inside its repo checkout (never symlinked).
+      if (strategy === 'symlink' && !isRepo) {
         // Symlink strategy keeps the repository as source of truth:
         // 1) copy source into repo, 2) replace source with symlink to repo.
         await copyFileOrDir(expandedPath, destination, { overwrite: true });
@@ -199,7 +229,7 @@ export const trackFilesWithProgress = async (
           throw error;
         }
       } else {
-        // Default: copy file into the repository
+        // Default: copy file into the repository (from the absolute live path).
         await copyFileOrDir(expandedPath, destination, { overwrite: true });
       }
 
@@ -208,15 +238,16 @@ export const trackFilesWithProgress = async (
       const info = await getFileInfo(expandedPath);
       const now = new Date().toISOString();
 
-      // Generate unique ID
-      const id = generateFileId(file.path);
+      // Generate unique ID (from the stable identity for repo files).
+      const id = generateFileId(sourcePath);
 
       // Add to manifest
       await addFileToManifest(tuckDir, id, {
         source: sourcePath,
         destination: relativeDestination,
         category,
-        strategy,
+        // Repo scope is copy-only regardless of the configured global strategy.
+        strategy: isRepo ? 'copy' : strategy,
         // TODO: Encryption and templating are planned for a future version
         encrypted: false,
         template: false,
@@ -225,7 +256,22 @@ export const trackFilesWithProgress = async (
         modified: now,
         checksum,
         bundle: file.bundle ?? 'default',
+        ...(isRepo
+          ? {
+              scope: 'repo' as const,
+              repoKey: file.repoKey,
+              repoRelative: file.repoRelative,
+            }
+          : {}),
       });
+
+      // Bind the repo on THIS machine so the stable key resolves to the live
+      // root for later sync/restore. Idempotent upsert.
+      if (isRepo && file.repoKey && file.repoRoot) {
+        await bindRepo(file.repoKey, file.repoRoot, {
+          ...(file.remoteUrl ? { remoteUrl: file.remoteUrl } : {}),
+        });
+      }
 
       spinner.stop();
       const categoryStr = showCategory ? chalk.dim(` ${icon} ${category}`) : '';

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -16,6 +16,7 @@ import { join, dirname, basename, relative } from 'path';
 import { constants } from 'fs';
 import { FileNotFoundError, PermissionError } from '../errors.js';
 import { expandPath, pathExists, isDirectory, validateSafeDestinationPath } from './paths.js';
+import { allowedRoots } from './writeContext.js';
 import { IS_WINDOWS } from './platform.js';
 
 export interface FileInfo {
@@ -246,7 +247,10 @@ export const copyFileOrDir = async (
     throw new FileNotFoundError(source);
   }
 
-  validateSafeDestinationPath(expandedDest);
+  // Validate against the active allowed roots ($HOME + bound repo roots, or the
+  // sandbox root) — not just $HOME — so repo-scoped writes to a bound checkout
+  // outside home are permitted while everything else stays confined.
+  validateSafeDestinationPath(expandedDest, allowedRoots());
 
   // Ensure destination directory exists
   await ensureDir(dirname(expandedDest));
@@ -325,7 +329,7 @@ export const createSymlink = async (
     throw new FileNotFoundError(target);
   }
 
-  validateSafeDestinationPath(expandedLink);
+  validateSafeDestinationPath(expandedLink, allowedRoots());
 
   // Ensure link parent directory exists
   await ensureDir(dirname(expandedLink));

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -348,6 +348,41 @@ export const validateSafeManifestDestination = (destination: string): void => {
 };
 
 /**
+ * Validate a repo-scoped file's live target. Repo files live under a repo root
+ * that may be OUTSIDE $HOME, so home-confinement (validateSafeSourcePath) does
+ * not apply; instead the file must stay within its (bound) repo root. The
+ * `repoRelative` must be a safe relative path (no absolute, no `..`).
+ */
+export const validateSafeRepoSourcePath = (repoRoot: string, repoRelative: string): void => {
+  const norm = repoRelative.replace(/\\/g, '/');
+  if (
+    isAbsolute(repoRelative) ||
+    /^[A-Za-z]:[\\/]/.test(repoRelative) ||
+    norm.split('/').includes('..')
+  ) {
+    throw new Error(`Unsafe repo-relative path detected: ${repoRelative}`);
+  }
+  const root = resolve(expandPath(repoRoot));
+  validatePathWithinRoot(join(root, norm), root, 'repo-scoped source');
+};
+
+/**
+ * Build the in-repo destination for a repo-scoped file's tracked copy,
+ * namespaced under `files/repos/<repoKey>/...`. The result is a safe relative
+ * manifest path (validated by validateSafeManifestDestination).
+ */
+export const getRepoScopedDestination = (repoKey: string, repoRelative: string): string => {
+  const norm = repoRelative.replace(/\\/g, '/');
+  if (isAbsolute(repoRelative) || norm.split('/').includes('..')) {
+    throw new Error(`Unsafe repoRelative path detected: ${repoRelative}`);
+  }
+  const keySlug = repoKey.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const dest = posix.join(FILES_DIR, 'repos', keySlug, norm);
+  validateSafeManifestDestination(dest);
+  return dest;
+};
+
+/**
  * Resolve a manifest destination to an absolute repository path safely.
  * Ensures the destination is a valid manifest path and cannot escape the tuck root.
  */

--- a/src/lib/repoScope.ts
+++ b/src/lib/repoScope.ts
@@ -1,0 +1,156 @@
+/**
+ * Repo-scoped tracking: stable cross-machine repo identity + the machine-local
+ * registry that maps that identity to a concrete absolute root.
+ *
+ * A repo-scoped tracked file is identified in the (committed) manifest by
+ * `(repoKey, repoRelative)` only — NO absolute path. Each machine keeps its own
+ * `repos.json` (under the off-repo state dir) mapping `repoKey -> { root }`, so
+ * the same shared manifest resolves to `/Users/a/work/foo` on one machine and
+ * `/home/b/projects/foo` on another. An unknown key resolves to `null` and is
+ * skipped — never guessed.
+ */
+
+import { join, basename, resolve } from 'path';
+import { createHash } from 'crypto';
+import { readFile } from 'fs/promises';
+import { ensureDir } from 'fs-extra';
+import { getStateDir } from './state.js';
+import { atomicWriteFile } from './files.js';
+import { pathExists } from './paths.js';
+import { getRemoteUrl } from './git.js';
+import { reposRegistrySchema, type ReposRegistry } from '../schemas/repos.schema.js';
+
+const REGISTRY_MODE = 0o600;
+
+export const getReposRegistryPath = (): string => join(getStateDir(), 'repos.json');
+
+const emptyRegistry = (): ReposRegistry => ({ version: '1', repos: {} });
+
+/** Load the machine-local repo registry; returns empty on absence or corruption. */
+export const loadReposRegistry = async (): Promise<ReposRegistry> => {
+  const p = getReposRegistryPath();
+  if (!(await pathExists(p))) return emptyRegistry();
+  try {
+    const parsed = reposRegistrySchema.safeParse(JSON.parse(await readFile(p, 'utf-8')));
+    return parsed.success ? parsed.data : emptyRegistry();
+  } catch {
+    return emptyRegistry();
+  }
+};
+
+/** Bind a repoKey to an absolute root on THIS machine (idempotent upsert). */
+export const bindRepo = async (
+  repoKey: string,
+  root: string,
+  opts: { remoteUrl?: string; boundAt?: string } = {}
+): Promise<void> => {
+  const reg = await loadReposRegistry();
+  reg.repos[repoKey] = {
+    root: resolve(root),
+    ...(opts.remoteUrl ? { remoteUrl: opts.remoteUrl } : {}),
+    boundAt: opts.boundAt ?? new Date().toISOString(),
+  };
+  await ensureDir(getStateDir());
+  await atomicWriteFile(getReposRegistryPath(), JSON.stringify(reg, null, 2) + '\n', {
+    mode: REGISTRY_MODE,
+  });
+};
+
+/** Remove a binding. */
+export const unbindRepo = async (repoKey: string): Promise<boolean> => {
+  const reg = await loadReposRegistry();
+  if (!(repoKey in reg.repos)) return false;
+  delete reg.repos[repoKey];
+  await ensureDir(getStateDir());
+  await atomicWriteFile(getReposRegistryPath(), JSON.stringify(reg, null, 2) + '\n', {
+    mode: REGISTRY_MODE,
+  });
+  return true;
+};
+
+/** Resolve a repoKey to this machine's absolute root, or null if unbound. */
+export const resolveRepoRoot = async (repoKey: string): Promise<string | null> => {
+  const reg = await loadReposRegistry();
+  return reg.repos[repoKey]?.root ?? null;
+};
+
+const slugify = (s: string): string =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32) || 'repo';
+
+/**
+ * Canonicalize a git remote URL so the SSH and HTTPS forms of the same repo
+ * map to ONE string — the basis for a machine-independent repoKey.
+ *   git@github.com:u/r.git  ->  github.com/u/r
+ *   https://github.com/u/r  ->  github.com/u/r
+ *   ssh://git@github.com/u/r.git -> github.com/u/r
+ */
+export const canonicalRemoteUrl = (url: string): string => {
+  const u = url.trim().toLowerCase().replace(/\.git$/, '').replace(/\/+$/, '');
+  const ssh = u.match(/^git@([^:]+):(.+)$/);
+  if (ssh) return `${ssh[1]}/${ssh[2]}`;
+  const proto = u.match(/^[a-z]+:\/\/(?:[^@/]+@)?([^/]+)\/(.+)$/);
+  if (proto) return `${proto[1]}/${proto[2]}`;
+  return u;
+};
+
+/** Build a stable repoKey from a directory basename + a stable identity string. */
+export const repoKeyFromIdentity = (dirBasename: string, identity: string): string =>
+  `${slugify(dirBasename)}-${createHash('sha256').update(identity).digest('hex').slice(0, 8)}`;
+
+/** Walk up from `start` to find the enclosing git repo root, or null. */
+export const findGitRoot = async (start: string): Promise<string | null> => {
+  let dir = resolve(start);
+  for (let i = 0; i < 64; i++) {
+    if (await pathExists(join(dir, '.git'))) return dir;
+    const parent = join(dir, '..');
+    const resolvedParent = resolve(parent);
+    if (resolvedParent === dir) return null;
+    dir = resolvedParent;
+  }
+  return null;
+};
+
+/**
+ * Derive the stable repoKey for a repo root. Identity priority:
+ *   1. explicit `opts.repoKey` (slugified) — the escape hatch
+ *   2. canonicalized `origin` remote URL — identical across clones/machines
+ *   3. first-commit hash — stable when there is no remote
+ *   4. basename + random suffix — last resort (not cross-machine stable)
+ */
+export const deriveRepoKey = async (
+  repoRoot: string,
+  opts: { repoKey?: string; remoteUrl?: string } = {}
+): Promise<{ repoKey: string; remoteUrl?: string }> => {
+  const name = basename(resolve(repoRoot));
+  if (opts.repoKey) return { repoKey: slugify(opts.repoKey) };
+
+  const remoteUrl = opts.remoteUrl ?? (await getRemoteUrl(repoRoot).catch(() => null)) ?? undefined;
+  if (remoteUrl) {
+    const canonical = canonicalRemoteUrl(remoteUrl);
+    return { repoKey: repoKeyFromIdentity(name, canonical), remoteUrl: canonical };
+  }
+
+  const firstCommit = await firstCommitHash(repoRoot).catch(() => null);
+  if (firstCommit) return { repoKey: repoKeyFromIdentity(name, firstCommit) };
+
+  // Last resort: not cross-machine stable, but unique. randomBytes via crypto.
+  const rand = createHash('sha256').update(`${name}:${process.pid}:${Math.random()}`).digest('hex');
+  return { repoKey: repoKeyFromIdentity(name, rand) };
+};
+
+const firstCommitHash = async (repoRoot: string): Promise<string | null> => {
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', repoRoot, 'rev-list', '--max-parents=0', 'HEAD']);
+    const hash = stdout.trim().split('\n')[0]?.trim();
+    return hash || null;
+  } catch {
+    return null;
+  }
+};

--- a/src/lib/repoScope.ts
+++ b/src/lib/repoScope.ts
@@ -16,7 +16,7 @@ import { readFile } from 'fs/promises';
 import { ensureDir } from 'fs-extra';
 import { getStateDir } from './state.js';
 import { atomicWriteFile } from './files.js';
-import { pathExists } from './paths.js';
+import { pathExists, expandPath } from './paths.js';
 import { getRemoteUrl } from './git.js';
 import { reposRegistrySchema, type ReposRegistry } from '../schemas/repos.schema.js';
 
@@ -72,6 +72,28 @@ export const unbindRepo = async (repoKey: string): Promise<boolean> => {
 export const resolveRepoRoot = async (repoKey: string): Promise<string | null> => {
   const reg = await loadReposRegistry();
   return reg.repos[repoKey]?.root ?? null;
+};
+
+/** Minimal shape needed to resolve a tracked file's live location. */
+export interface ResolvableFile {
+  source: string;
+  scope?: 'home' | 'repo';
+  repoKey?: string;
+  repoRelative?: string;
+}
+
+/**
+ * Resolve a tracked file's LIVE location on THIS machine.
+ *   - home (scope absent/'home'): expandPath(source).
+ *   - repo: join(resolveRepoRoot(repoKey), repoRelative), or `null` when the
+ *     repo is not bound on this machine (caller skips it — never guesses).
+ */
+export const resolveLiveTarget = async (file: ResolvableFile): Promise<string | null> => {
+  if (file.scope !== 'repo') return expandPath(file.source);
+  if (!file.repoKey || !file.repoRelative) return null;
+  const root = await resolveRepoRoot(file.repoKey);
+  if (!root) return null;
+  return join(root, file.repoRelative);
 };
 
 const slugify = (s: string): string =>

--- a/src/lib/stateModel.ts
+++ b/src/lib/stateModel.ts
@@ -14,9 +14,10 @@
  */
 
 import { join } from 'path';
-import { expandPath, pathExists } from './paths.js';
+import { pathExists } from './paths.js';
 import { getFileChecksum } from './files.js';
 import { getAllTrackedFiles } from './manifest.js';
+import { resolveLiveTarget } from './repoScope.js';
 import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
 
 export type FileState =
@@ -25,7 +26,9 @@ export type FileState =
   | 'drift-repo'
   | 'missing-live'
   | 'missing-repo'
-  | 'missing-both';
+  | 'missing-both'
+  // Repo-scoped file whose repo is not bound on this machine (run `tuck repo link`).
+  | 'unknown-repo';
 
 export interface FileStateEntry {
   id: string;
@@ -62,11 +65,25 @@ export const computeFileState = async (
   id: string,
   file: TrackedFileOutput
 ): Promise<FileStateEntry> => {
-  const sourceAbs = expandPath(file.source);
   const repoAbs = join(tuckDir, file.destination);
+  const repoChecksum = (await pathExists(repoAbs)) ? await getFileChecksum(repoAbs) : null;
+
+  // Resolve the LIVE location (home: expandPath; repo: bound root or null).
+  const sourceAbs = await resolveLiveTarget(file);
+  if (sourceAbs === null) {
+    // Repo-scoped file whose repo is not bound on this machine — cannot compare.
+    return {
+      id,
+      source: file.source,
+      destination: file.destination,
+      state: 'unknown-repo',
+      liveChecksum: null,
+      repoChecksum,
+      manifestChecksum: file.checksum,
+    };
+  }
 
   const liveChecksum = (await pathExists(sourceAbs)) ? await getFileChecksum(sourceAbs) : null;
-  const repoChecksum = (await pathExists(repoAbs)) ? await getFileChecksum(repoAbs) : null;
 
   return {
     id,
@@ -96,6 +113,7 @@ export interface StateSummary {
   missingLive: number;
   missingRepo: number;
   missingBoth: number;
+  unknownRepo: number;
 }
 
 export const summarizeStateModel = (entries: FileStateEntry[]): StateSummary => {
@@ -107,6 +125,7 @@ export const summarizeStateModel = (entries: FileStateEntry[]): StateSummary => 
     missingLive: 0,
     missingRepo: 0,
     missingBoth: 0,
+    unknownRepo: 0,
   };
   for (const e of entries) {
     switch (e.state) {
@@ -127,6 +146,9 @@ export const summarizeStateModel = (entries: FileStateEntry[]): StateSummary => 
         break;
       case 'missing-both':
         summary.missingBoth++;
+        break;
+      case 'unknown-repo':
+        summary.unknownRepo++;
         break;
     }
   }

--- a/src/lib/trackPipeline.ts
+++ b/src/lib/trackPipeline.ts
@@ -1,15 +1,19 @@
-import { basename } from 'path';
+import { basename, relative } from 'path';
 import { colors as c, logger, prompts } from '../ui/index.js';
 import {
   collapsePath,
   detectCategory,
   getDestinationPathFromSource,
+  getRepoScopedDestination,
   expandPath,
   isDirectory,
   pathExists,
   sanitizeFilename,
   validateSafeSourcePath,
+  validateSafeRepoSourcePath,
 } from './paths.js';
+import { findGitRoot, deriveRepoKey } from './repoScope.js';
+import { toPosixPath } from './platform.js';
 import { isFileTracked } from './manifest.js';
 import { checkFileSizeThreshold, formatFileSize, getDirectoryFileCount } from './files.js';
 import { shouldExcludeFromBin } from './binary.js';
@@ -74,6 +78,23 @@ export interface PreparedTrackFile {
   isDir: boolean;
   fileCount: number;
   sensitive: boolean;
+  /**
+   * Tracking scope. Absent (or 'home') means a home-scoped file resolved
+   * against $HOME exactly as before. 'repo' means the file lives inside a git
+   * repo whose absolute path differs per machine; it is identified by a stable
+   * (repoKey, repoRelative) pair.
+   */
+  scope?: 'home' | 'repo';
+  /** Stable cross-machine repo identity (repo scope only). */
+  repoKey?: string;
+  /** POSIX path relative to the repo root (repo scope only). */
+  repoRelative?: string;
+  /** Absolute repo root on THIS machine (repo scope only; not committed). */
+  repoRoot?: string;
+  /** Canonicalized remote URL discovered while deriving the key, if any. */
+  remoteUrl?: string;
+  /** Absolute live path to copy FROM (repo scope only). */
+  liveSource?: string;
 }
 
 export interface PreparePathsForTrackingOptions {
@@ -83,6 +104,14 @@ export interface PreparePathsForTrackingOptions {
   allowAlreadyTracked?: boolean;
   secretHandling?: 'interactive' | 'strict';
   forceBypassCommand?: string;
+  /**
+   * Track candidates as REPO-scoped. `true` (or an empty string) means
+   * "auto-detect the enclosing git root from each path"; a string is an
+   * explicit repo root directory.
+   */
+  repo?: string | boolean;
+  /** Explicit repoKey override (advanced; default derives from the remote). */
+  repoKey?: string;
 }
 
 const isPrivateKey = (collapsedPath: string): boolean => {
@@ -216,7 +245,9 @@ const applySecretPolicy = async (
     return files;
   }
 
-  const filePaths = files.map((f) => expandPath(f.source));
+  // Repo-scoped entries carry a stable `<repoKey>:<repoRelative>` source, so we
+  // must scan the live absolute path instead of expanding the identity string.
+  const filePaths = files.map((f) => f.liveSource ?? expandPath(f.source));
   const summary = await scanForSecrets(filePaths, tuckDir);
 
   if (summary.filesWithSecrets === 0) {
@@ -312,13 +343,51 @@ export const preparePathsForTracking = async (
 ): Promise<PreparedTrackFile[]> => {
   const secretHandling = options.secretHandling ?? 'interactive';
   const prepared: PreparedTrackFile[] = [];
+  const isRepoScoped = options.repo !== undefined && options.repo !== false;
 
   for (const candidate of candidates) {
     const expandedPath = expandPath(candidate.path);
-    const collapsedPath = collapsePath(expandedPath);
-    validateSafeSourcePath(collapsedPath);
 
-    if (isPrivateKey(collapsedPath)) {
+    // For repo-scoped tracking the live file may be OUTSIDE $HOME, so we resolve
+    // a stable (repoKey, repoRelative) identity instead of a home-relative path.
+    let repoMeta: {
+      repoKey: string;
+      repoRelative: string;
+      repoRoot: string;
+      remoteUrl?: string;
+    } | null = null;
+
+    if (isRepoScoped) {
+      const explicitRoot =
+        typeof options.repo === 'string' && options.repo.trim() ? options.repo.trim() : undefined;
+      const repoRoot = explicitRoot
+        ? expandPath(explicitRoot)
+        : await findGitRoot(expandedPath);
+      if (!repoRoot) {
+        throw new FileNotFoundError(
+          `${candidate.path} (no enclosing git repository found for --repo)`
+        );
+      }
+
+      const repoRelative = toPosixPath(relative(repoRoot, expandedPath));
+      // Confine the file to the repo root and reject `..`/absolute escapes.
+      validateSafeRepoSourcePath(repoRoot, repoRelative);
+
+      const { repoKey, remoteUrl } = await deriveRepoKey(repoRoot, { repoKey: options.repoKey });
+      repoMeta = { repoKey, repoRelative, repoRoot, remoteUrl };
+    }
+
+    // The label used for already-tracked / ignored / display checks. Repo files
+    // are identified by their stable identity, never a home-relative path.
+    const trackingId = repoMeta
+      ? `${repoMeta.repoKey}:${repoMeta.repoRelative}`
+      : collapsePath(expandedPath);
+
+    if (!repoMeta) {
+      validateSafeSourcePath(trackingId);
+    }
+
+    if (!repoMeta && isPrivateKey(trackingId)) {
       throw new PrivateKeyError(candidate.path);
     }
 
@@ -326,19 +395,19 @@ export const preparePathsForTracking = async (
       throw new FileNotFoundError(candidate.path);
     }
 
-    if (!options.allowAlreadyTracked && (await isFileTracked(tuckDir, collapsedPath))) {
+    if (!options.allowAlreadyTracked && (await isFileTracked(tuckDir, trackingId))) {
       throw new FileAlreadyTrackedError(candidate.path);
     }
 
-    if (await isIgnored(tuckDir, collapsedPath)) {
-      logger.info(`Skipping ${collapsedPath} (in .tuckignore)`);
+    if (!repoMeta && (await isIgnored(tuckDir, trackingId))) {
+      logger.info(`Skipping ${trackingId} (in .tuckignore)`);
       continue;
     }
 
     if (await shouldExcludeFromBin(expandedPath)) {
       const sizeCheck = await checkFileSizeThreshold(expandedPath);
       logger.info(
-        `Skipping binary executable: ${collapsedPath}` +
+        `Skipping binary executable: ${trackingId}` +
           `${sizeCheck.size > 0 ? ` (${formatFileSize(sizeCheck.size)})` : ''}` +
           ' - Add to .tuckignore to customize'
       );
@@ -347,7 +416,7 @@ export const preparePathsForTracking = async (
 
     const sizeCheck = await checkFileSizeThreshold(expandedPath);
     const shouldTrack = await handleFileSizePolicy(
-      collapsedPath,
+      trackingId,
       sizeCheck.size,
       tuckDir,
       secretHandling
@@ -363,15 +432,35 @@ export const preparePathsForTracking = async (
     const nameOverride = customName ? sanitizeFilename(customName) : undefined;
     const filename = nameOverride || sanitizeFilename(expandedPath);
 
+    if (repoMeta) {
+      prepared.push({
+        source: trackingId,
+        destination: getRepoScopedDestination(repoMeta.repoKey, repoMeta.repoRelative),
+        category,
+        filename,
+        nameOverride,
+        isDir,
+        fileCount,
+        sensitive: isSensitiveFile(filename),
+        scope: 'repo',
+        repoKey: repoMeta.repoKey,
+        repoRelative: repoMeta.repoRelative,
+        repoRoot: repoMeta.repoRoot,
+        remoteUrl: repoMeta.remoteUrl,
+        liveSource: expandedPath,
+      });
+      continue;
+    }
+
     prepared.push({
-      source: collapsedPath,
+      source: trackingId,
       destination: getDestinationPathFromSource(tuckDir, category, expandedPath, nameOverride),
       category,
       filename,
       nameOverride,
       isDir,
       fileCount,
-      sensitive: isSensitiveFile(collapsedPath),
+      sensitive: isSensitiveFile(trackingId),
     });
   }
 

--- a/src/lib/writeContext.ts
+++ b/src/lib/writeContext.ts
@@ -22,14 +22,23 @@ interface WriteContext {
 }
 
 let ctx: WriteContext | null = null;
+// Absolute roots of repos bound on THIS machine (from the repo registry). They
+// are allowed write destinations in addition to $HOME when not sandboxed.
+let knownRepoRoots: string[] = [];
 
 export const setWriteContext = (next: WriteContext): void => {
   ctx = { root: resolve(next.root), isSandbox: next.isSandbox };
 };
 
+/** Register the machine's known repo roots (loaded from the repo registry). */
+export const setKnownRepoRoots = (roots: string[]): void => {
+  knownRepoRoots = roots.map((r) => resolve(r));
+};
+
 /** Test-only: clear the context back to the default (real home). */
 export const resetWriteContext = (): void => {
   ctx = null;
+  knownRepoRoots = [];
 };
 
 /** The directory all writes are confined to (real home unless sandboxed). */
@@ -37,20 +46,57 @@ export const getWriteRoot = (): string => (ctx ? ctx.root : homedir());
 
 export const isSandbox = (): boolean => (ctx ? ctx.isSandbox : false);
 
-/** Allowed roots for `validateSafeDestinationPath(dest, allowedRoots())`. */
-export const allowedRoots = (): string[] => [getWriteRoot()];
+/**
+ * Allowed roots for `validateSafeDestinationPath(dest, allowedRoots())`.
+ *   - sandbox: ONLY the sandbox root (repo writes are rebased under it).
+ *   - normal: $HOME plus every bound repo root (so repo-scoped writes to a
+ *     genuine out-of-home checkout are permitted, but only for bound repos).
+ */
+export const allowedRoots = (): string[] => {
+  if (isSandbox()) return [getWriteRoot()];
+  return Array.from(new Set([resolve(homedir()), ...knownRepoRoots]));
+};
+
+/** A repo-scoped write target descriptor. */
+export interface RepoWriteTarget {
+  repoKey: string;
+  repoRelative: string;
+  repoRoot: string;
+}
 
 /**
  * Resolve a write destination, confining it within the active root.
+ *
+ * Repo-scoped writes (when `repo` is given):
+ *   - sandbox: rebased by STABLE IDENTITY to `<root>/repos/<repoKey>/<rel>` — the
+ *     real (possibly out-of-home) repoRoot is NEVER used to place the file, so a
+ *     hostile repoRoot can't escape the sandbox.
+ *   - normal: the genuine `<repoRoot>/<rel>`, confined to `repoRoot`.
+ *
+ * Home-scoped writes (no `repo`):
  *   - `~/x` and `$HOME/x` map to `<root>/x`.
  *   - an absolute path UNDER the real home is re-based into `<root>` when
  *     sandboxed (handles call sites that pass an already-expanded path).
  *   - relative paths resolve against `<root>`.
- * Always validated to be inside the root; throws on any escape.
+ * Always validated to be inside the confining root; throws on any escape.
  */
-export const resolveWriteTarget = (source: string): string => {
+export const resolveWriteTarget = (source: string, repo?: RepoWriteTarget): string => {
   const root = resolve(getWriteRoot());
   const home = resolve(homedir());
+
+  if (repo) {
+    const relNorm = repo.repoRelative.replace(/\\/g, '/');
+    if (isSandbox()) {
+      const keySlug = repo.repoKey.replace(/[^a-zA-Z0-9._-]/g, '_');
+      const target = resolve(root, 'repos', keySlug, relNorm);
+      validatePathWithinRoot(target, root, 'repo write target (sandbox)');
+      return target;
+    }
+    const repoRootAbs = resolve(repo.repoRoot);
+    const target = resolve(repoRootAbs, relNorm);
+    validatePathWithinRoot(target, repoRootAbs, 'repo write target');
+    return target;
+  }
 
   let target: string;
   if (source === '~' || source.startsWith('~/') || source.startsWith('~\\')) {

--- a/src/schemas/manifest.schema.ts
+++ b/src/schemas/manifest.schema.ts
@@ -2,24 +2,61 @@ import { z } from 'zod';
 
 export const fileStrategySchema = z.enum(['copy', 'symlink']);
 
-export const trackedFileSchema = z.object({
-  source: z.string(),
-  destination: z.string(),
-  category: z.string(),
-  strategy: fileStrategySchema,
-  encrypted: z.boolean().default(false),
-  template: z.boolean().default(false),
-  permissions: z.string().optional(),
-  added: z.string(),
-  modified: z.string(),
-  checksum: z.string(),
-  /**
-   * Logical grouping above category — files default to the implicit "default"
-   * bundle so legacy manifests load unchanged. Bundles let callers scope
-   * `tuck apply --bundle <name>` and similar operations.
-   */
-  bundle: z.string().default('default'),
-});
+export const trackedFileSchema = z
+  .object({
+    source: z.string(),
+    destination: z.string(),
+    category: z.string(),
+    strategy: fileStrategySchema,
+    encrypted: z.boolean().default(false),
+    template: z.boolean().default(false),
+    permissions: z.string().optional(),
+    added: z.string(),
+    modified: z.string(),
+    checksum: z.string(),
+    /**
+     * Logical grouping above category — files default to the implicit "default"
+     * bundle so legacy manifests load unchanged. Bundles let callers scope
+     * `tuck apply --bundle <name>` and similar operations.
+     */
+    bundle: z.string().default('default'),
+    /**
+     * Tracking scope. ABSENT (undefined) means a legacy/home-scoped file,
+     * resolved against `$HOME` and validated exactly as before — so existing
+     * manifests parse byte-identical (these fields are `.optional()`, never
+     * `.default()`). `'repo'` means the file lives inside a git repo whose
+     * absolute path differs per machine; it is identified by a stable, machine-
+     * INDEPENDENT (repoKey, repoRelative) pair and resolved via the machine-
+     * local repo registry. The manifest never stores an absolute repo path.
+     */
+    scope: z.enum(['home', 'repo']).optional(),
+    /** Stable cross-machine repo identity (never an absolute path). */
+    repoKey: z.string().optional(),
+    /** POSIX path of the file relative to the repo root. */
+    repoRelative: z.string().optional(),
+  })
+  .superRefine((file, ctx) => {
+    if (file.scope === 'repo') {
+      if (!file.repoKey) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['repoKey'], message: 'repoKey is required for repo-scoped files' });
+      }
+      if (!file.repoRelative) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['repoRelative'], message: 'repoRelative is required for repo-scoped files' });
+      } else {
+        const norm = file.repoRelative.replace(/\\/g, '/');
+        const unsafe =
+          norm.startsWith('/') ||
+          /^[A-Za-z]:[\\/]/.test(file.repoRelative) ||
+          norm.split('/').includes('..');
+        if (unsafe) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['repoRelative'], message: `Unsafe repoRelative path: ${file.repoRelative}` });
+        }
+      }
+    } else if (file.repoKey !== undefined || file.repoRelative !== undefined) {
+      // Home-scoped (or scope absent) files must not carry repo fields.
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['repoKey'], message: 'repoKey/repoRelative are only valid on repo-scoped files' });
+    }
+  });
 
 export const bundleMetadataSchema = z.object({
   description: z.string().optional(),

--- a/src/schemas/repos.schema.ts
+++ b/src/schemas/repos.schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/**
+ * Machine-local registry of repo bindings (repos.json under the state dir).
+ *
+ * This is per-machine and NEVER committed — it maps a stable, cross-machine
+ * `repoKey` to that machine's absolute repo root, so a repo-scoped tracked file
+ * (whose manifest entry holds only repoKey + repoRelative) can be resolved to a
+ * concrete path that differs from machine to machine. It is validated, never
+ * `as`-cast, since it is read off disk.
+ */
+export const repoBindingSchema = z.object({
+  /** Absolute path to the repo root ON THIS MACHINE. */
+  root: z.string(),
+  /** Canonical remote URL the key was derived from (for diagnostics). */
+  remoteUrl: z.string().optional(),
+  boundAt: z.string(),
+});
+
+export const reposRegistrySchema = z.object({
+  version: z.literal('1'),
+  repos: z.record(repoBindingSchema).default({}),
+});
+
+export type RepoBinding = z.infer<typeof repoBindingSchema>;
+export type ReposRegistry = z.infer<typeof reposRegistrySchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,14 @@ export interface AddOptions extends CommonOptions {
   template?: boolean;
   /** Bundle to assign the tracked file to. Defaults to "default". */
   bundle?: string;
+  /**
+   * Track the file as REPO-scoped: it lives inside a git repo (optionally at
+   * the given dir; auto-detected from the path otherwise) whose absolute path
+   * differs per machine. Stored by stable (repoKey, repoRelative).
+   */
+  repo?: string | boolean;
+  /** Explicit repoKey override (advanced; default derives from the remote). */
+  repoKey?: string;
 }
 
 export interface RemoveOptions extends CommonOptions {
@@ -158,6 +166,8 @@ export interface RestoreOptions extends CommonOptions {
   noHooks?: boolean;
   trustHooks?: boolean;
   noSecrets?: boolean;
+  /** Bind an as-yet-unknown repo to this root before restoring repo-scoped files. */
+  repoRoot?: string;
 }
 
 export interface StatusOptions extends CommonOptions {
@@ -184,6 +194,8 @@ export interface ApplyOptions extends CommonOptions {
   noSecrets?: boolean;
   /** Scope apply to a single bundle. Defaults to all bundles when unset. */
   bundle?: string;
+  /** Bind an as-yet-unknown repo to this root before applying repo-scoped files. */
+  repoRoot?: string;
 }
 
 export interface DoctorOptions extends CommonOptions {

--- a/tests/commands/add-repo.test.ts
+++ b/tests/commands/add-repo.test.ts
@@ -1,0 +1,189 @@
+/**
+ * tuck add --repo (Step 8) integration tests.
+ *
+ * `tuck add --repo [dir]` tracks a file as REPO-scoped: it lives inside a git
+ * repo whose absolute path differs per machine. The committed manifest entry
+ * carries scope:'repo' + stable (repoKey, repoRelative) and NO absolute path;
+ * the live copy is staged under files/repos/<key>/..., and the repo is bound in
+ * the machine-local registry so it can be resolved later.
+ *
+ * These run against the global memfs sandbox (os.homedir() -> /test-home). The
+ * "git repo" lives OUTSIDE that home (under /work) to prove repo-scoped tracking
+ * is not home-confined. An explicit --repo-key is used so the derived key is
+ * deterministic (the remote/first-commit derivation shells out to real git,
+ * which the virtual repo has no answer for).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join, posix } from 'path';
+import { TEST_HOME, TEST_TUCK_DIR } from '../utils/testHelpers.js';
+import { initTestTuck } from '../utils/testHelpers.js';
+import { addFilesFromPaths } from '../../src/commands/add.js';
+import { loadManifest, clearManifestCache } from '../../src/lib/manifest.js';
+import { resolveRepoRoot, getReposRegistryPath } from '../../src/lib/repoScope.js';
+import { getRepoScopedDestination } from '../../src/lib/paths.js';
+
+// Real git in this sandbox cannot inspect the virtual repo; the symlink/copy
+// path and checksums all run against memfs already via the global setup.
+
+const REPO_ROOT = '/work/myrepo';
+
+const makeRepo = (): void => {
+  // A git repo OUTSIDE the (mocked) home directory.
+  vol.mkdirSync(join(REPO_ROOT, '.git'), { recursive: true });
+  vol.writeFileSync(join(REPO_ROOT, '.git', 'HEAD'), 'ref: refs/heads/main');
+  vol.mkdirSync(join(REPO_ROOT, 'config'), { recursive: true });
+  vol.writeFileSync(join(REPO_ROOT, 'config', 'settings.toml'), 'theme = "dark"\n');
+};
+
+describe('tuck add --repo (repo-scoped tracking)', () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+    clearManifestCache();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  it('writes a repo-scoped manifest entry with correct repoKey/repoRelative', async () => {
+    await initTestTuck();
+    makeRepo();
+
+    const count = await addFilesFromPaths([join(REPO_ROOT, 'config', 'settings.toml')], {
+      repo: REPO_ROOT,
+      repoKey: 'myrepo',
+      force: true,
+    });
+
+    expect(count).toBe(1);
+
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    const entries = Object.values(manifest.files);
+    expect(entries).toHaveLength(1);
+
+    const entry = entries[0];
+    expect(entry.scope).toBe('repo');
+    expect(entry.repoKey).toBe('myrepo');
+    expect(entry.repoRelative).toBe('config/settings.toml');
+    expect(entry.strategy).toBe('copy');
+    // source is the stable identity, never an absolute path.
+    expect(entry.source).toBe('myrepo:config/settings.toml');
+    expect(entry.source).not.toContain(REPO_ROOT);
+  });
+
+  it('stages the live file under files/repos/<key>/ in the tuck repo', async () => {
+    await initTestTuck();
+    makeRepo();
+
+    await addFilesFromPaths([join(REPO_ROOT, 'config', 'settings.toml')], {
+      repo: REPO_ROOT,
+      repoKey: 'myrepo',
+      force: true,
+    });
+
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    const entry = Object.values(manifest.files)[0];
+
+    const expectedDest = getRepoScopedDestination('myrepo', 'config/settings.toml');
+    expect(entry.destination).toBe(expectedDest);
+    expect(entry.destination.startsWith('files/repos/')).toBe(true);
+
+    // The file content was actually copied into the tuck repo.
+    const copiedPath = join(TEST_TUCK_DIR, entry.destination);
+    expect(vol.existsSync(copiedPath)).toBe(true);
+    expect(vol.readFileSync(copiedPath, 'utf-8')).toBe('theme = "dark"\n');
+  });
+
+  it('binds the repoKey to the repo root in the machine-local registry', async () => {
+    await initTestTuck();
+    makeRepo();
+
+    await addFilesFromPaths([join(REPO_ROOT, 'config', 'settings.toml')], {
+      repo: REPO_ROOT,
+      repoKey: 'myrepo',
+      force: true,
+    });
+
+    // The off-repo registry now resolves the key back to the live root.
+    expect(await resolveRepoRoot('myrepo')).toBe(REPO_ROOT);
+    // ...and it lives off-repo, not inside ~/.tuck.
+    expect(getReposRegistryPath()).not.toContain('/.tuck/');
+    expect(vol.existsSync(getReposRegistryPath())).toBe(true);
+  });
+
+  it('auto-detects the enclosing git root when --repo is given without a dir', async () => {
+    await initTestTuck();
+    makeRepo();
+
+    // Pass the path to a file nested under the repo; --repo with no dir means
+    // "treat as repo-scoped, find the enclosing git root from the path".
+    const count = await addFilesFromPaths([join(REPO_ROOT, 'config', 'settings.toml')], {
+      repo: true,
+      repoKey: 'autorepo',
+      force: true,
+    });
+
+    expect(count).toBe(1);
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    const entry = Object.values(manifest.files)[0];
+    expect(entry.scope).toBe('repo');
+    expect(entry.repoKey).toBe('autorepo');
+    expect(entry.repoRelative).toBe('config/settings.toml');
+    expect(await resolveRepoRoot('autorepo')).toBe(REPO_ROOT);
+  });
+
+  it('rejects --symlink combined with --repo (repo scope is copy-only)', async () => {
+    await initTestTuck();
+    makeRepo();
+
+    await expect(
+      addFilesFromPaths([join(REPO_ROOT, 'config', 'settings.toml')], {
+        repo: REPO_ROOT,
+        repoKey: 'myrepo',
+        symlink: true,
+        force: true,
+      })
+    ).rejects.toThrow(/--symlink cannot be combined with --repo/);
+
+    // Nothing was tracked or bound.
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    expect(Object.keys(manifest.files)).toHaveLength(0);
+    expect(await resolveRepoRoot('myrepo')).toBeNull();
+  });
+
+  it('leaves home-scoped add unchanged (no scope/repo fields) when --repo is absent', async () => {
+    await initTestTuck();
+    vol.writeFileSync(join(TEST_HOME, '.zshrc'), 'export PATH=$PATH\n');
+
+    const count = await addFilesFromPaths(['~/.zshrc'], { force: true });
+    expect(count).toBe(1);
+
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    const entry = Object.values(manifest.files)[0];
+    expect(entry.scope).toBeUndefined();
+    expect(entry.repoKey).toBeUndefined();
+    expect(entry.repoRelative).toBeUndefined();
+    expect(entry.source).toBe('~/.zshrc');
+    // Home dest is under files/<category>/, never files/repos/.
+    expect(entry.destination.startsWith('files/repos/')).toBe(false);
+  });
+
+  it('persists a manifest that re-parses against the schema (repo superRefine)', async () => {
+    await initTestTuck();
+    makeRepo();
+
+    await addFilesFromPaths([join(REPO_ROOT, 'config', 'settings.toml')], {
+      repo: REPO_ROOT,
+      repoKey: 'myrepo',
+      force: true,
+    });
+
+    // loadManifest re-validates with the zod schema; a missing repoKey or an
+    // unsafe repoRelative would throw here.
+    const raw = vol.readFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), 'utf-8') as string;
+    const parsed = JSON.parse(raw);
+    const stored = Object.values(parsed.files)[0] as Record<string, unknown>;
+    expect(stored.scope).toBe('repo');
+    expect(stored.repoRelative).toBe(posix.normalize('config/settings.toml'));
+    expect(stored.repoKey).toBe('myrepo');
+  });
+});

--- a/tests/commands/apply.test.ts
+++ b/tests/commands/apply.test.ts
@@ -385,6 +385,137 @@ describe('apply command behavior', () => {
     expect(env.data.dryRun).toBeUndefined();
   });
 
+  it('writes a BOUND repo-scoped file to the local checkout, not into $HOME', async () => {
+    // Bind the repoKey to an out-of-home checkout on THIS machine before applying.
+    const { bindRepo } = await import('../../src/lib/repoScope.js');
+    const { getRepoScopedDestination } = await import('../../src/lib/paths.js');
+    const repoKey = 'myrepo-deadbeef';
+    const repoRoot = '/work/myrepo';
+    const repoRelative = 'config/app.toml';
+    await bindRepo(repoKey, repoRoot);
+
+    const dest = getRepoScopedDestination(repoKey, repoRelative);
+
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          repofile: createMockTrackedFile({
+            source: `${repoKey}:${repoRelative}`,
+            destination: dest,
+            scope: 'repo',
+            repoKey,
+            repoRelative,
+          }),
+        },
+      });
+
+      vol.mkdirSync(join(dir, 'files', 'repos', repoKey, 'config'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, dest), 'from-repo = true');
+    };
+
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true });
+
+    // The file landed inside the bound checkout, NOT under $HOME.
+    expect(vol.readFileSync(join(repoRoot, repoRelative), 'utf-8')).toBe('from-repo = true');
+    expect(vol.existsSync(join(TEST_HOME, repoKey + ':' + repoRelative))).toBe(false);
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Applied 1 files');
+  });
+
+  it('skips an UNBOUND repo-scoped file and lists it in the JSON envelope', async () => {
+    // No bindRepo() call → the repo is unbound on this machine. resolveLiveTarget
+    // returns null, so the file must be SKIPPED (never guessed / written) and
+    // surfaced in the envelope's `skipped` list.
+    const { getRepoScopedDestination } = await import('../../src/lib/paths.js');
+    const repoKey = 'otherrepo-cafef00d';
+    const repoRelative = 'settings/keys.json';
+    const dest = getRepoScopedDestination(repoKey, repoRelative);
+
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          repofile: createMockTrackedFile({
+            source: `${repoKey}:${repoRelative}`,
+            destination: dest,
+            scope: 'repo',
+            repoKey,
+            repoRelative,
+          }),
+        },
+      });
+
+      vol.mkdirSync(join(dir, 'files', 'repos', repoKey, 'settings'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, dest), '{"k":1}');
+    };
+
+    const { __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+    __resetJsonEmitState();
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { json: true, yes: true } as never);
+
+    writeSpy.mockRestore();
+    const env = JSON.parse(writes.join('').trim());
+
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck apply');
+    // Nothing applied; the unbound repo file is reported as skipped.
+    expect(env.data.applied).toBe(0);
+    expect(Array.isArray(env.data.skipped)).toBe(true);
+    expect(env.data.skipped).toContain(`${repoKey}:${repoRelative}`);
+    expect(loggerSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it('binds an unbound repo via --repo-root then writes the repo file there', async () => {
+    // On a fresh machine the repo is unbound; --repo-root binds the single repoKey
+    // present so the apply can place the file in the freshly-linked checkout.
+    const { getRepoScopedDestination } = await import('../../src/lib/paths.js');
+    const repoKey = 'freshrepo-12345678';
+    const repoRoot = '/freshly/cloned/repo';
+    const repoRelative = 'config/init.lua';
+    const dest = getRepoScopedDestination(repoKey, repoRelative);
+
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          repofile: createMockTrackedFile({
+            source: `${repoKey}:${repoRelative}`,
+            destination: dest,
+            scope: 'repo',
+            repoKey,
+            repoRelative,
+          }),
+        },
+      });
+
+      vol.mkdirSync(join(dir, 'files', 'repos', repoKey, 'config'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, dest), '-- lua config');
+    };
+
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true, repoRoot } as never);
+
+    expect(vol.readFileSync(join(repoRoot, repoRelative), 'utf-8')).toBe('-- lua config');
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Applied 1 files');
+  });
+
   it('supports explicit GitLab-prefixed apply sources', async () => {
     cloneSetup = (dir: string) => {
       const manifest = createMockManifest({

--- a/tests/commands/repo.test.ts
+++ b/tests/commands/repo.test.ts
@@ -1,0 +1,198 @@
+/**
+ * `tuck repo` command tests.
+ *
+ * `tuck repo` manages the MACHINE-LOCAL repoKey -> root bindings (repos.json,
+ * off-repo under the state dir). These are the bindings that let a committed,
+ * machine-independent repo-scoped manifest entry resolve to a concrete absolute
+ * path on THIS machine.
+ *
+ *   repo link <repoKey> <path>  — verify path exists + is a git repo, then bind
+ *   repo list                   — show all bindings
+ *   repo unlink <repoKey>       — remove a binding
+ *
+ * link MUST refuse a non-existent path and a path that is not inside a git repo
+ * (never bind a key to a phantom or non-repo root).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+
+// Silence UI noise (banners/logs/colors). The command's behaviour is observed
+// via the registry on disk and via the --json envelope on stdout.
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    note: vi.fn(),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+  },
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    dim: vi.fn(),
+    error: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: {
+    cyan: (x: string) => x,
+    dim: (x: string) => x,
+    bold: (x: string) => x,
+    green: (x: string) => x,
+    yellow: (x: string) => x,
+    red: (x: string) => x,
+  },
+}));
+
+import { resolveRepoRoot, loadReposRegistry } from '../../src/lib/repoScope.js';
+
+/** Stage a directory in memfs that looks like a git repo root (has .git). */
+const stageGitRepo = (root: string): void => {
+  vol.mkdirSync(root, { recursive: true });
+  vol.mkdirSync(`${root}/.git`, { recursive: true });
+  vol.writeFileSync(`${root}/.git/HEAD`, 'ref: refs/heads/main\n');
+};
+
+/** Stage a plain directory that is NOT a git repo. */
+const stagePlainDir = (root: string): void => {
+  vol.mkdirSync(root, { recursive: true });
+};
+
+const runRepo = async (args: string[]): Promise<void> => {
+  const { repoCommand } = await import('../../src/commands/repo.js');
+  await repoCommand.parseAsync(['node', 'tuck', ...args]);
+};
+
+describe('tuck repo', () => {
+  let writes: string[];
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vol.reset();
+    vol.mkdirSync('/test-home', { recursive: true });
+    const { setJsonMode, __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+    __resetJsonEmitState();
+    writes = [];
+    writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    writeSpy.mockRestore();
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+  });
+
+  const jsonEnvelope = (): { ok: boolean; command: string; data?: any; error?: any } => {
+    const jsonLine = writes.find((w) => w.trim().startsWith('{'));
+    return JSON.parse((jsonLine ?? writes.join('')).trim());
+  };
+
+  describe('link', () => {
+    it('binds a repoKey to a git repo root and resolveRepoRoot returns it', async () => {
+      stageGitRepo('/srv/proj');
+
+      await runRepo(['link', 'proj-abcd1234', '/srv/proj', '--json']);
+
+      expect(await resolveRepoRoot('proj-abcd1234')).toBe('/srv/proj');
+
+      const env = jsonEnvelope();
+      expect(env.ok).toBe(true);
+      expect(env.command).toBe('tuck repo link');
+      expect(env.data.repoKey).toBe('proj-abcd1234');
+      expect(env.data.root).toBe('/srv/proj');
+    });
+
+    it('binds when given a subdirectory of a git repo (findGitRoot walks up)', async () => {
+      stageGitRepo('/srv/proj');
+      vol.mkdirSync('/srv/proj/src/deep', { recursive: true });
+
+      await runRepo(['link', 'proj-deep', '/srv/proj/src/deep']);
+
+      // It binds to the discovered repo ROOT, not the subdirectory.
+      expect(await resolveRepoRoot('proj-deep')).toBe('/srv/proj');
+    });
+
+    it('rejects a non-existent path and binds nothing', async () => {
+      await expect(runRepo(['link', 'ghost', '/does/not/exist', '--json'])).rejects.toThrow();
+
+      expect(await resolveRepoRoot('ghost')).toBeNull();
+    });
+
+    it('rejects a path that is not inside a git repo and binds nothing', async () => {
+      stagePlainDir('/srv/plain');
+
+      await expect(runRepo(['link', 'plain', '/srv/plain', '--json'])).rejects.toThrow();
+
+      expect(await resolveRepoRoot('plain')).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('lists all bindings in the --json envelope', async () => {
+      stageGitRepo('/srv/a');
+      stageGitRepo('/srv/b');
+      await runRepo(['link', 'key-a', '/srv/a']);
+      await runRepo(['link', 'key-b', '/srv/b']);
+
+      writes = [];
+      const { __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+      __resetJsonEmitState();
+
+      await runRepo(['list', '--json']);
+
+      const env = jsonEnvelope();
+      expect(env.ok).toBe(true);
+      expect(env.command).toBe('tuck repo list');
+      const keys = env.data.repos.map((r: { repoKey: string }) => r.repoKey).sort();
+      expect(keys).toEqual(['key-a', 'key-b']);
+      const a = env.data.repos.find((r: { repoKey: string }) => r.repoKey === 'key-a');
+      expect(a.root).toBe('/srv/a');
+    });
+
+    it('returns an empty repos list when nothing is bound', async () => {
+      await runRepo(['list', '--json']);
+      const env = jsonEnvelope();
+      expect(env.ok).toBe(true);
+      expect(env.data.repos).toEqual([]);
+    });
+  });
+
+  describe('unlink', () => {
+    it('removes a binding so resolveRepoRoot returns null', async () => {
+      stageGitRepo('/srv/proj');
+      await runRepo(['link', 'rm-me', '/srv/proj']);
+      expect(await resolveRepoRoot('rm-me')).toBe('/srv/proj');
+
+      writes = [];
+      const { __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+      __resetJsonEmitState();
+
+      await runRepo(['unlink', 'rm-me', '--json']);
+
+      expect(await resolveRepoRoot('rm-me')).toBeNull();
+      const reg = await loadReposRegistry();
+      expect('rm-me' in reg.repos).toBe(false);
+
+      const env = jsonEnvelope();
+      expect(env.ok).toBe(true);
+      expect(env.command).toBe('tuck repo unlink');
+      expect(env.data.repoKey).toBe('rm-me');
+      expect(env.data.removed).toBe(true);
+    });
+
+    it('reports removed:false for an unknown key (no throw)', async () => {
+      await runRepo(['unlink', 'never-bound', '--json']);
+      const env = jsonEnvelope();
+      expect(env.ok).toBe(true);
+      expect(env.data.removed).toBe(false);
+    });
+  });
+});

--- a/tests/commands/restore-repo.test.ts
+++ b/tests/commands/restore-repo.test.ts
@@ -1,0 +1,357 @@
+/**
+ * repo-aware restore unit tests (Step 9).
+ *
+ * A repo-scoped tracked file (scope:'repo') is identified by a stable
+ * (repoKey, repoRelative) pair, NOT an absolute path. At restore time:
+ *   - if the repoKey is BOUND on this machine, the live target is the bound
+ *     root joined with repoRelative — restoring writes THERE (not under $HOME).
+ *   - if the repoKey is UNBOUND, the file is SKIPPED (and surfaced as skipped),
+ *     UNLESS --repo-root <dir> is given, in which case the key is bound first.
+ *   - under --root (sandbox), a repo write rebases to <root>/repos/<key>/<rel>.
+ *   - home-scoped restore is unchanged.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'path';
+
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+const getTrackedFileBySourceMock = vi.fn();
+const loadConfigMock = vi.fn();
+const copyFileOrDirMock = vi.fn();
+const createSymlinkMock = vi.fn();
+const createBackupMock = vi.fn();
+const runPreRestoreHookMock = vi.fn();
+const runPostRestoreHookMock = vi.fn();
+const restoreSecretsMock = vi.fn();
+const getSecretCountMock = vi.fn();
+const pathExistsMock = vi.fn();
+const validateSafeSourcePathMock = vi.fn();
+const validateSafeManifestDestinationMock = vi.fn();
+const validatePathWithinRootMock = vi.fn();
+const validateSafeRepoSourcePathMock = vi.fn();
+
+const resolveLiveTargetMock = vi.fn();
+const resolveRepoRootMock = vi.fn();
+const bindRepoMock = vi.fn();
+const loadReposRegistryMock = vi.fn();
+
+const resolveWriteTargetMock = vi.fn();
+const setKnownRepoRootsMock = vi.fn();
+
+const loggerWarningMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    multiselect: vi.fn(),
+    select: vi.fn(),
+    confirm: vi.fn(),
+    cancel: vi.fn(),
+    note: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+  logger: {
+    warning: loggerWarningMock,
+    info: vi.fn(),
+    success: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: vi.fn(),
+  },
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../src/ui/theme.js', () => ({
+  colors: {
+    yellow: (x: string) => x,
+    dim: (x: string) => x,
+  },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  pathExists: pathExistsMock,
+  collapsePath: vi.fn((p: string) => p),
+  validateSafeSourcePath: validateSafeSourcePathMock,
+  validateSafeManifestDestination: validateSafeManifestDestinationMock,
+  validatePathWithinRoot: validatePathWithinRootMock,
+  validateSafeRepoSourcePath: validateSafeRepoSourcePathMock,
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  getAllTrackedFiles: getAllTrackedFilesMock,
+  getTrackedFileBySource: getTrackedFileBySourceMock,
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../src/lib/files.js', () => ({
+  copyFileOrDir: copyFileOrDirMock,
+  createSymlink: createSymlinkMock,
+}));
+
+vi.mock('../../src/lib/backup.js', () => ({
+  createBackup: createBackupMock,
+}));
+
+vi.mock('../../src/lib/hooks.js', () => ({
+  runPreRestoreHook: runPreRestoreHookMock,
+  runPostRestoreHook: runPostRestoreHookMock,
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  restoreFiles: restoreSecretsMock,
+  getSecretCount: getSecretCountMock,
+}));
+
+vi.mock('../../src/lib/repoScope.js', () => ({
+  resolveLiveTarget: resolveLiveTargetMock,
+  resolveRepoRoot: resolveRepoRootMock,
+  bindRepo: bindRepoMock,
+  loadReposRegistry: loadReposRegistryMock,
+}));
+
+vi.mock('../../src/lib/writeContext.js', () => ({
+  resolveWriteTarget: resolveWriteTargetMock,
+  setKnownRepoRoots: setKnownRepoRootsMock,
+}));
+
+describe('repo-aware restore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    getAllTrackedFilesMock.mockResolvedValue({});
+    getTrackedFileBySourceMock.mockResolvedValue(null);
+    loadConfigMock.mockResolvedValue({
+      files: { strategy: 'copy', backupOnRestore: false },
+    });
+    copyFileOrDirMock.mockResolvedValue(undefined);
+    createSymlinkMock.mockResolvedValue(undefined);
+    createBackupMock.mockResolvedValue(undefined);
+    runPreRestoreHookMock.mockResolvedValue(undefined);
+    runPostRestoreHookMock.mockResolvedValue(undefined);
+    getSecretCountMock.mockResolvedValue(0);
+    restoreSecretsMock.mockResolvedValue({ totalRestored: 0, allUnresolved: [] });
+    pathExistsMock.mockResolvedValue(true);
+    validateSafeSourcePathMock.mockImplementation(() => {});
+    validateSafeManifestDestinationMock.mockImplementation(() => {});
+    validatePathWithinRootMock.mockImplementation(() => {});
+    validateSafeRepoSourcePathMock.mockImplementation(() => {});
+
+    // Default write-target behavior: home maps under /test-home; repo writes
+    // compose to <repoRoot>/<rel> (normal mode) — mirrors the real module.
+    resolveWriteTargetMock.mockImplementation(
+      (
+        source: string,
+        repo?: { repoKey: string; repoRelative: string; repoRoot: string }
+      ) => {
+        if (repo) return join(repo.repoRoot, repo.repoRelative);
+        return source.replace(/^~\//, '/test-home/');
+      }
+    );
+    setKnownRepoRootsMock.mockImplementation(() => {});
+
+    resolveRepoRootMock.mockResolvedValue(null);
+    bindRepoMock.mockResolvedValue(undefined);
+    loadReposRegistryMock.mockResolvedValue({ version: '1', repos: {} });
+
+    // Default: repo files are unbound (null); home files expand under /test-home.
+    resolveLiveTargetMock.mockImplementation(async (file: { scope?: string; source: string }) => {
+      if (file.scope === 'repo') return null;
+      return file.source.replace(/^~\//, '/test-home/');
+    });
+  });
+
+  it('restores a bound repo file to its bound root (not under $HOME)', async () => {
+    const repoRoot = '/Users/somebody/work/myrepo';
+    getAllTrackedFilesMock.mockResolvedValue({
+      cfg: {
+        source: 'myrepo-abc123:.config/app.toml',
+        destination: 'files/repos/myrepo-abc123/.config/app.toml',
+        category: 'misc',
+        scope: 'repo',
+        repoKey: 'myrepo-abc123',
+        repoRelative: '.config/app.toml',
+      },
+    });
+    // Key is bound to a concrete (out-of-home) root.
+    resolveLiveTargetMock.mockResolvedValue(join(repoRoot, '.config/app.toml'));
+    resolveRepoRootMock.mockResolvedValue(repoRoot);
+
+    const { runRestore } = await import('../../src/commands/restore.js');
+    await runRestore({ all: true, noHooks: true, noSecrets: true });
+
+    // It must write to the bound repo root, NOT a home path.
+    expect(copyFileOrDirMock).toHaveBeenCalledTimes(1);
+    const dest = copyFileOrDirMock.mock.calls[0][1] as string;
+    expect(dest).toBe(join(repoRoot, '.config/app.toml'));
+    expect(dest.startsWith('/test-home/')).toBe(false);
+
+    // The repo write must compose through resolveWriteTarget with the repo descriptor.
+    expect(resolveWriteTargetMock).toHaveBeenCalledWith(
+      'myrepo-abc123:.config/app.toml',
+      expect.objectContaining({
+        repoKey: 'myrepo-abc123',
+        repoRelative: '.config/app.toml',
+        repoRoot,
+      })
+    );
+    // Repo files are validated with the repo-scoped validator, not the home one.
+    expect(validateSafeRepoSourcePathMock).toHaveBeenCalledWith(repoRoot, '.config/app.toml');
+  });
+
+  it('skips an unbound repo file and reports it in the JSON envelope', async () => {
+    getAllTrackedFilesMock.mockResolvedValue({
+      cfg: {
+        source: 'ghost-deadbeef:.config/app.toml',
+        destination: 'files/repos/ghost-deadbeef/.config/app.toml',
+        category: 'misc',
+        scope: 'repo',
+        repoKey: 'ghost-deadbeef',
+        repoRelative: '.config/app.toml',
+      },
+    });
+    // Unbound: live target resolves to null.
+    resolveLiveTargetMock.mockResolvedValue(null);
+    resolveRepoRootMock.mockResolvedValue(null);
+
+    const { __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+    __resetJsonEmitState();
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    const { runRestoreCommand } = await import('../../src/commands/restore.js');
+    await runRestoreCommand([], { all: true, json: true, yes: true, noHooks: true, noSecrets: true });
+
+    writeSpy.mockRestore();
+
+    // Nothing was written to disk for the unbound repo file.
+    expect(copyFileOrDirMock).not.toHaveBeenCalled();
+    expect(bindRepoMock).not.toHaveBeenCalled();
+
+    const env = JSON.parse(writes.join('').trim());
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck restore');
+    expect(env.data.restored).toBe(0);
+    // The skipped repo file must be surfaced.
+    expect(env.data.skipped).toContain('ghost-deadbeef:.config/app.toml');
+    // The user should have been warned.
+    expect(loggerWarningMock).toHaveBeenCalled();
+  });
+
+  it('binds an unbound repo to --repo-root and restores there', async () => {
+    const repoRoot = '/tmp/fresh-checkout';
+    getAllTrackedFilesMock.mockResolvedValue({
+      cfg: {
+        source: 'fresh-cafe:.config/app.toml',
+        destination: 'files/repos/fresh-cafe/.config/app.toml',
+        category: 'misc',
+        scope: 'repo',
+        repoKey: 'fresh-cafe',
+        repoRelative: '.config/app.toml',
+      },
+    });
+    // existsAtTarget probe (prepareFilesToRestore) — unbound for now.
+    resolveLiveTargetMock.mockResolvedValue(null);
+    // restoreFilesInternal: first resolveRepoRoot is unbound (null); after
+    // bindRepo the second resolveRepoRoot returns the freshly-bound root.
+    resolveRepoRootMock.mockResolvedValueOnce(null).mockResolvedValue(repoRoot);
+
+    const { runRestore } = await import('../../src/commands/restore.js');
+    await runRestore({
+      all: true,
+      noHooks: true,
+      noSecrets: true,
+      repoRoot,
+    });
+
+    // The unbound key was bound to --repo-root before resolving.
+    expect(bindRepoMock).toHaveBeenCalledWith('fresh-cafe', repoRoot);
+
+    // It then wrote into the freshly-bound root.
+    expect(copyFileOrDirMock).toHaveBeenCalledTimes(1);
+    const dest = copyFileOrDirMock.mock.calls[0][1] as string;
+    expect(dest).toBe(join(repoRoot, '.config/app.toml'));
+
+    // copyFileOrDir validates against allowedRoots(); restore must register the
+    // new repo root via setKnownRepoRoots so an out-of-home dest is accepted.
+    expect(setKnownRepoRootsMock).toHaveBeenCalled();
+    const registered = setKnownRepoRootsMock.mock.calls.flatMap((c) => c[0] as string[]);
+    expect(registered).toContain(repoRoot);
+  });
+
+  it('rebases a repo write under --root (sandbox) to <root>/repos/<key>/<rel>', async () => {
+    const sandboxRoot = '/tmp/dryhome';
+    // Simulate sandbox resolveWriteTarget: repo writes rebase by stable identity.
+    resolveWriteTargetMock.mockImplementation(
+      (
+        _source: string,
+        repo?: { repoKey: string; repoRelative: string; repoRoot: string }
+      ) => {
+        if (repo) return join(sandboxRoot, 'repos', repo.repoKey, repo.repoRelative);
+        return join(sandboxRoot, _source.replace(/^~\//, ''));
+      }
+    );
+    getAllTrackedFilesMock.mockResolvedValue({
+      cfg: {
+        source: 'myrepo-abc123:.config/app.toml',
+        destination: 'files/repos/myrepo-abc123/.config/app.toml',
+        category: 'misc',
+        scope: 'repo',
+        repoKey: 'myrepo-abc123',
+        repoRelative: '.config/app.toml',
+      },
+    });
+    resolveLiveTargetMock.mockResolvedValue('/Users/somebody/work/myrepo/.config/app.toml');
+    resolveRepoRootMock.mockResolvedValue('/Users/somebody/work/myrepo');
+
+    const { runRestore } = await import('../../src/commands/restore.js');
+    await runRestore({ all: true, noHooks: true, noSecrets: true });
+
+    expect(copyFileOrDirMock).toHaveBeenCalledTimes(1);
+    const dest = copyFileOrDirMock.mock.calls[0][1] as string;
+    expect(dest).toBe(join(sandboxRoot, 'repos', 'myrepo-abc123', '.config/app.toml'));
+  });
+
+  it('leaves home-scoped restore unchanged (uses validateSafeSourcePath + plain resolveWriteTarget)', async () => {
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        category: 'shell',
+      },
+    });
+
+    const { runRestore } = await import('../../src/commands/restore.js');
+    await runRestore({ all: true, noHooks: true, noSecrets: true });
+
+    expect(copyFileOrDirMock).toHaveBeenCalledTimes(1);
+    const dest = copyFileOrDirMock.mock.calls[0][1] as string;
+    expect(dest).toBe('/test-home/.zshrc');
+
+    // Home files: validated with the home validator, written with no repo descriptor.
+    expect(validateSafeSourcePathMock).toHaveBeenCalledWith('~/.zshrc');
+    expect(resolveWriteTargetMock).toHaveBeenCalledWith('~/.zshrc');
+    // The repo-scoped validator must NOT run for home files.
+    expect(validateSafeRepoSourcePathMock).not.toHaveBeenCalled();
+    expect(bindRepoMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -16,6 +16,7 @@ const isIgnoredMock = vi.fn();
 const validateSafeSourcePathMock = vi.fn();
 const validateSafeManifestDestinationMock = vi.fn();
 const validatePathWithinRootMock = vi.fn();
+const resolveLiveTargetMock = vi.fn();
 const runPreSyncHookMock = vi.fn();
 const runPostSyncHookMock = vi.fn();
 const stageAllMock = vi.fn();
@@ -83,6 +84,10 @@ vi.mock('../../src/lib/manifest.js', () => ({
   updateFileInManifest: updateFileInManifestMock,
   removeFileFromManifest: removeFileFromManifestMock,
   getTrackedFileBySource: getTrackedFileBySourceMock,
+}));
+
+vi.mock('../../src/lib/repoScope.js', () => ({
+  resolveLiveTarget: resolveLiveTargetMock,
 }));
 
 vi.mock('../../src/lib/git.js', () => ({
@@ -166,6 +171,10 @@ describe('sync command behavior', () => {
     validateSafeSourcePathMock.mockImplementation(() => {});
     validateSafeManifestDestinationMock.mockImplementation(() => {});
     validatePathWithinRootMock.mockImplementation(() => {});
+    // Default: home-scoped files resolve their live path exactly like expandPath.
+    resolveLiveTargetMock.mockImplementation(async (file: { scope?: string; source: string }) =>
+      file.source.replace(/^~\//, '/test-home/')
+    );
   });
 
   it('throws NotInitializedError when manifest is missing', async () => {
@@ -481,6 +490,98 @@ describe('sync command behavior', () => {
     // Force-bypass surfaced as a structured warning.
     expect(Array.isArray(env.warnings)).toBe(true);
     expect(env.warnings.some((w: string) => w.includes('bypassed via --force'))).toBe(true);
+  });
+
+  it('skips an unbound repo-scoped file instead of reporting it as deleted', async () => {
+    // A repo-scoped entry whose repo is NOT bound on this machine. resolveLiveTarget
+    // returns null, so detectChanges cannot read it. The CRITICAL regression to
+    // avoid: it must be SKIPPED, never reported as 'deleted' (which would delete
+    // the committed copy and drop it from the manifest).
+    getAllTrackedFilesMock.mockResolvedValue({
+      repofile: {
+        source: 'somekey-abcd1234:config/app.toml',
+        destination: 'files/repos/somekey-abcd1234/config/app.toml',
+        checksum: 'old',
+        scope: 'repo',
+        repoKey: 'somekey-abcd1234',
+        repoRelative: 'config/app.toml',
+      },
+    });
+    // Unbound repo → live target unresolvable.
+    resolveLiveTargetMock.mockResolvedValue(null);
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand(undefined, { json: true, pull: false, noHooks: true } as never);
+
+    // Nothing to do — and crucially nothing deleted.
+    expect(deleteFileOrDirMock).not.toHaveBeenCalled();
+    expect(removeFileFromManifestMock).not.toHaveBeenCalled();
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('emits a noop JSON envelope (no deletions) when the only tracked file is an unbound repo entry', async () => {
+    getAllTrackedFilesMock.mockResolvedValue({
+      repofile: {
+        source: 'somekey-abcd1234:config/app.toml',
+        destination: 'files/repos/somekey-abcd1234/config/app.toml',
+        checksum: 'old',
+        scope: 'repo',
+        repoKey: 'somekey-abcd1234',
+        repoRelative: 'config/app.toml',
+      },
+    });
+    resolveLiveTargetMock.mockResolvedValue(null);
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand(undefined, { json: true, pull: false, noHooks: true } as never);
+
+    writeSpy.mockRestore();
+    const env = JSON.parse(writes.join('').trim());
+    expect(env.ok).toBe(true);
+    expect(env.data.noop).toBe(true);
+    expect(env.data.deleted).toEqual([]);
+    expect(deleteFileOrDirMock).not.toHaveBeenCalled();
+  });
+
+  it('detects a BOUND repo-scoped file via its resolved live target, not expandPath', async () => {
+    // A repo-scoped entry bound to an out-of-home checkout. detectChanges must
+    // resolve the live path via resolveLiveTarget (NOT expandPath(source), which
+    // would mangle a "key:rel" source) and compare checksums against it.
+    getAllTrackedFilesMock.mockResolvedValue({
+      repofile: {
+        source: 'somekey-abcd1234:config/app.toml',
+        destination: 'files/repos/somekey-abcd1234/config/app.toml',
+        checksum: 'old',
+        scope: 'repo',
+        repoKey: 'somekey-abcd1234',
+        repoRelative: 'config/app.toml',
+      },
+    });
+    const liveRepoPath = '/work/myrepo/config/app.toml';
+    resolveLiveTargetMock.mockResolvedValue(liveRepoPath);
+    pathExistsMock.mockResolvedValue(true);
+    getFileChecksumMock.mockResolvedValue('new'); // differs from 'old' → modified
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand('sync: repo change', {
+      noCommit: true,
+      noHooks: true,
+      scan: false,
+      pull: false,
+    });
+
+    // The checksum was read from the RESOLVED live path, proving resolveLiveTarget
+    // (not expandPath of "somekey-...:config/app.toml") drove change detection.
+    expect(getFileChecksumMock).toHaveBeenCalledWith(liveRepoPath);
+    expect(copyFileOrDirMock).toHaveBeenCalledTimes(1);
   });
 
   it('fails fast when manifest destination is unsafe', async () => {

--- a/tests/lib/files-repo-dest.test.ts
+++ b/tests/lib/files-repo-dest.test.ts
@@ -1,0 +1,40 @@
+/**
+ * files write-guard repo-root threading (the load-bearing fix).
+ *
+ * copyFileOrDir/createSymlink independently call validateSafeDestinationPath,
+ * which defaults to [homedir()] and would reject ANY out-of-home repo target —
+ * even one resolveWriteTarget allowed. They must validate against allowedRoots()
+ * so a write to a BOUND repo root (outside $HOME) is permitted, while an
+ * unbound out-of-home path is still rejected.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { copyFileOrDir } from '../../src/lib/files.js';
+import { setKnownRepoRoots, resetWriteContext } from '../../src/lib/writeContext.js';
+
+beforeEach(() => {
+  vol.reset();
+  resetWriteContext();
+  vol.mkdirSync('/test-home', { recursive: true });
+  vol.mkdirSync('/srv', { recursive: true });
+  vol.writeFileSync('/src.txt', 'hi');
+});
+afterEach(() => resetWriteContext());
+
+describe('copyFileOrDir destination guard', () => {
+  it('still allows a normal in-home destination', async () => {
+    await copyFileOrDir('/src.txt', '/test-home/.config/f.txt');
+    expect(vol.readFileSync('/test-home/.config/f.txt', 'utf-8')).toBe('hi');
+  });
+
+  it('rejects an out-of-home repo path when no repo is bound', async () => {
+    await expect(copyFileOrDir('/src.txt', '/srv/repoX/sub/f.txt')).rejects.toThrow();
+    expect(vol.existsSync('/srv/repoX/sub/f.txt')).toBe(false);
+  });
+
+  it('allows a write to a BOUND repo root outside $HOME', async () => {
+    setKnownRepoRoots(['/srv/repoX']);
+    await copyFileOrDir('/src.txt', '/srv/repoX/sub/f.txt');
+    expect(vol.readFileSync('/srv/repoX/sub/f.txt', 'utf-8')).toBe('hi');
+  });
+});

--- a/tests/lib/manifest-schema.test.ts
+++ b/tests/lib/manifest-schema.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Manifest schema — repo-scope fields.
+ *
+ * Repo-scoped tracking adds optional scope/repoKey/repoRelative. They must be
+ * truly optional (legacy entries parse byte-identical — no injected keys) and
+ * shape-consistent (a repo entry requires repoKey + a safe repoRelative; a
+ * home entry must not carry repo fields).
+ */
+import { describe, it, expect } from 'vitest';
+import { trackedFileSchema } from '../../src/schemas/manifest.schema.js';
+
+const homeEntry = {
+  source: '~/.zshrc',
+  destination: 'files/shell/zshrc',
+  category: 'shell',
+  strategy: 'copy' as const,
+  added: '2026-01-01T00:00:00.000Z',
+  modified: '2026-01-01T00:00:00.000Z',
+  checksum: 'abc',
+};
+
+describe('trackedFileSchema repo scope', () => {
+  it('parses a legacy (home) entry without injecting any scope keys', () => {
+    const parsed = trackedFileSchema.parse(homeEntry);
+    expect('scope' in parsed).toBe(false);
+    expect('repoKey' in parsed).toBe(false);
+    expect('repoRelative' in parsed).toBe(false);
+    // Round-trips byte-identical (no scope noise) modulo defaulted bundle.
+    expect(JSON.stringify(parsed)).not.toContain('"scope"');
+  });
+
+  it('parses a valid repo-scoped entry', () => {
+    const parsed = trackedFileSchema.parse({
+      ...homeEntry,
+      source: 'abc123:.vscode/settings.json',
+      destination: 'files/repos/abc123/.vscode/settings.json',
+      scope: 'repo',
+      repoKey: 'abc123',
+      repoRelative: '.vscode/settings.json',
+    });
+    expect(parsed.scope).toBe('repo');
+    expect(parsed.repoKey).toBe('abc123');
+  });
+
+  it('rejects a repo entry missing repoKey', () => {
+    expect(
+      trackedFileSchema.safeParse({ ...homeEntry, scope: 'repo', repoRelative: 'a/b' }).success
+    ).toBe(false);
+  });
+
+  it('rejects a repo entry missing repoRelative', () => {
+    expect(
+      trackedFileSchema.safeParse({ ...homeEntry, scope: 'repo', repoKey: 'k' }).success
+    ).toBe(false);
+  });
+
+  it('rejects a repo entry whose repoRelative traverses out', () => {
+    expect(
+      trackedFileSchema.safeParse({
+        ...homeEntry,
+        scope: 'repo',
+        repoKey: 'k',
+        repoRelative: '../../etc/passwd',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects an absolute repoRelative', () => {
+    expect(
+      trackedFileSchema.safeParse({
+        ...homeEntry,
+        scope: 'repo',
+        repoKey: 'k',
+        repoRelative: '/etc/passwd',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects a home entry carrying stray repo fields', () => {
+    expect(trackedFileSchema.safeParse({ ...homeEntry, repoKey: 'k' }).success).toBe(false);
+  });
+});

--- a/tests/lib/repo-paths.test.ts
+++ b/tests/lib/repo-paths.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Repo-scope path-guard unit tests.
+ *
+ * Repo-scoped files live under a repo root that may be OUTSIDE $HOME, so the
+ * home-only validateSafeSourcePath cannot gate them. validateSafeRepoSourcePath
+ * confines a repo file to its (bound) repo root instead — still rejecting ..
+ * traversal and absolute paths. getRepoScopedDestination namespaces the repo
+ * copy under files/repos/<key>/... and stays a safe relative manifest path.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateSafeRepoSourcePath,
+  getRepoScopedDestination,
+} from '../../src/lib/paths.js';
+
+describe('validateSafeRepoSourcePath', () => {
+  it('accepts a file under a repo root OUTSIDE $HOME', () => {
+    expect(() => validateSafeRepoSourcePath('/tmp/foo', '.vscode/settings.json')).not.toThrow();
+    expect(() => validateSafeRepoSourcePath('/srv/work/proj', 'CLAUDE.md')).not.toThrow();
+  });
+
+  it('rejects a .. traversal out of the repo root', () => {
+    expect(() => validateSafeRepoSourcePath('/tmp/foo', '../escape')).toThrow();
+    expect(() => validateSafeRepoSourcePath('/tmp/foo', 'a/../../escape')).toThrow();
+  });
+
+  it('rejects an absolute repoRelative', () => {
+    expect(() => validateSafeRepoSourcePath('/tmp/foo', '/etc/passwd')).toThrow();
+  });
+});
+
+describe('getRepoScopedDestination', () => {
+  it('namespaces the repo copy under files/repos/<key>/', () => {
+    expect(getRepoScopedDestination('abc123', '.vscode/settings.json')).toBe(
+      'files/repos/abc123/.vscode/settings.json'
+    );
+  });
+
+  it('rejects a traversal in the repoRelative', () => {
+    expect(() => getRepoScopedDestination('abc123', '../../etc/passwd')).toThrow();
+  });
+});

--- a/tests/lib/repoScope.test.ts
+++ b/tests/lib/repoScope.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Repo registry + identity unit tests.
+ *
+ * Repo-scoped tracking resolves a stable, machine-INDEPENDENT repoKey to an
+ * absolute repo root via a MACHINE-LOCAL, off-repo registry (repos.json under
+ * the state dir). The key must be identical across machines (derived from the
+ * canonicalized remote URL), and the registry must never throw on bad input.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vol } from 'memfs';
+import {
+  loadReposRegistry,
+  bindRepo,
+  resolveRepoRoot,
+  getReposRegistryPath,
+  canonicalRemoteUrl,
+  repoKeyFromIdentity,
+} from '../../src/lib/repoScope.js';
+
+beforeEach(() => {
+  vol.reset();
+  vol.mkdirSync('/test-home', { recursive: true });
+});
+
+describe('repos registry', () => {
+  it('returns an empty registry when none exists', async () => {
+    const reg = await loadReposRegistry();
+    expect(reg.repos).toEqual({});
+  });
+
+  it('binds a repoKey to a root and resolves it back', async () => {
+    await bindRepo('proj-abcd1234', '/Users/me/work/proj', { remoteUrl: 'git@github.com:me/proj.git' });
+    expect(await resolveRepoRoot('proj-abcd1234')).toBe('/Users/me/work/proj');
+  });
+
+  it('stores the registry off-repo (under the state dir, not ~/.tuck)', async () => {
+    await bindRepo('k', '/tmp/x');
+    const p = getReposRegistryPath();
+    expect(vol.existsSync(p)).toBe(true);
+    expect(p).not.toContain('/.tuck/');
+  });
+
+  it('returns null for an unknown repoKey (never guesses)', async () => {
+    expect(await resolveRepoRoot('not-bound')).toBeNull();
+  });
+
+  it('treats a malformed registry as empty rather than throwing', async () => {
+    const p = getReposRegistryPath();
+    vol.mkdirSync(p.replace(/\/[^/]+$/, ''), { recursive: true });
+    vol.writeFileSync(p, '{ not valid json');
+    const reg = await loadReposRegistry();
+    expect(reg.repos).toEqual({});
+  });
+});
+
+describe('canonicalRemoteUrl', () => {
+  it('canonicalizes ssh and https of the same repo to the same value', () => {
+    const ssh = canonicalRemoteUrl('git@github.com:user/dots.git');
+    const https = canonicalRemoteUrl('https://github.com/user/dots');
+    expect(ssh).toBe(https);
+    expect(ssh).toBe('github.com/user/dots');
+  });
+
+  it('normalizes ssh:// form too', () => {
+    expect(canonicalRemoteUrl('ssh://git@github.com/user/dots.git')).toBe('github.com/user/dots');
+  });
+});
+
+describe('repoKeyFromIdentity', () => {
+  it('is deterministic and identical for ssh vs https of the same repo', () => {
+    const fromSsh = repoKeyFromIdentity('proj', canonicalRemoteUrl('git@gitlab.com:me/proj.git'));
+    const fromHttps = repoKeyFromIdentity('proj', canonicalRemoteUrl('https://gitlab.com/me/proj'));
+    expect(fromSsh).toBe(fromHttps);
+    expect(fromSsh).toMatch(/^proj-[0-9a-f]{8}$/);
+  });
+
+  it('differs for different identities', () => {
+    expect(repoKeyFromIdentity('proj', 'a')).not.toBe(repoKeyFromIdentity('proj', 'b'));
+  });
+});

--- a/tests/lib/repoScope.test.ts
+++ b/tests/lib/repoScope.test.ts
@@ -15,6 +15,7 @@ import {
   getReposRegistryPath,
   canonicalRemoteUrl,
   repoKeyFromIdentity,
+  resolveLiveTarget,
 } from '../../src/lib/repoScope.js';
 
 beforeEach(() => {
@@ -76,5 +77,29 @@ describe('repoKeyFromIdentity', () => {
 
   it('differs for different identities', () => {
     expect(repoKeyFromIdentity('proj', 'a')).not.toBe(repoKeyFromIdentity('proj', 'b'));
+  });
+});
+
+describe('resolveLiveTarget', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync('/test-home', { recursive: true });
+  });
+
+  it('resolves a home file via expandPath', async () => {
+    expect(await resolveLiveTarget({ source: '~/.zshrc' })).toBe('/test-home/.zshrc');
+  });
+
+  it('resolves a repo file with an UNBOUND key to null (skip, never guess)', async () => {
+    expect(
+      await resolveLiveTarget({ source: 'k:a.txt', scope: 'repo', repoKey: 'k', repoRelative: 'a.txt' })
+    ).toBeNull();
+  });
+
+  it('resolves a repo file with a bound key to join(root, repoRelative)', async () => {
+    await bindRepo('k', '/srv/proj');
+    expect(
+      await resolveLiveTarget({ source: 'k:a.txt', scope: 'repo', repoKey: 'k', repoRelative: 'a.txt' })
+    ).toBe('/srv/proj/a.txt');
   });
 });

--- a/tests/lib/stateModel.test.ts
+++ b/tests/lib/stateModel.test.ts
@@ -110,4 +110,35 @@ describe('computeStateModel', () => {
     const model = await computeStateModel(TUCK);
     expect(model[0].state).toBe('drift-local');
   });
+
+  it('reports unknown-repo for a repo-scoped file whose repo is not bound here', async () => {
+    vol.mkdirSync(`${TUCK}/files/repos/proj-xyz`, { recursive: true });
+    vol.writeFileSync(`${TUCK}/files/repos/proj-xyz/a.txt`, 'x');
+    vol.writeFileSync(
+      `${TUCK}/.tuckmanifest.json`,
+      JSON.stringify({
+        version: '1',
+        created: '2026-01-01T00:00:00.000Z',
+        updated: '2026-01-01T00:00:00.000Z',
+        files: {
+          repofile: {
+            source: 'proj-xyz:a.txt',
+            destination: 'files/repos/proj-xyz/a.txt',
+            category: 'misc',
+            strategy: 'copy',
+            checksum: 'abc',
+            added: '2026-01-01T00:00:00.000Z',
+            modified: '2026-01-01T00:00:00.000Z',
+            scope: 'repo',
+            repoKey: 'proj-xyz',
+            repoRelative: 'a.txt',
+          },
+        },
+        bundles: {},
+      })
+    );
+
+    const model = await computeStateModel(TUCK);
+    expect(model[0].state).toBe('unknown-repo');
+  });
 });

--- a/tests/lib/writeContext.test.ts
+++ b/tests/lib/writeContext.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   setWriteContext,
   resetWriteContext,
+  setKnownRepoRoots,
   getWriteRoot,
   isSandbox,
   allowedRoots,
@@ -52,5 +53,42 @@ describe('sandbox (--root)', () => {
   it('rejects an absolute path outside the sandbox root', () => {
     setWriteContext({ root: '/tmp/fake-home', isSandbox: true });
     expect(() => resolveWriteTarget('/etc/cron.d/evil')).toThrow();
+  });
+});
+
+describe('repo-scoped write targets', () => {
+  const REPO = { repoKey: 'proj-abc12345', repoRelative: 'a/b.txt', repoRoot: '/srv/work/proj' };
+
+  it('resolves to the genuine repo path when not sandboxed', () => {
+    expect(resolveWriteTarget('ignored', REPO)).toBe('/srv/work/proj/a/b.txt');
+  });
+
+  it('rebases under the sandbox by stable identity (real repoRoot never places the file)', () => {
+    setWriteContext({ root: '/tmp/fake-home', isSandbox: true });
+    expect(resolveWriteTarget('ignored', REPO)).toBe('/tmp/fake-home/repos/proj-abc12345/a/b.txt');
+  });
+
+  it('a hostile repoRoot/repoRelative cannot escape the sandbox', () => {
+    setWriteContext({ root: '/tmp/fake-home', isSandbox: true });
+    const out = resolveWriteTarget('ignored', {
+      repoKey: 'k',
+      repoRelative: 'etc/passwd',
+      repoRoot: '/',
+    });
+    expect(out.startsWith('/tmp/fake-home/repos/')).toBe(true);
+  });
+
+  it('allowedRoots includes known repo roots (non-sandbox) and only the sandbox root (sandbox)', () => {
+    setKnownRepoRoots(['/srv/work/proj']);
+    expect(allowedRoots()).toContain('/srv/work/proj');
+    expect(allowedRoots()).toContain('/test-home'); // home still allowed
+
+    setWriteContext({ root: '/tmp/fake-home', isSandbox: true });
+    setKnownRepoRoots(['/srv/work/proj']);
+    expect(allowedRoots()).toEqual(['/tmp/fake-home']);
+  });
+
+  it('1-arg resolveWriteTarget is unchanged (home path)', () => {
+    expect(resolveWriteTarget('~/.zshrc')).toBe('/test-home/.zshrc');
   });
 });


### PR DESCRIPTION
## Summary

**Repo-scoped / arbitrary-path tracking** — generalizes tuck from "manage `$HOME` dotfiles" to **manage any config file, anywhere**, including files inside git repos (`.vscode/settings.json`, `CLAUDE.md`, `.cursorrules`), synced across machines even when the repo lives at a different path on each. Designed via a judge-panel workflow (`docs/REPO-SCOPED-PLAN.md`) and built test-first in 12 small steps. **Stacks on #90.** 1050 tests pass; typecheck + lint clean; end-to-end verified with the built binary.

## How it works
- Manifest gains optional `scope`/`repoKey`/`repoRelative` (legacy entries parse byte-identical).
- `repoKey` is derived from the **canonical remote URL** (same on every machine); the committed manifest holds **no absolute paths**.
- A **machine-local** `repos.json` (off-repo, under the state dir) maps `repoKey → absolute root`, so the shared manifest resolves per-machine.

## Commands
- `tuck add --repo [dir] [--repo-key <k>]` — track a file inside a repo (copy-only).
- `tuck repo link/list/unlink` — manage per-machine repo bindings.
- `restore`/`apply`/`sync`/`verify` are repo-aware: an unbound repo resolves to **`unknown-repo`** and is **skipped** (never guessed; sync does not mis-report it as deleted). `restore --repo-root`/`apply --repo-root` bind on the fly.

## Safety / sandbox
- Home confinement for ordinary dotfiles is unchanged; repo files are confined to their bound root (`validateSafeRepoSourcePath`).
- Composes with `--root`: a repo write is rebased to `<root>/repos/<key>/<rel>` by stable identity, so an out-of-home repo can't escape the sandbox. (`copyFileOrDir`/`createSymlink` validate against `allowedRoots()` — the load-bearing fix.)

See `docs/REPO-SCOPED.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
