### PR TITLE
fix(safety): wave-1 data-loss & safety hardening

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -17,6 +17,7 @@ import {
   getTuckDir,
 } from '../lib/paths.js';
 import { resolveWriteTarget, setKnownRepoRoots, type RepoWriteTarget } from '../lib/writeContext.js';
+import { setFilePermissions } from '../lib/files.js';
 import { resolveLiveTarget, resolveRepoRoot, bindRepo } from '../lib/repoScope.js';
 import { cloneRepo } from '../lib/git.js';
 import { isGhInstalled, ghCloneRepo, repoExists } from '../lib/github.js';
@@ -72,6 +73,24 @@ const fixSecurePermissions = async (path: string): Promise<void> => {
   }
 };
 
+/**
+ * Reapply the permissions recorded in the manifest to a freshly-written file.
+ * writeFile uses the umask default, so without this a 0755 script lands
+ * non-executable and a 0600 file lands world-readable. No-op on Windows (handled
+ * inside setFilePermissions) and when no permissions were recorded.
+ */
+const applyRecordedPermissions = async (
+  writeTarget: string,
+  permissions?: string
+): Promise<void> => {
+  if (!permissions) return;
+  try {
+    await setFilePermissions(writeTarget, permissions);
+  } catch {
+    // Never fail an apply over a chmod that the filesystem rejects.
+  }
+};
+
 export interface ApplyOptions {
   merge?: boolean;
   replace?: boolean;
@@ -98,6 +117,8 @@ interface ApplyFile {
    * files; absent for home-scoped files (which route through the home logic).
    */
   repoTarget?: RepoWriteTarget;
+  /** Recorded octal permissions (e.g. "755"), reapplied to the written file. */
+  permissions?: string;
 }
 
 interface ApplyResult {
@@ -447,6 +468,7 @@ const prepareFilesToApply = async (
       category: file.category,
       repoPath: repoFilePath,
       repoTarget,
+      permissions: file.permissions,
     });
   }
 
@@ -537,6 +559,7 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
         const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
         await ensureDir(dirname(writeTarget));
         await writeFile(writeTarget, mergeResult.content, 'utf-8');
+        await applyRecordedPermissions(writeTarget, file.permissions);
         logger.file('merge', collapsePath(file.destination));
       }
     } else {
@@ -553,6 +576,9 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
         // Write file content directly instead of copying (to preserve resolved secrets)
         await ensureDir(dirname(writeTarget));
         await writeFile(writeTarget, fileContent, 'utf-8');
+        // Reapply recorded permissions first (so a 0755 script lands executable),
+        // then the SSH/GPG fixup enforces its stricter floor for those dirs.
+        await applyRecordedPermissions(writeTarget, file.permissions);
         await fixSecurePermissions(writeTarget);
         logger.file(fileExists ? 'modify' : 'add', collapsePath(file.destination));
       }
@@ -604,6 +630,9 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       // Write file content directly instead of copying (to preserve resolved secrets)
       await ensureDir(dirname(writeTarget));
       await writeFile(writeTarget, fileContent, 'utf-8');
+      // Reapply recorded permissions first (so a 0755 script lands executable),
+      // then the SSH/GPG fixup enforces its stricter floor for those dirs.
+      await applyRecordedPermissions(writeTarget, file.permissions);
       await fixSecurePermissions(writeTarget);
       logger.file(fileExists ? 'modify' : 'add', collapsePath(file.destination));
     }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -201,8 +201,11 @@ const runPush = async (options: PushOptions): Promise<void> => {
     await withSpinner('Pushing...', async () => {
       await push(tuckDir, {
         force: options.force,
+        // --set-upstream is a boolean trigger. We ALWAYS push the current
+        // branch — never a ref named after the flag's value — so the upstream
+        // is set for the branch the user is actually on.
         setUpstream: Boolean(options.setUpstream),
-        branch: options.setUpstream || branch,
+        branch,
       });
     });
     if (isJsonMode()) {
@@ -228,7 +231,7 @@ const runPush = async (options: PushOptions): Promise<void> => {
 export const pushCommand = new Command('push')
   .description('Push changes to remote repository')
   .option('-f, --force', 'Force push')
-  .option('--set-upstream <name>', 'Set upstream branch')
+  .option('--set-upstream', 'Set upstream tracking for the current branch')
   .option('--json', 'Emit JSON envelope to stdout')
   .option('-y, --yes', 'Auto-confirm prompts (skip force-push confirmation)')
   .action(async (options: PushOptions) => {

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -22,7 +22,7 @@ import {
   loadReposRegistry,
 } from '../lib/repoScope.js';
 import { loadConfig } from '../lib/config.js';
-import { copyFileOrDir, createSymlink } from '../lib/files.js';
+import { copyFileOrDir, createSymlink, setFilePermissions } from '../lib/files.js';
 import { createBackup } from '../lib/backup.js';
 import { runPreRestoreHook, runPostRestoreHook, type HookOptions } from '../lib/hooks.js';
 import { NotInitializedError, FileNotFoundError, TuckError } from '../errors.js';
@@ -96,6 +96,8 @@ interface FileToRestore {
   repoKey?: string;
   /** POSIX path relative to the repo root (repo-scoped files only). */
   repoRelative?: string;
+  /** Recorded octal permissions (e.g. "755"), reapplied to the restored file. */
+  permissions?: string;
 }
 
 interface RestoreResult {
@@ -146,6 +148,7 @@ const prepareFilesToRestore = async (
         scope: tracked.file.scope,
         repoKey: tracked.file.repoKey,
         repoRelative: tracked.file.repoRelative,
+        permissions: tracked.file.permissions,
       });
     }
   } else {
@@ -168,6 +171,7 @@ const prepareFilesToRestore = async (
         scope: file.scope,
         repoKey: file.repoKey,
         repoRelative: file.repoRelative,
+        permissions: file.permissions,
       });
     }
   }
@@ -274,6 +278,19 @@ const restoreFilesInternal = async (
         await createSymlink(file.destination, targetPath, { overwrite: true });
       } else {
         await copyFileOrDir(file.destination, targetPath, { overwrite: true });
+      }
+
+      // Reapply the recorded permissions so a 0755 script restores executable
+      // and a 0600 file is not left world-readable. Symlinks have no own mode,
+      // so only copies are adjusted. The SSH/GPG fixups below still run and act
+      // as a stricter safety floor for those directories.
+      if (file.permissions && !useSymlink) {
+        try {
+          await setFilePermissions(targetPath, file.permissions);
+        } catch {
+          // Permission set may fail on exotic filesystems / Windows — never fail
+          // the restore over it.
+        }
       }
 
       // Fix permissions on the RESOLVED target (the sandbox copy in --root

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -263,8 +263,21 @@ const pullIfBehind = async (
       // envelope.
       const nonInteractive = options.json === true || options.yes === true || isJsonMode();
       if (nonInteractive) {
-        // Leave the rebase in progress so the user / next interactive run can
-        // resolve it; the dedicated exit code lets agents detect this.
+        // Abort the in-progress rebase BEFORE throwing so ~/.tuck is left in a
+        // clean state — an automated/JSON caller cannot resolve conflicts, and
+        // leaving a half-finished rebase behind would wedge every subsequent
+        // git operation. The pre-pull snapshot already captured the live files
+        // so nothing is lost. If the abort itself fails we surface that too
+        // rather than masking it behind the conflict error.
+        try {
+          await abortRebase(tuckDir);
+        } catch (abortError) {
+          const abortMsg =
+            abortError instanceof Error ? abortError.message : String(abortError);
+          logger.dim(`Could not abort in-progress rebase automatically: ${abortMsg}`);
+        }
+        // The dedicated exit code (3) + stable MERGE_CONFLICTS code + recovery
+        // suggestions let agents detect and report this via the JSON envelope.
         throw new MergeConflictsError(conflicts.map((c) => c.path));
       }
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -141,14 +141,18 @@ export async function getRecentAuditEntries(limit = 10): Promise<AuditEntry[]> {
 
       for (const line of lines) {
         try {
-          parsedEntries.push(JSON.parse(line) as AuditEntry);
+          const parsed = JSON.parse(line) as AuditEntry;
+          // Skip entries whose timestamp is unparseable. A NaN timestamp would
+          // poison the sort below and break the recency check, so we never
+          // fabricate placeholder 'unknown' entries for corrupted log lines.
+          if (Number.isNaN(new Date(parsed.timestamp).getTime())) {
+            continue;
+          }
+          parsedEntries.push(parsed);
         } catch {
-          parsedEntries.push({
-            timestamp: 'unknown',
-            action: 'DANGEROUS_CONFIRMED' as AuditAction,
-            command: 'unknown',
-            details: line,
-          });
+          // Corrupted/garbage log line — skip it entirely rather than
+          // fabricating an 'unknown' entry that would produce NaN downstream.
+          continue;
         }
       }
     }

--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -1,6 +1,6 @@
 import { open, stat } from 'fs/promises';
 import { expandPath } from './paths.js';
-import { basename, dirname } from 'path';
+import { sep } from 'path';
 import { IS_WINDOWS } from './platform.js';
 
 /**
@@ -183,12 +183,13 @@ export const isScriptFile = async (path: string): Promise<boolean> => {
 export const shouldExcludeFromBin = async (path: string): Promise<boolean> => {
   const expandedPath = expandPath(path);
 
-  // Check if file is in a bin directory by checking if parent directory is 'bin'
-  // This matches both ~/bin and ~/.local/bin directories
-  const parentDir = dirname(expandedPath);
-  const parentBasename = basename(parentDir);
-  
-  const isInBinDir = parentBasename === 'bin';
+  // Only the user's executable bin roots count. Resolve them to absolute
+  // paths and require the file to live *under* one of those exact roots.
+  // Matching on the parent directory's basename ('bin') is wrong because it
+  // would also exclude unrelated paths like ~/projects/bin/script and would
+  // over/under-match variants such as ~/.local/foo-bin.
+  const binRoots = [expandPath('~/bin'), expandPath('~/.local/bin')];
+  const isInBinDir = binRoots.some((root) => expandedPath.startsWith(root + sep));
 
   if (!isInBinDir) {
     return false;

--- a/src/lib/fileTracking.ts
+++ b/src/lib/fileTracking.ts
@@ -9,7 +9,7 @@ import {
   detectCategory,
 } from './paths.js';
 import { addFileToManifest, loadManifest } from './manifest.js';
-import { copyFileOrDir, createSymlink, deleteFileOrDir, getFileChecksum, getFileInfo } from './files.js';
+import { copyFileOrDir, createSymlink, getFileChecksum, getFileInfo } from './files.js';
 import { loadConfig } from './config.js';
 import { CATEGORIES } from '../constants.js';
 import { ensureDir } from 'fs-extra';
@@ -216,17 +216,39 @@ export const trackFilesWithProgress = async (
       // Copy or symlink based on strategy. Repo-scoped tracking is copy-only:
       // the live file stays put inside its repo checkout (never symlinked).
       if (strategy === 'symlink' && !isRepo) {
-        // Symlink strategy keeps the repository as source of truth:
-        // 1) copy source into repo, 2) replace source with symlink to repo.
+        // Symlink strategy keeps the repository as source of truth. Order is
+        // safety-critical:
+        //   1) Copy source into the repo FIRST so a durable copy exists before
+        //      we touch the user's original at all.
+        //   2) Only then replace the source with a symlink to the repo copy.
+        // The original is never removed by us until the durable repo copy is in
+        // place — createSymlink performs the replacement against that durable
+        // copy, so if it fails we can always restore from the repo.
         await copyFileOrDir(expandedPath, destination, { overwrite: true });
 
         try {
           await createSymlink(destination, expandedPath, { overwrite: true });
-        } catch (error) {
-          // Best effort rollback so users keep a working source file if symlinking fails.
-          await deleteFileOrDir(expandedPath).catch(() => undefined);
-          await copyFileOrDir(destination, expandedPath, { overwrite: true }).catch(() => undefined);
-          throw error;
+        } catch (symlinkError) {
+          // The symlink failed. createSymlink's overwrite step may have already
+          // removed the user's original source, so restore it from the durable
+          // repo copy. NEVER swallow errors here: if the restore ALSO fails the
+          // user could be left without their file, and they must be told loudly.
+          try {
+            await copyFileOrDir(destination, expandedPath, { overwrite: true });
+          } catch (restoreError) {
+            const symlinkMsg =
+              symlinkError instanceof Error ? symlinkError.message : String(symlinkError);
+            const restoreMsg =
+              restoreError instanceof Error ? restoreError.message : String(restoreError);
+            throw new Error(
+              `Failed to create symlink for ${collapsePath(file.path)} (${symlinkMsg}) ` +
+                `and restoring the original from the repository copy also failed (${restoreMsg}). ` +
+                `A durable copy may remain at ${destination}.`
+            );
+          }
+          // Restore succeeded: surface the original symlink failure so the
+          // caller records it and the user is never told this silently "worked".
+          throw symlinkError;
         }
       } else {
         // Default: copy file into the repository (from the absolute live path).

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -2,6 +2,7 @@ import { homedir } from 'os';
 import { join, basename, dirname, relative, isAbsolute, resolve, sep, posix } from 'path';
 import { stat, lstat, access } from 'fs/promises';
 import { constants } from 'fs';
+import { createHash } from 'crypto';
 import {
   DEFAULT_TUCK_DIR,
   FILES_DIR,
@@ -433,10 +434,46 @@ export const generateFileId = (source: string): string => {
   // 3. Replace . with -
   // 4. Strip all remaining unsafe characters (keep only a-z, A-Z, 0-9, _, -)
   // 5. Remove leading - if present
-  return normalized
+  const readable = normalized
     .replace(/^~\//, '')
     .replace(/\//g, '_')
     .replace(/\./g, '-')
     .replace(/[^a-zA-Z0-9_-]/g, '')
     .replace(/^-/, '');
+
+  // INJECTIVITY: the readable form strips the leading dot off a home-root entry,
+  // so `~/.foo` and `~/foo` both collapsed to `foo` (a misleading "already
+  // tracked"). Dotfiles are the overwhelmingly common — and the
+  // historically-stable — case, so they keep their exact readable id. The rarer
+  // NON-dotfile home-root entry (e.g. `~/foo`, whose first segment has no `.`)
+  // is the one that aliases onto a dotfile id, so disambiguate THAT side with a
+  // short, deterministic suffix derived from the full collapsed path.
+  const homeRelative = normalized.replace(/^~\//, '');
+  const firstSegment = homeRelative.split('/')[0] ?? '';
+  const isHomeRootDotfile = firstSegment.startsWith('.');
+  if (!isHomeRootDotfile && readable) {
+    return `${readable}_${shortPathHash(normalized)}`;
+  }
+
+  return readable;
+};
+
+/**
+ * Short, deterministic hash of a collapsed path, used to disambiguate file ids
+ * whose readable form would otherwise collide.
+ */
+const shortPathHash = (value: string): string =>
+  createHash('sha256').update(value).digest('hex').slice(0, 8);
+
+/**
+ * Detect a case-insensitive collision between two repository destinations.
+ *
+ * On macOS/Windows filesystems are case-insensitive, so `files/misc/config` and
+ * `files/misc/Config` resolve to ONE physical file — tracking both would
+ * silently clobber. Callers use this to disambiguate or reject before writing.
+ * Separator differences are normalized so the comparison is purely on case.
+ */
+export const destinationsCollideCaseInsensitively = (a: string, b: string): boolean => {
+  const norm = (d: string): string => d.replace(/\\/g, '/').toLowerCase();
+  return norm(a) === norm(b);
 };

--- a/src/lib/secretBackends/bitwarden.ts
+++ b/src/lib/secretBackends/bitwarden.ts
@@ -157,8 +157,10 @@ export class BitwardenBackend implements SecretBackend {
     const env = this.getEnv();
 
     try {
-      // Get the item by name or ID
-      const { stdout } = await execFileAsync('bw', ['get', 'item', ref.backendPath], { env });
+      // Get the item by name or ID. The `--` end-of-options separator ensures
+      // the user-controlled backendPath is treated as a positional argument and
+      // never reinterpreted as a flag (matches op/pass).
+      const { stdout } = await execFileAsync('bw', ['get', 'item', '--', ref.backendPath], { env });
       const item = JSON.parse(stdout) as BitwardenItem;
 
       // Determine which field to return

--- a/src/lib/timemachine.ts
+++ b/src/lib/timemachine.ts
@@ -1,11 +1,12 @@
 import { join, dirname, relative, resolve, sep } from 'path';
-import { readdir, readFile, rm, stat } from 'fs/promises';
+import { readdir, readFile, rename, rm, stat } from 'fs/promises';
 import { copy, ensureDir, pathExists } from 'fs-extra';
 import { homedir } from 'os';
 import { expandPath, pathExists as checkPathExists } from './paths.js';
 import { atomicWriteFile } from './files.js';
 import { BackupError } from '../errors.js';
 import { getLegacySnapshotsDir, getSnapshotsDir } from './state.js';
+import { snapshotMetadataSchema } from '../schemas/snapshot.schema.js';
 
 export interface SnapshotMetadata {
   id: string;
@@ -206,7 +207,10 @@ export const listSnapshots = async (): Promise<Snapshot[]> => {
 
       try {
         const content = await readFile(metadataPath, 'utf-8');
-        const metadata: SnapshotMetadata = JSON.parse(content);
+        // Validate the on-disk metadata against the schema. A corrupted or
+        // schema-violating metadata.json must skip THIS snapshot only — never
+        // crash the whole list.
+        const metadata = snapshotMetadataSchema.parse(JSON.parse(content));
 
         snapshots.push({
           id: metadata.id,
@@ -249,7 +253,9 @@ export const getSnapshot = async (snapshotId: string): Promise<Snapshot | null> 
 
     try {
       const content = await readFile(metadataPath, 'utf-8');
-      const metadata: SnapshotMetadata = JSON.parse(content);
+      // Validate against the schema; a corrupted/invalid metadata.json is
+      // treated as a missing snapshot rather than crashing the caller.
+      const metadata = snapshotMetadataSchema.parse(JSON.parse(content));
 
       return {
         id: metadata.id,
@@ -292,31 +298,101 @@ export const restoreSnapshot = async (snapshotId: string): Promise<string[]> => 
   // delete BEFORE mutating anything, so this undo is itself reversible
   // (undo-of-undo) and any file created after the original snapshot — which
   // would otherwise be silently rm'd — can be recovered.
+  //
+  // We keep this pre-restore snapshot in hand so that if the restore loop fails
+  // partway through, we can roll the live filesystem back to exactly this
+  // captured state (best-effort) instead of leaving it half-restored.
   const touchedPaths = snapshot.files.map((f) => f.originalPath);
+  let preRestore: Snapshot | undefined;
   if (touchedPaths.length > 0) {
-    await createSnapshot(touchedPaths, `Pre-undo backup before restoring snapshot ${snapshotId}`);
+    preRestore = await createSnapshot(
+      touchedPaths,
+      `Pre-undo backup before restoring snapshot ${snapshotId}`
+    );
   }
 
   const restoredFiles: string[] = [];
 
-  for (const file of snapshot.files) {
-    if (!file.existed) {
-      // File didn't exist before, delete it if it exists now
-      if (await checkPathExists(file.originalPath)) {
-        await rm(file.originalPath, { recursive: true });
+  try {
+    for (const file of snapshot.files) {
+      if (!file.existed) {
+        // File didn't exist before, delete it if it exists now
+        if (await checkPathExists(file.originalPath)) {
+          await rm(file.originalPath, { recursive: true });
+        }
+        continue;
       }
-      continue;
-    }
 
-    // Restore the backup
-    if (await pathExists(file.backupPath)) {
-      await ensureDir(dirname(file.originalPath));
-      await copy(file.backupPath, file.originalPath, { overwrite: true, preserveTimestamps: true });
-      restoredFiles.push(file.originalPath);
+      // Restore the backup. Stage the copy into a temp path alongside the
+      // destination first, then rename it into place. A rename is atomic, so a
+      // mid-copy failure can never leave a half-written file at the live path.
+      if (await pathExists(file.backupPath)) {
+        await ensureDir(dirname(file.originalPath));
+        const stagingPath = `${file.originalPath}.tuck-restore-${process.pid}-${Date.now()}.tmp`;
+        try {
+          await copy(file.backupPath, stagingPath, {
+            overwrite: true,
+            preserveTimestamps: true,
+          });
+          // If a previous restore left the live path as a directory (or any
+          // non-file), rename() can refuse to overwrite it — clear it first.
+          if (await checkPathExists(file.originalPath)) {
+            await rm(file.originalPath, { recursive: true });
+          }
+          await rename(stagingPath, file.originalPath);
+        } catch (error) {
+          // Clean up the staging artifact so a failed restore leaves no debris.
+          await rm(stagingPath, { recursive: true, force: true }).catch(() => {});
+          throw error;
+        }
+        restoredFiles.push(file.originalPath);
+      }
     }
+  } catch (error) {
+    // Best-effort rollback: return every touched path to its pre-restore state
+    // captured above, then rethrow so the caller knows the undo did not apply.
+    if (preRestore) {
+      await rollbackToSnapshot(preRestore);
+    }
+    throw error;
   }
 
   return restoredFiles;
+};
+
+/**
+ * Best-effort rollback of the live filesystem to the state captured in a
+ * (pre-restore) snapshot. Used to recover after a failed `restoreSnapshot`.
+ *
+ * For each captured file: if it existed at capture time, copy its backup back
+ * over the live path; if it did NOT exist at capture time, delete whatever is
+ * now at that path. Every step is wrapped so one failure cannot abort the rest
+ * of the rollback.
+ */
+const rollbackToSnapshot = async (preRestore: Snapshot): Promise<void> => {
+  for (const file of preRestore.files) {
+    try {
+      if (!file.existed) {
+        if (await checkPathExists(file.originalPath)) {
+          await rm(file.originalPath, { recursive: true, force: true });
+        }
+        continue;
+      }
+
+      if (await pathExists(file.backupPath)) {
+        await ensureDir(dirname(file.originalPath));
+        if (await checkPathExists(file.originalPath)) {
+          await rm(file.originalPath, { recursive: true, force: true });
+        }
+        await copy(file.backupPath, file.originalPath, {
+          overwrite: true,
+          preserveTimestamps: true,
+        });
+      }
+    } catch {
+      // Best-effort: keep rolling back the remaining paths.
+    }
+  }
 };
 
 /**

--- a/src/schemas/snapshot.schema.ts
+++ b/src/schemas/snapshot.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for a single file entry inside a snapshot's metadata.json.
+ * Mirrors the `SnapshotFile` interface in `src/lib/timemachine.ts`.
+ */
+export const snapshotFileSchema = z.object({
+  originalPath: z.string(),
+  backupPath: z.string(),
+  existed: z.boolean(),
+});
+
+/**
+ * Validation schema for a snapshot's `metadata.json`. Mirrors the
+ * `SnapshotMetadata` interface in `src/lib/timemachine.ts`.
+ *
+ * This is parsed defensively when reading snapshots off disk: a corrupted or
+ * schema-violating metadata.json must NOT crash the whole snapshot list — the
+ * caller is expected to skip the offending snapshot.
+ */
+export const snapshotMetadataSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  reason: z.string(),
+  files: z.array(snapshotFileSchema),
+  machine: z.string(),
+  profile: z.string().optional(),
+});
+
+export type SnapshotFileInput = z.input<typeof snapshotFileSchema>;
+export type SnapshotMetadataInput = z.input<typeof snapshotMetadataSchema>;
+export type SnapshotMetadataOutput = z.output<typeof snapshotMetadataSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,10 @@ export interface SyncOptions extends CommonOptions {
 
 export interface PushOptions extends CommonOptions {
   force?: boolean;
-  setUpstream?: string;
+  // Boolean trigger: set the upstream for the CURRENT branch on push.
+  // (Was historically typed as a string ref, which let `--set-upstream <name>`
+  // push a ref named after the flag value instead of the current branch.)
+  setUpstream?: boolean;
 }
 
 export interface PullOptions extends CommonOptions {

--- a/tests/commands/apply-permissions.test.ts
+++ b/tests/commands/apply-permissions.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Manifest-permissions round-trip test for `tuck apply`.
+ *
+ * apply writes a file's resolved content via writeFile, which uses the process
+ * umask default mode — it does NOT honor the manifest's recorded `permissions`.
+ * So a 0755 script applied from a repo would land non-executable, and a 0600
+ * file would land world-readable. apply must reapply the recorded permissions.
+ *
+ * Uses the same memfs + local-directory-source pattern as apply.test.ts; memfs
+ * preserves chmod mode bits, and writes go to the mocked TEST_HOME (virtual),
+ * never the real home.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+
+const findPlaceholdersMock = vi.fn();
+const restoreContentMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('replace'),
+    multiselect: vi.fn().mockResolvedValue([]),
+    cancel: vi.fn(),
+  },
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: vi.fn(),
+    dim: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: {
+    yellow: (x: string) => x,
+    dim: (x: string) => x,
+    bold: (x: string) => x,
+    green: (x: string) => x,
+    cyan: (x: string) => x,
+  },
+}));
+
+vi.mock('../../src/lib/git.js', () => ({ cloneRepo: vi.fn() }));
+vi.mock('../../src/lib/github.js', () => ({
+  isGhInstalled: vi.fn().mockResolvedValue(false),
+  findDotfilesRepo: vi.fn().mockResolvedValue(null),
+  ghCloneRepo: vi.fn(),
+  repoExists: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../../src/lib/timemachine.js', () => ({
+  createPreApplySnapshot: vi.fn().mockResolvedValue({ id: 'snapshot-test' }),
+}));
+vi.mock('../../src/lib/merge.js', () => ({
+  smartMerge: vi.fn(async (_destination: string, content: string) => ({
+    content,
+    preservedBlocks: 0,
+  })),
+  isShellFile: vi.fn().mockReturnValue(false),
+  generateMergePreview: vi.fn().mockResolvedValue(''),
+}));
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  findPlaceholders: findPlaceholdersMock,
+  restoreContent: restoreContentMock,
+  restoreFiles: vi.fn().mockResolvedValue({ totalRestored: 0, allUnresolved: [] }),
+  getAllSecrets: vi.fn().mockResolvedValue({}),
+  getSecretCount: vi.fn().mockResolvedValue(0),
+}));
+vi.mock('../../src/lib/secretBackends/index.js', () => ({ createResolver: vi.fn() }));
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: vi.fn().mockResolvedValue({ security: { secretBackend: 'local' } }),
+}));
+vi.mock('../../src/lib/platform.js', () => ({ IS_WINDOWS: false }));
+
+describe('apply honors manifest permissions for non-ssh/gpg files', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+
+    // Re-establish mock implementations cleared by clearAllMocks().
+    findPlaceholdersMock.mockReturnValue([]);
+    restoreContentMock.mockImplementation((content: string) => ({
+      restoredContent: content,
+      unresolved: [],
+    }));
+  });
+  afterEach(() => vol.reset());
+
+  it.skipIf(process.platform === 'win32')(
+    'applies a 0755 script as executable',
+    async () => {
+      const localSrc = join(TEST_HOME, 'dotfiles-src');
+      const manifest = createMockManifest({
+        files: {
+          script: createMockTrackedFile({
+            source: '~/deploy.sh',
+            destination: 'files/misc/deploy.sh',
+            category: 'misc',
+            permissions: '755',
+          }),
+        },
+      });
+      vol.mkdirSync(join(localSrc, 'files', 'misc'), { recursive: true });
+      vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(localSrc, 'files', 'misc', 'deploy.sh'), '#!/bin/sh\n');
+
+      const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+      setJsonMode(false);
+
+      const { runApply } = await import('../../src/commands/apply.js');
+      await runApply(localSrc, { replace: true });
+
+      const target = join(TEST_HOME, 'deploy.sh');
+      expect(vol.existsSync(target)).toBe(true);
+      const mode = vol.statSync(target).mode & 0o777;
+      expect(mode.toString(8)).toBe('755');
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'applies a 0600 file without making it world-readable',
+    async () => {
+      const localSrc = join(TEST_HOME, 'dotfiles-src');
+      const manifest = createMockManifest({
+        files: {
+          secret: createMockTrackedFile({
+            source: '~/token.env',
+            destination: 'files/misc/token.env',
+            category: 'misc',
+            permissions: '600',
+          }),
+        },
+      });
+      vol.mkdirSync(join(localSrc, 'files', 'misc'), { recursive: true });
+      vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(localSrc, 'files', 'misc', 'token.env'), 'TOKEN=x\n');
+
+      const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+      setJsonMode(false);
+
+      const { runApply } = await import('../../src/commands/apply.js');
+      await runApply(localSrc, { replace: true });
+
+      const target = join(TEST_HOME, 'token.env');
+      expect(vol.existsSync(target)).toBe(true);
+      const mode = vol.statSync(target).mode & 0o777;
+      expect(mode.toString(8)).toBe('600');
+    }
+  );
+});

--- a/tests/commands/push-set-upstream.test.ts
+++ b/tests/commands/push-set-upstream.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadManifestMock = vi.fn();
+const checkLocalModeMock = vi.fn();
+const showLocalModeWarningForPushMock = vi.fn();
+const pushMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const getRemoteUrlMock = vi.fn();
+const getStatusMock = vi.fn();
+const getCurrentBranchMock = vi.fn();
+const addRemoteMock = vi.fn();
+const logForcePushMock = vi.fn();
+
+const loggerSuccessMock = vi.fn();
+const loggerInfoMock = vi.fn();
+const loggerWarningMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
+    confirmDangerous: vi.fn().mockResolvedValue(true),
+    text: vi.fn(),
+    cancel: vi.fn(),
+    note: vi.fn(),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+  logger: {
+    success: loggerSuccessMock,
+    info: loggerInfoMock,
+    warning: loggerWarningMock,
+  },
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  colors: {
+    dim: (value: string) => value,
+    yellow: (value: string) => value,
+    green: (value: string) => value,
+    cyan: (value: string) => value,
+  },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+}));
+
+vi.mock('../../src/lib/remoteChecks.js', () => ({
+  checkLocalMode: checkLocalModeMock,
+  showLocalModeWarningForPush: showLocalModeWarningForPushMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  push: pushMock,
+  hasRemote: hasRemoteMock,
+  getRemoteUrl: getRemoteUrlMock,
+  getStatus: getStatusMock,
+  getCurrentBranch: getCurrentBranchMock,
+  addRemote: addRemoteMock,
+}));
+
+vi.mock('../../src/lib/audit.js', () => ({
+  logForcePush: logForcePushMock,
+}));
+
+describe('push --set-upstream (boolean trigger)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    checkLocalModeMock.mockResolvedValue(false);
+    showLocalModeWarningForPushMock.mockResolvedValue(undefined);
+    pushMock.mockResolvedValue(undefined);
+    hasRemoteMock.mockResolvedValue(true);
+    getRemoteUrlMock.mockResolvedValue('git@github.com:user/dotfiles.git');
+    getStatusMock.mockResolvedValue({ ahead: 2, behind: 0, tracking: undefined });
+    getCurrentBranchMock.mockResolvedValue('main');
+    addRemoteMock.mockResolvedValue(undefined);
+    logForcePushMock.mockResolvedValue(undefined);
+  });
+
+  it('pushes the CURRENT branch, never a ref named after the flag value', async () => {
+    // The current branch is `main`. Passing `--set-upstream` must set upstream
+    // for `main` — it must NOT push a branch literally named "main" only by
+    // accident, and crucially must NOT push some other ref derived from a flag
+    // string. We prove this by making the current branch distinct from any
+    // plausible flag string.
+    getCurrentBranchMock.mockResolvedValue('feature/work');
+
+    const { pushCommand } = await import('../../src/commands/push.js');
+    await pushCommand.parseAsync(['--set-upstream'], { from: 'user' });
+
+    expect(pushMock).toHaveBeenCalledWith('/test-home/.tuck', {
+      force: undefined,
+      setUpstream: true,
+      branch: 'feature/work',
+    });
+    // The flag value must never leak into the branch ref.
+    const call = pushMock.mock.calls[0][1];
+    expect(call.branch).toBe('feature/work');
+    expect(typeof call.setUpstream).toBe('boolean');
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Pushed successfully!');
+  });
+});

--- a/tests/commands/push.test.ts
+++ b/tests/commands/push.test.ts
@@ -121,21 +121,24 @@ describe('push command', () => {
     const { pushCommand } = await import('../../src/commands/push.js');
 
     await expect(
-      pushCommand.parseAsync(['--set-upstream', 'main'], { from: 'user' })
+      pushCommand.parseAsync(['--set-upstream'], { from: 'user' })
     ).rejects.toMatchObject({
       code: 'GIT_ERROR',
     });
   });
 
-  it('pushes with a requested upstream branch in non-interactive mode', async () => {
+  it('sets upstream on the current branch in non-interactive mode', async () => {
+    // --set-upstream is a boolean trigger: it always pushes the CURRENT branch,
+    // never a ref named after a flag value.
+    getCurrentBranchMock.mockResolvedValue('main');
     const { pushCommand } = await import('../../src/commands/push.js');
 
-    await pushCommand.parseAsync(['--set-upstream', 'release'], { from: 'user' });
+    await pushCommand.parseAsync(['--set-upstream'], { from: 'user' });
 
     expect(pushMock).toHaveBeenCalledWith('/test-home/.tuck', {
       force: undefined,
       setUpstream: true,
-      branch: 'release',
+      branch: 'main',
     });
     expect(loggerSuccessMock).toHaveBeenCalledWith('Pushed successfully!');
   });

--- a/tests/commands/sync-merge-abort.test.ts
+++ b/tests/commands/sync-merge-abort.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MergeConflictsError } from '../../src/errors.js';
+
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+const getTrackedFileBySourceMock = vi.fn();
+const pathExistsMock = vi.fn();
+const getFileChecksumMock = vi.fn();
+const loadTuckignoreMock = vi.fn();
+const isIgnoredMock = vi.fn();
+const resolveLiveTargetMock = vi.fn();
+
+const stageAllMock = vi.fn();
+const commitMock = vi.fn();
+const getStatusMock = vi.fn();
+const pushMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const fetchMock = vi.fn();
+const pullMock = vi.fn();
+
+const detectConflictsMock = vi.fn();
+const abortRebaseMock = vi.fn();
+const continueRebaseMock = vi.fn();
+const applyResolutionMock = vi.fn();
+
+const createSnapshotMock = vi.fn();
+const checkLocalModeMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(false),
+    confirmDangerous: vi.fn().mockResolvedValue(true),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      step: vi.fn(),
+      message: vi.fn(),
+    },
+  },
+  logger: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    file: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    dim: vi.fn(),
+  },
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  colors: { dim: (x: string) => x },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  pathExists: pathExistsMock,
+  collapsePath: vi.fn((p: string) => p),
+  getDestinationPathFromSource: vi.fn(),
+  detectCategory: vi.fn(() => 'misc'),
+  sanitizeFilename: vi.fn((path: string) => path.split('/').pop() || 'file'),
+  isDirectory: vi.fn().mockResolvedValue(false),
+  validateSafeSourcePath: vi.fn(),
+  validateSafeManifestDestination: vi.fn(),
+  validatePathWithinRoot: vi.fn(),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  getAllTrackedFiles: getAllTrackedFilesMock,
+  updateFileInManifest: vi.fn(),
+  removeFileFromManifest: vi.fn(),
+  getTrackedFileBySource: getTrackedFileBySourceMock,
+  clearManifestCache: vi.fn(),
+}));
+
+vi.mock('../../src/lib/repoScope.js', () => ({
+  resolveLiveTarget: resolveLiveTargetMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  stageAll: stageAllMock,
+  commit: commitMock,
+  getStatus: getStatusMock,
+  push: pushMock,
+  hasRemote: hasRemoteMock,
+  fetch: fetchMock,
+  pull: pullMock,
+}));
+
+vi.mock('../../src/lib/mergeConflicts.js', () => ({
+  detectConflicts: detectConflictsMock,
+  abortRebase: abortRebaseMock,
+  continueRebase: continueRebaseMock,
+  applyResolution: applyResolutionMock,
+}));
+
+vi.mock('../../src/ui/merge.js', () => ({
+  resolveConflictsInteractively: vi.fn(),
+}));
+
+vi.mock('../../src/lib/timemachine.js', () => ({
+  createSnapshot: createSnapshotMock,
+}));
+
+vi.mock('../../src/lib/files.js', () => ({
+  copyFileOrDir: vi.fn(),
+  getFileChecksum: getFileChecksumMock,
+  deleteFileOrDir: vi.fn(),
+  checkFileSizeThreshold: vi.fn().mockResolvedValue({ warn: false, block: false, size: 10 }),
+  formatFileSize: vi.fn((n: number) => `${n} B`),
+  SIZE_BLOCK_THRESHOLD: 100 * 1024 * 1024,
+}));
+
+vi.mock('../../src/lib/tuckignore.js', () => ({
+  addToTuckignore: vi.fn(),
+  loadTuckignore: loadTuckignoreMock,
+  isIgnored: isIgnoredMock,
+}));
+
+vi.mock('../../src/lib/hooks.js', () => ({
+  runPreSyncHook: vi.fn(),
+  runPostSyncHook: vi.fn(),
+}));
+
+vi.mock('../../src/lib/detect.js', () => ({
+  detectDotfiles: vi.fn().mockResolvedValue([]),
+  DETECTION_CATEGORIES: {},
+}));
+
+vi.mock('../../src/lib/fileTracking.js', () => ({
+  trackFilesWithProgress: vi
+    .fn()
+    .mockResolvedValue({ succeeded: 0, failed: 0, errors: [], sensitiveFiles: [] }),
+}));
+
+vi.mock('../../src/lib/trackPipeline.js', () => ({
+  preparePathsForTracking: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  scanForSecrets: vi.fn().mockResolvedValue({ totalSecrets: 0, results: [] }),
+  isSecretScanningEnabled: vi.fn().mockResolvedValue(false),
+  shouldBlockOnSecrets: vi.fn().mockResolvedValue(true),
+  processSecretsForRedaction: vi.fn(),
+  redactFile: vi.fn(),
+}));
+
+vi.mock('../../src/commands/secrets.js', () => ({
+  displayScanResults: vi.fn(),
+}));
+
+vi.mock('../../src/lib/audit.js', () => ({
+  logForceSecretBypass: vi.fn(),
+}));
+
+vi.mock('../../src/lib/remoteChecks.js', () => ({
+  checkLocalMode: checkLocalModeMock,
+}));
+
+describe('sync --json pull-conflict: abort rebase, leave ~/.tuck clean', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    loadTuckignoreMock.mockResolvedValue(new Set());
+    getAllTrackedFilesMock.mockResolvedValue({});
+    pathExistsMock.mockResolvedValue(true);
+    isIgnoredMock.mockResolvedValue(false);
+    getFileChecksumMock.mockResolvedValue('checksum');
+    checkLocalModeMock.mockResolvedValue(false);
+    createSnapshotMock.mockResolvedValue(undefined);
+    abortRebaseMock.mockResolvedValue(undefined);
+
+    // Remote is behind by one commit, so a pull is attempted.
+    hasRemoteMock.mockResolvedValue(true);
+    fetchMock.mockResolvedValue(undefined);
+    getStatusMock.mockResolvedValue({ behind: 1, ahead: 0 });
+    // The rebase pull fails...
+    pullMock.mockRejectedValue(new Error('CONFLICT (content): rebase failed'));
+    // ...and the index is left with a conflicted file.
+    detectConflictsMock.mockResolvedValue([
+      { path: 'files/shell/.zshrc', ours: 'a', theirs: 'b' },
+    ]);
+  });
+
+  it('aborts the in-progress rebase BEFORE throwing in JSON mode', async () => {
+    const { runSync } = await import('../../src/commands/sync.js');
+
+    await expect(
+      runSync({ json: true, noHooks: true, scan: false } as never)
+    ).rejects.toBeInstanceOf(MergeConflictsError);
+
+    // The rebase MUST have been aborted so ~/.tuck is not left mid-rebase.
+    expect(abortRebaseMock).toHaveBeenCalledWith('/test-home/.tuck');
+  });
+
+  it('throws a MergeConflictsError carrying a stable code and recovery hints', async () => {
+    const { runSync } = await import('../../src/commands/sync.js');
+
+    let caught: unknown;
+    try {
+      await runSync({ json: true, noHooks: true, scan: false } as never);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(MergeConflictsError);
+    const e = caught as MergeConflictsError;
+    expect(e.code).toBe('MERGE_CONFLICTS');
+    expect(e.conflicts).toEqual(['files/shell/.zshrc']);
+    // Recovery instructions must be present for agents/JSON envelope.
+    expect(e.suggestions && e.suggestions.length).toBeGreaterThan(0);
+    // The JSON projection must expose the stable code + hint.
+    const json = e.toJSON();
+    expect(json.code).toBe('MERGE_CONFLICTS');
+    expect(json.exit_code).toBe(3);
+    expect(json.hint).toBeTruthy();
+  });
+
+  it('aborts the rebase before throwing in --yes (non-interactive) mode too', async () => {
+    const { runSync } = await import('../../src/commands/sync.js');
+
+    await expect(
+      runSync({ yes: true, noHooks: true, scan: false } as never)
+    ).rejects.toBeInstanceOf(MergeConflictsError);
+
+    expect(abortRebaseMock).toHaveBeenCalledWith('/test-home/.tuck');
+  });
+});

--- a/tests/integration/restore-permissions.test.ts
+++ b/tests/integration/restore-permissions.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Manifest-permissions round-trip integration test.
+ *
+ * The manifest records each tracked file's `permissions` (e.g. "755" for an
+ * executable script, "600" for a secret), but restore historically only fixed
+ * permissions for SSH/GPG files. A restored 0755 script must come back
+ * executable, and a 0600 file must NOT become world-readable.
+ *
+ * This drives the real `runRestoreCommand` against a memfs sandbox root (as
+ * `--root` does) so nothing touches the real home, and memfs preserves chmod
+ * mode bits — giving a genuine permission round-trip.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { setWriteContext, resetWriteContext } from '../../src/lib/writeContext.js';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { clearConfigCache } from '../../src/lib/config.js';
+
+const TUCK = '/test-home/.tuck';
+const SANDBOX = '/test-home/sandbox';
+
+const seedRepo = async (
+  destination: string,
+  source: string,
+  permissions: string,
+  repoContent: string,
+  repoMode: number
+) => {
+  const repoFile = `${TUCK}/${destination}`;
+  vol.mkdirSync(repoFile.slice(0, repoFile.lastIndexOf('/')), { recursive: true });
+  vol.writeFileSync(repoFile, repoContent, { mode: repoMode });
+  const { getFileChecksum } = await import('../../src/lib/files.js');
+  const checksum = await getFileChecksum(repoFile);
+  vol.writeFileSync(
+    `${TUCK}/.tuckrc.json`,
+    JSON.stringify({
+      repository: { path: TUCK },
+      files: { strategy: 'copy', backupOnRestore: false },
+    })
+  );
+  vol.writeFileSync(
+    `${TUCK}/.tuckmanifest.json`,
+    JSON.stringify({
+      version: '1',
+      created: '2026-01-01T00:00:00.000Z',
+      updated: '2026-01-01T00:00:00.000Z',
+      files: {
+        entry: {
+          source,
+          destination,
+          category: 'misc',
+          strategy: 'copy',
+          permissions,
+          checksum,
+          added: '2026-01-01T00:00:00.000Z',
+          modified: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      bundles: {},
+    })
+  );
+};
+
+describe('restore honors manifest permissions for non-ssh/gpg files', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    clearConfigCache();
+    resetWriteContext();
+    vol.mkdirSync('/test-home', { recursive: true });
+  });
+  afterEach(() => resetWriteContext());
+
+  it.skipIf(process.platform === 'win32')(
+    'restores a 0755 script as executable',
+    async () => {
+      // Repo copy is stored 0644 (the default for a committed text file); the
+      // manifest says the live file should be 0755.
+      await seedRepo('files/misc/deploy.sh', '~/deploy.sh', '755', '#!/bin/sh\n', 0o644);
+      setWriteContext({ root: SANDBOX, isSandbox: true });
+
+      const { runRestoreCommand } = await import('../../src/commands/restore.js');
+      await runRestoreCommand(['~/deploy.sh'], {
+        yes: true,
+        noHooks: true,
+        noSecrets: true,
+      } as never);
+
+      const target = `${SANDBOX}/deploy.sh`;
+      expect(vol.existsSync(target)).toBe(true);
+      const mode = vol.statSync(target).mode & 0o777;
+      expect(mode.toString(8)).toBe('755');
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'restores a 0600 file without making it world-readable',
+    async () => {
+      await seedRepo('files/misc/token.env', '~/token.env', '600', 'TOKEN=x\n', 0o644);
+      setWriteContext({ root: SANDBOX, isSandbox: true });
+
+      const { runRestoreCommand } = await import('../../src/commands/restore.js');
+      await runRestoreCommand(['~/token.env'], {
+        yes: true,
+        noHooks: true,
+        noSecrets: true,
+      } as never);
+
+      const target = `${SANDBOX}/token.env`;
+      expect(vol.existsSync(target)).toBe(true);
+      const mode = vol.statSync(target).mode & 0o777;
+      expect(mode.toString(8)).toBe('600');
+    }
+  );
+});

--- a/tests/lib/auditCorruptLog.test.ts
+++ b/tests/lib/auditCorruptLog.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { dirname } from 'path';
+import { TEST_HOME } from '../setup.js';
+
+// Mock fs modules to use memfs
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+  return memfs.fs.promises;
+});
+
+vi.mock('fs', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+  return memfs.fs;
+});
+
+// Mock os.homedir to return test home
+vi.mock('os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('os')>();
+  return {
+    ...original,
+    homedir: () => TEST_HOME,
+  };
+});
+
+// Import after mocks are set up
+import { getRecentAuditEntries, hasRecentDangerousOperations } from '../../src/lib/audit.js';
+import { getAuditLogPath } from '../../src/lib/state.js';
+
+describe('Audit corrupt log handling', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+    vi.restoreAllMocks();
+  });
+
+  function writeRawLog(...lines: string[]): void {
+    const logPath = getAuditLogPath();
+    vol.mkdirSync(dirname(logPath), { recursive: true });
+    vol.writeFileSync(logPath, lines.join('\n') + '\n', 'utf-8');
+  }
+
+  it('should skip corrupted/garbage log lines instead of fabricating "unknown" entries', async () => {
+    const valid = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: 'FORCE_PUSH',
+      command: 'tuck push --force',
+    });
+    writeRawLog('this is not json {{{', valid, '{ broken json ]');
+
+    const entries = await getRecentAuditEntries(10);
+
+    // Only the single valid entry should be returned; garbage lines are skipped.
+    expect(entries.length).toBe(1);
+    expect(entries[0].command).toBe('tuck push --force');
+    // No fabricated 'unknown' timestamps should leak through.
+    expect(entries.some((e) => e.timestamp === 'unknown')).toBe(false);
+  });
+
+  it('should not produce NaN in the sort when a corrupted line is present', async () => {
+    const older = JSON.stringify({
+      timestamp: '2020-01-01T00:00:00.000Z',
+      action: 'FORCE_PUSH',
+      command: 'older',
+    });
+    const newer = JSON.stringify({
+      timestamp: '2024-01-01T00:00:00.000Z',
+      action: 'FORCE_PUSH',
+      command: 'newer',
+    });
+    writeRawLog(newer, 'garbage line that cannot parse', older);
+
+    const entries = await getRecentAuditEntries(10);
+
+    // Both valid entries returned, sorted oldest -> newest, garbage skipped.
+    expect(entries.length).toBe(2);
+    expect(entries[0].command).toBe('older');
+    expect(entries[1].command).toBe('newer');
+    // Every returned timestamp must parse to a real (non-NaN) number.
+    for (const entry of entries) {
+      expect(Number.isNaN(new Date(entry.timestamp).getTime())).toBe(false);
+    }
+  });
+
+  it('should not crash and should return a clean recency result with a corrupted line', async () => {
+    const recent = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: 'FORCE_PUSH',
+      command: 'recent',
+    });
+    writeRawLog('totally corrupted !!!', recent);
+
+    // A fabricated 'unknown' timestamp would make this throw/return based on NaN.
+    const hasRecent = await hasRecentDangerousOperations(24);
+    expect(hasRecent).toBe(true);
+  });
+
+  it('should report no recent operations when only a corrupted line exists', async () => {
+    writeRawLog('garbage only, no valid entries');
+
+    const hasRecent = await hasRecentDangerousOperations(24);
+    // A fabricated 'unknown' entry would yield NaN-based false here regardless,
+    // but the corrupted line must not be treated as a recent operation.
+    expect(hasRecent).toBe(false);
+  });
+});

--- a/tests/lib/binaryBinMatch.test.ts
+++ b/tests/lib/binaryBinMatch.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm, chmod } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Per-test fake home directory, set before importing the module under test.
+let fakeHome: string;
+
+// Mock the platform module (binary.ts depends on IS_WINDOWS).
+const mockIsWindows = vi.fn(() => false);
+vi.mock('../../src/lib/platform.js', () => ({
+  get IS_WINDOWS() {
+    return mockIsWindows();
+  },
+  IS_MACOS: false,
+  IS_LINUX: true,
+  expandWindowsEnvVars: (path: string) => path,
+  toPosixPath: (path: string) => path.replace(/\\/g, '/'),
+  fromPosixPath: (path: string) => path,
+  normalizePath: (path: string) => path,
+}));
+
+// Mock os.homedir so that ~/bin and ~/.local/bin resolve under our tmp root,
+// without ever touching the real home directory.
+vi.mock('os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('os')>();
+  return {
+    ...original,
+    homedir: () => fakeHome,
+  };
+});
+
+describe('shouldExcludeFromBin bin-root matching', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    mockIsWindows.mockReturnValue(false);
+    fakeHome = join(tmpdir(), `tuck-binmatch-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(fakeHome, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    try {
+      await rm(fakeHome, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  /** Write an ELF binary executable (magic numbers + execute bit) at the path. */
+  async function writeBinary(filePath: string): Promise<void> {
+    const elfHeader = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00]);
+    await writeFile(filePath, elfHeader);
+    await chmod(filePath, 0o755);
+  }
+
+  it('should NOT exclude a binary under ~/projects/bin (parent basename is bin but not a bin root)', async () => {
+    const { shouldExcludeFromBin } = await import('../../src/lib/binary.js');
+    const dir = join(fakeHome, 'projects', 'bin');
+    await mkdir(dir, { recursive: true });
+    const filePath = join(dir, 'script');
+    await writeBinary(filePath);
+
+    expect(await shouldExcludeFromBin(filePath)).toBe(false);
+  });
+
+  it('should exclude a binary under ~/bin', async () => {
+    const { shouldExcludeFromBin } = await import('../../src/lib/binary.js');
+    const dir = join(fakeHome, 'bin');
+    await mkdir(dir, { recursive: true });
+    const filePath = join(dir, 'script');
+    await writeBinary(filePath);
+
+    expect(await shouldExcludeFromBin(filePath)).toBe(true);
+  });
+
+  it('should exclude a binary under ~/.local/bin', async () => {
+    const { shouldExcludeFromBin } = await import('../../src/lib/binary.js');
+    const dir = join(fakeHome, '.local', 'bin');
+    await mkdir(dir, { recursive: true });
+    const filePath = join(dir, 'script');
+    await writeBinary(filePath);
+
+    expect(await shouldExcludeFromBin(filePath)).toBe(true);
+  });
+
+  it('should NOT exclude a binary under a sibling like ~/.local/foo-bin', async () => {
+    const { shouldExcludeFromBin } = await import('../../src/lib/binary.js');
+    const dir = join(fakeHome, '.local', 'foo-bin');
+    await mkdir(dir, { recursive: true });
+    const filePath = join(dir, 'script');
+    await writeBinary(filePath);
+
+    expect(await shouldExcludeFromBin(filePath)).toBe(false);
+  });
+
+  it('should still NOT exclude a script under ~/bin', async () => {
+    const { shouldExcludeFromBin } = await import('../../src/lib/binary.js');
+    const dir = join(fakeHome, 'bin');
+    await mkdir(dir, { recursive: true });
+    const filePath = join(dir, 'myscript');
+    await writeFile(filePath, '#!/bin/bash\necho hello');
+    await chmod(filePath, 0o755);
+
+    expect(await shouldExcludeFromBin(filePath)).toBe(false);
+  });
+});

--- a/tests/lib/bitwarden-argv.test.ts
+++ b/tests/lib/bitwarden-argv.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Bitwarden argv end-of-options regression test.
+ *
+ * backendPath is user-controlled (read from a committed mappings file) and is
+ * passed as an argv element to `bw`. Even though execFile uses no shell, a path
+ * could still be misread as a flag by the bw CLI. Inserting a `--`
+ * end-of-options separator BEFORE the path guarantees it is treated as a
+ * positional argument. (op/pass already do this; bw must too.)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execFileMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => {
+    // promisify(execFile) calls execFile(cmd, args, opts, callback).
+    const callback = args[args.length - 1] as (
+      err: Error | null,
+      result: { stdout: string; stderr: string }
+    ) => void;
+    const recorded = args.slice(0, -1);
+    execFileMock(...recorded);
+    callback(null, {
+      stdout: JSON.stringify({
+        id: 'x',
+        name: 'item',
+        login: { password: 'sekret' },
+      }),
+      stderr: '',
+    });
+  },
+}));
+
+describe('BitwardenBackend.getSecret argv', () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+  });
+
+  it("passes '--' before the user-controlled backendPath", async () => {
+    const { BitwardenBackend } = await import('../../src/lib/secretBackends/bitwarden.js');
+    const backend = new BitwardenBackend();
+
+    const value = await backend.getSecret({ name: 'GITHUB_TOKEN', backendPath: 'github-token' });
+    expect(value).toBe('sekret');
+
+    // Find the `bw get item ...` invocation among recorded execFile calls.
+    const getItemCall = execFileMock.mock.calls.find(
+      (call) => call[0] === 'bw' && Array.isArray(call[1]) && call[1][0] === 'get'
+    );
+    expect(getItemCall).toBeDefined();
+
+    const argv = getItemCall![1] as string[];
+    expect(argv).toEqual(['get', 'item', '--', 'github-token']);
+
+    // The separator must come immediately before the path.
+    const sepIndex = argv.indexOf('--');
+    const pathIndex = argv.indexOf('github-token');
+    expect(sepIndex).toBeGreaterThanOrEqual(0);
+    expect(sepIndex).toBe(pathIndex - 1);
+  });
+});

--- a/tests/lib/fileTracking-symlink-rollback.test.ts
+++ b/tests/lib/fileTracking-symlink-rollback.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { initTestTuck, createTestDotfile, TEST_TUCK_DIR } from '../utils/testHelpers.js';
+
+// We need to control createSymlink so we can simulate it failing AFTER it has
+// already handled (removed) the user's original source file. Everything else in
+// files.js keeps its real, memfs-backed behavior.
+vi.mock('../../src/lib/files.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/lib/files.js')>('../../src/lib/files.js');
+  return {
+    ...actual,
+    createSymlink: vi.fn(),
+  };
+});
+
+import { createSymlink, deleteFileOrDir } from '../../src/lib/files.js';
+import { trackFilesWithProgress } from '../../src/lib/fileTracking.js';
+import { getTrackedFileBySource } from '../../src/lib/manifest.js';
+
+describe('fileTracking symlink rollback safety', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+  });
+
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('preserves the original file and surfaces the error when createSymlink fails after source handling', async () => {
+    await initTestTuck();
+    const sourcePath = createTestDotfile('.zshrc', 'export ORIGINAL_CONTENT=1');
+
+    // Simulate the real createSymlink overwrite window: it removes the original
+    // source as part of "source handling", then blows up before the link is in
+    // place. A naive implementation would leave the user with NO file.
+    vi.mocked(createSymlink).mockImplementation(async (_target, linkPath) => {
+      // Source handling: remove the original (this is what overwrite:true does
+      // inside the real createSymlink before symlink() is attempted).
+      await deleteFileOrDir(linkPath);
+      throw new Error('symlink failed: EPERM');
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await trackFilesWithProgress(
+      [{ path: '~/.zshrc', category: 'shell' }],
+      TEST_TUCK_DIR,
+      {
+        strategy: 'symlink',
+        showCategory: false,
+        delayBetween: 0,
+      }
+    );
+
+    logSpy.mockRestore();
+
+    // The operation must be reported as failed (loud error surfaced), never a
+    // silent success.
+    expect(result.failed).toBe(1);
+    expect(result.succeeded).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    // The underlying failure must be surfaced, not swallowed.
+    expect(result.errors[0].error).toBeInstanceOf(Error);
+    expect(result.errors[0].error.message.length).toBeGreaterThan(0);
+
+    // CRITICAL: the user's original file must still exist with its original
+    // content — restored from the durable repo copy.
+    expect(vol.existsSync(sourcePath)).toBe(true);
+    expect(vol.readFileSync(sourcePath, 'utf-8')).toBe('export ORIGINAL_CONTENT=1');
+
+    // The file must NOT have been added to the manifest since tracking failed.
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.zshrc');
+    expect(tracked).toBeNull();
+  });
+
+  it('surfaces a combined error when both symlink AND restore fail (never silent data loss)', async () => {
+    await initTestTuck();
+    const sourcePath = createTestDotfile('.bashrc', 'export KEEP_ME=1');
+    const repoCopyPath = join(TEST_TUCK_DIR, 'files', 'shell', '.bashrc');
+
+    vi.mocked(createSymlink).mockImplementation(async (_target, linkPath) => {
+      await deleteFileOrDir(linkPath);
+      // Destroy the durable repo copy too, so restore-from-repo is impossible.
+      await deleteFileOrDir(repoCopyPath);
+      throw new Error('symlink failed: EPERM');
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await trackFilesWithProgress(
+      [{ path: '~/.bashrc', category: 'shell' }],
+      TEST_TUCK_DIR,
+      {
+        strategy: 'symlink',
+        showCategory: false,
+        delayBetween: 0,
+      }
+    );
+
+    logSpy.mockRestore();
+
+    // Must be reported as a failure with a real error message — never swallowed.
+    expect(result.failed).toBe(1);
+    expect(result.errors).toHaveLength(1);
+
+    // The restore failure must be SURFACED in the error, not swallowed by a
+    // `.catch(() => undefined)`. A user whose original is unrecoverable must be
+    // told loudly that the restore also failed — otherwise they think the only
+    // problem was a benign symlink hiccup while their file is actually gone.
+    const msg = result.errors[0].error.message.toLowerCase();
+    expect(msg).toMatch(/restor/);
+
+    // We deliberately destroyed both copies in the test harness; the point is
+    // that the failure is LOUD, not that the impossible-to-recover file is
+    // magically restored.
+    expect(vol.existsSync(sourcePath)).toBe(false);
+  });
+});

--- a/tests/lib/generateFileId-collisions.test.ts
+++ b/tests/lib/generateFileId-collisions.test.ts
@@ -1,0 +1,57 @@
+/**
+ * generateFileId collision regression tests.
+ *
+ * Historically `generateFileId` stripped the leading dot off a home-root entry,
+ * so `~/.foo` and `~/foo` BOTH collapsed to the id `foo`. Tracking the second
+ * file then produced a misleading "already tracked" error. The id must be
+ * injective: structurally distinct source paths must map to distinct ids.
+ *
+ * Separately, on case-insensitive filesystems (macOS/Windows) two destinations
+ * that differ only in case (`config` vs `Config`) resolve to ONE physical repo
+ * file, so we must be able to detect that collision before writing.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  generateFileId,
+  destinationsCollideCaseInsensitively,
+} from '../../src/lib/paths.js';
+
+describe('generateFileId injectivity', () => {
+  it('maps ~/.foo and ~/foo to DIFFERENT ids (no leading-dot collision)', () => {
+    expect(generateFileId('~/.foo')).not.toBe(generateFileId('~/foo'));
+  });
+
+  it('keeps existing exact ids for common dotfiles (backward compatible)', () => {
+    expect(generateFileId('~/.zshrc')).toBe('zshrc');
+    expect(generateFileId('~/.config/nvim')).toBe('config_nvim');
+  });
+
+  it('is deterministic for a given path', () => {
+    expect(generateFileId('~/foo')).toBe(generateFileId('~/foo'));
+  });
+
+  it('always produces a safe id', () => {
+    expect(generateFileId('~/foo')).toMatch(/^[a-zA-Z0-9_-]+$/);
+    expect(generateFileId('~/.foo')).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+});
+
+describe('case-insensitive destination collisions', () => {
+  it('flags two destinations that differ only by case', () => {
+    expect(
+      destinationsCollideCaseInsensitively('files/misc/config', 'files/misc/Config')
+    ).toBe(true);
+  });
+
+  it('does not flag genuinely distinct destinations', () => {
+    expect(
+      destinationsCollideCaseInsensitively('files/misc/config', 'files/misc/nvim')
+    ).toBe(false);
+  });
+
+  it('treats an identical destination as a collision', () => {
+    expect(
+      destinationsCollideCaseInsensitively('files/misc/config', 'files/misc/config')
+    ).toBe(true);
+  });
+});

--- a/tests/lib/redactor-roundtrip.test.ts
+++ b/tests/lib/redactor-roundtrip.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Redactor round-trip regression test.
+ *
+ * When a SHORT detected secret ("abc123") is a literal substring of a LONGER
+ * one ("abc123DEF456"), redacting shortest-first would rewrite the longer
+ * secret's prefix and leave its tail in cleartext (and orphan the longer
+ * placeholder). `redactContent` already sorts length-descending to avoid this.
+ * This test locks in a byte-for-byte redact -> restore round-trip so that
+ * ordering guarantee cannot silently regress.
+ */
+import { describe, it, expect } from 'vitest';
+import { redactContent, restoreContent } from '../../src/lib/secrets/redactor.js';
+import type { SecretMatch } from '../../src/lib/secrets/scanner.js';
+
+const makeMatch = (value: string, placeholder: string): SecretMatch => ({
+  patternId: 'test',
+  patternName: 'test',
+  severity: 'high',
+  value,
+  redactedValue: '***',
+  line: 1,
+  column: 0,
+  context: '',
+  placeholder,
+});
+
+describe('redactor round-trip with overlapping (short ⊂ long) secrets', () => {
+  it('reconstructs the original string byte-for-byte', () => {
+    const SHORT = 'abc123';
+    const LONG = 'abc123DEF456';
+    const original = `KEY=${LONG}`;
+
+    // Both values are detected; SHORT is a literal prefix of LONG.
+    const matches: SecretMatch[] = [
+      makeMatch(SHORT, 'SHORT_SECRET'),
+      makeMatch(LONG, 'LONG_SECRET'),
+    ];
+
+    const placeholderMap = new Map<string, string>([
+      [SHORT, 'SHORT_SECRET'],
+      [LONG, 'LONG_SECRET'],
+    ]);
+
+    const { redactedContent } = redactContent(original, matches, placeholderMap);
+
+    // Longest-first means the whole LONG value is replaced as one unit; the
+    // cleartext tail "DEF456" must NOT survive in the redacted output.
+    expect(redactedContent).toBe('KEY={{LONG_SECRET}}');
+    expect(redactedContent).not.toContain('DEF456');
+    expect(redactedContent).not.toContain(SHORT);
+
+    // Restore from the secrets store (placeholder name -> value).
+    const secrets: Record<string, string> = {
+      SHORT_SECRET: SHORT,
+      LONG_SECRET: LONG,
+    };
+    const { restoredContent, restored } = restoreContent(redactedContent, secrets);
+
+    expect(restored).toBe(1);
+    expect(restoredContent).toBe(original);
+  });
+});

--- a/tests/lib/timemachine-atomicity.test.ts
+++ b/tests/lib/timemachine-atomicity.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Regression tests for snapshot restore atomicity + metadata validation.
+ *
+ * These cover the P0 data-loss hardening of `src/lib/timemachine.ts`:
+ *   (a) a corrupted metadata.json is skipped gracefully (listSnapshots /
+ *       getSnapshot must not crash the whole list).
+ *   (b) a restore/undo that hits a mid-loop error rolls back to the
+ *       pre-restore state (best-effort rollback) and rethrows.
+ *   (c) the documented pre-undo safety snapshot still captures a file the
+ *       user created after the original snapshot, AND rollback works when a
+ *       partial failure occurs while deleting it.
+ *
+ * Matches the neighboring `timemachine.test.ts` memfs pattern (os.homedir is
+ * mocked to /test-home by tests/setup.ts) so nothing touches the real home
+ * directory. `fs-extra.copy` is made fault-injectable via a module-level
+ * control so we can simulate a mid-loop failure without real I/O.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_HOME } from '../setup.js';
+
+// Module-level fault injection for the fs-extra `copy` mock. When
+// `copyFailOn` is set, any copy whose DESTINATION contains that substring
+// throws — letting us simulate a mid-restore-loop failure.
+let copyFailOn: string | null = null;
+
+vi.mock('fs-extra', async () => {
+  const { join, dirname } = await import('path');
+  return {
+    pathExists: async (path: string) => {
+      const { vol } = await import('memfs');
+      try {
+        vol.statSync(path);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    ensureDir: async (dir: string) => {
+      const { vol } = await import('memfs');
+      vol.mkdirSync(dir, { recursive: true });
+    },
+    copy: async (
+      src: string,
+      dest: string,
+      _options?: { overwrite?: boolean; preserveTimestamps?: boolean }
+    ) => {
+      if (copyFailOn && dest.includes(copyFailOn)) {
+        throw new Error(`injected copy failure for ${dest}`);
+      }
+      const { vol } = await import('memfs');
+      const copyRecursive = async (source: string, destination: string) => {
+        const srcStats = vol.statSync(source);
+        if (srcStats.isDirectory()) {
+          vol.mkdirSync(destination, { recursive: true });
+          const entries = vol.readdirSync(source);
+          for (const entry of entries) {
+            const srcPath = join(source, entry as string);
+            const destPath = join(destination, entry as string);
+            await copyRecursive(srcPath, destPath);
+          }
+        } else {
+          vol.mkdirSync(dirname(destination), { recursive: true });
+          vol.writeFileSync(destination, vol.readFileSync(source));
+        }
+      };
+      await copyRecursive(src, dest);
+    },
+  };
+});
+
+// Import after mocking
+import {
+  createSnapshot,
+  listSnapshots,
+  getSnapshot,
+  restoreSnapshot,
+} from '../../src/lib/timemachine.js';
+import { getSnapshotsDir } from '../../src/lib/state.js';
+import { snapshotMetadataSchema } from '../../src/schemas/snapshot.schema.js';
+
+const TIMEMACHINE_DIR = getSnapshotsDir();
+
+describe('timemachine atomicity + validation', () => {
+  beforeEach(() => {
+    copyFailOn = null;
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    vol.mkdirSync(join(TEST_HOME, '.tuck'), { recursive: true });
+  });
+
+  afterEach(() => {
+    copyFailOn = null;
+    vol.reset();
+  });
+
+  // ==========================================================================
+  // snapshotMetadataSchema
+  // ==========================================================================
+
+  describe('snapshotMetadataSchema', () => {
+    it('parses a well-formed metadata object', () => {
+      const meta = {
+        id: '2024-06-15-143022',
+        timestamp: '2024-06-15T14:30:22.000Z',
+        reason: 'Test backup',
+        files: [
+          {
+            originalPath: '/test-home/.zshrc',
+            backupPath: '/test-home/snap/files/.zshrc',
+            existed: true,
+          },
+        ],
+        machine: 'test-machine',
+      };
+      const parsed = snapshotMetadataSchema.parse(meta);
+      expect(parsed.id).toBe('2024-06-15-143022');
+      expect(parsed.files[0].existed).toBe(true);
+    });
+
+    it('accepts an optional profile', () => {
+      const meta = {
+        id: 'x',
+        timestamp: 't',
+        reason: 'r',
+        files: [],
+        machine: 'm',
+        profile: 'work',
+      };
+      expect(snapshotMetadataSchema.parse(meta).profile).toBe('work');
+    });
+
+    it('rejects metadata missing required fields', () => {
+      expect(() =>
+        snapshotMetadataSchema.parse({ id: 'x' })
+      ).toThrow();
+    });
+
+    it('rejects a file entry with a non-boolean existed flag', () => {
+      const meta = {
+        id: 'x',
+        timestamp: 't',
+        reason: 'r',
+        files: [{ originalPath: '/a', backupPath: '/b', existed: 'yes' }],
+        machine: 'm',
+      };
+      expect(() => snapshotMetadataSchema.parse(meta)).toThrow();
+    });
+  });
+
+  // ==========================================================================
+  // (a) corrupted metadata is skipped, not fatal
+  // ==========================================================================
+
+  describe('corrupted metadata handling', () => {
+    it('listSnapshots skips a snapshot whose metadata.json is unparseable JSON', async () => {
+      // One good snapshot.
+      vol.writeFileSync(join(TEST_HOME, '.zshrc'), 'content');
+      const good = await createSnapshot([join(TEST_HOME, '.zshrc')], 'Good');
+
+      // One corrupted snapshot dir alongside it.
+      const badDir = join(TIMEMACHINE_DIR, '2024-01-01-000000');
+      vol.mkdirSync(badDir, { recursive: true });
+      vol.writeFileSync(join(badDir, 'metadata.json'), '{ this is not json');
+
+      const snapshots = await listSnapshots();
+
+      // The good one survives; the corrupt one is dropped, no throw.
+      expect(snapshots.map((s) => s.id)).toContain(good.id);
+      expect(snapshots.map((s) => s.id)).not.toContain('2024-01-01-000000');
+    });
+
+    it('listSnapshots skips a snapshot whose metadata violates the schema', async () => {
+      vol.writeFileSync(join(TEST_HOME, '.zshrc'), 'content');
+      const good = await createSnapshot([join(TEST_HOME, '.zshrc')], 'Good');
+
+      // Valid JSON, but wrong shape (files is a string, missing fields).
+      const badDir = join(TIMEMACHINE_DIR, '2024-02-02-000000');
+      vol.mkdirSync(badDir, { recursive: true });
+      vol.writeFileSync(
+        join(badDir, 'metadata.json'),
+        JSON.stringify({ id: '2024-02-02-000000', files: 'nope' })
+      );
+
+      const snapshots = await listSnapshots();
+
+      expect(snapshots.map((s) => s.id)).toContain(good.id);
+      expect(snapshots.map((s) => s.id)).not.toContain('2024-02-02-000000');
+    });
+
+    it('getSnapshot returns null for a schema-invalid metadata.json instead of throwing', async () => {
+      const badDir = join(TIMEMACHINE_DIR, '2024-03-03-000000');
+      vol.mkdirSync(badDir, { recursive: true });
+      vol.writeFileSync(
+        join(badDir, 'metadata.json'),
+        JSON.stringify({ id: '2024-03-03-000000', files: 42 })
+      );
+
+      const snap = await getSnapshot('2024-03-03-000000');
+      expect(snap).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // (b) mid-loop restore failure rolls back to pre-restore state
+  // ==========================================================================
+
+  describe('restore atomicity / rollback', () => {
+    it('rolls back overwritten files when a later file in the restore loop fails', async () => {
+      const fileA = join(TEST_HOME, '.aaa');
+      const fileB = join(TEST_HOME, '.zzz');
+      vol.writeFileSync(fileA, 'A-original');
+      vol.writeFileSync(fileB, 'B-original');
+
+      // Snapshot captures both originals.
+      const snap = await createSnapshot([fileA, fileB], 'Before changes');
+
+      // User modifies both live files.
+      vol.writeFileSync(fileA, 'A-live');
+      vol.writeFileSync(fileB, 'B-live');
+
+      // Inject a failure when STAGING the restore of fileB. The restore stages
+      // each backup into a `<dest>.tuck-restore-*.tmp` file before renaming it
+      // into place, so matching the staging marker for `.zzz` fails the forward
+      // restore of fileB without also tripping the (different-path) rollback
+      // copies — modelling a single transient forward-path failure.
+      copyFailOn = '.zzz.tuck-restore-';
+
+      await expect(restoreSnapshot(snap.id)).rejects.toThrow();
+
+      // After the failed restore, BOTH live files must be back to their
+      // pre-restore ("live") state — fileA must NOT be left half-restored to
+      // 'A-original'. Rollback restores the pre-restore safety snapshot.
+      expect(vol.readFileSync(fileA, 'utf-8')).toBe('A-live');
+      expect(vol.readFileSync(fileB, 'utf-8')).toBe('B-live');
+    });
+
+    it('does not lose a user-created file when restore fails mid-loop', async () => {
+      // fileKeep exists at snapshot time; fileNew is created by the user later
+      // and would be rm'd by a successful undo. If the undo fails partway, the
+      // user-created file must survive (rolled back).
+      const fileKeep = join(TEST_HOME, '.keep');
+      const fileNew = join(TEST_HOME, '.created-later');
+      vol.writeFileSync(fileKeep, 'keep-original');
+
+      // Snapshot: .created-later did NOT exist (listed first so the restore
+      // loop deletes it BEFORE the failure), .keep existed.
+      const snap = await createSnapshot([fileNew, fileKeep], 'Initial');
+
+      // User changes .keep and creates .created-later with valuable data.
+      vol.writeFileSync(fileKeep, 'keep-live');
+      vol.writeFileSync(fileNew, 'valuable-user-data');
+
+      // The restore loop first deletes .created-later (it didn't exist in the
+      // snapshot), then fails while staging the restore of .keep — forcing a
+      // rollback that must bring the deleted user file back.
+      copyFailOn = '.keep.tuck-restore-';
+
+      await expect(restoreSnapshot(snap.id)).rejects.toThrow();
+
+      // Rollback must have restored the pre-restore state of every touched
+      // path: the user's valuable file is intact, .keep is back to 'keep-live'.
+      expect(vol.existsSync(fileNew)).toBe(true);
+      expect(vol.readFileSync(fileNew, 'utf-8')).toBe('valuable-user-data');
+      expect(vol.readFileSync(fileKeep, 'utf-8')).toBe('keep-live');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Wave 1 of the remaining 2026-05 audit remediation — the safety/data-loss cluster. Every fix is implemented test-first (TDD); all tests run against memfs or sandboxed temp roots, **never the real home**.

### Snapshot / time-machine (P0 data-loss)
- **Zod-validate `metadata.json`** on read (new `src/schemas/snapshot.schema.ts`) — a corrupted snapshot is skipped, not fatal to the whole list.
- **Atomic, rollback-safe `restoreSnapshot`** — each restored file is staged to a temp path and `rename()`d into place (no half-written live files), and the whole mutating loop rolls every touched path back to its pre-restore state on any error before rethrowing. (`undo` `rm -r`s files absent from the snapshot — now recoverable.)

### Lifecycle data-loss (P1)
- **Symlink-strategy `add`**: never swallow rollback errors; restore the original from the durable repo copy and surface a loud combined error if restore also fails.
- **Non-interactive pull conflict**: `abortRebase()` before throwing so `~/.tuck` is left clean (stable `MERGE_CONFLICTS` code + exit 3 + recovery hints in the envelope).
- **`push --set-upstream`** is now a boolean trigger that always pushes the **current** branch (was pushing a ref named after the flag's string value). Type corrected in `types.ts`.

### Paths / permissions / arg-injection (P1/P2)
- **`generateFileId` is injective** — `~/.foo` and `~/foo` no longer collide (dotfile ids unchanged for backward-compat; aliasing non-dotfile side gets a short deterministic hash). Exported `destinationsCollideCaseInsensitively`.
- **Honor recorded permissions on restore + apply** — a `0755` script restores executable; a `0600` file isn't left world-readable (chmod wrapped defensively).
- **bitwarden backend**: `--` end-of-options guard before the user path.
- **Redactor** longest-first round-trip regression test (substring secrets).

### Audit / binary correctness (P2)
- Audit reader skips unparseable / NaN-timestamp lines (fixes NaN sort + always-false recency).
- bin-dir exclusion anchors to resolved `~/bin` / `~/.local/bin` (no longer matches `~/projects/bin/script`).

## Verification
`pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` **1087 passing** (+37 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)