### PR TITLE
feat(agent+sandbox+keystore): wave-2 — json completeness, verify dry-apply, platform/keystore hardening

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -210,27 +210,45 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
     return;
   }
 
-  // --plan / --dry-run: print what would be added without mutating.
-  if (options.plan || options.dryRun) {
-    const planned = paths.map((p) => ({
-      path: p,
-      category: options.category,
-      bundle: options.bundle ?? 'default',
-    }));
-    if (isJsonMode()) {
-      emitJsonOk({ plan: planned });
-    } else {
-      logger.heading('Plan — would track:');
-      for (const p of planned) logger.file('add', `${p.path} [${p.category ?? 'auto'}]`);
-    }
-    return;
-  }
-
   const candidates: TrackPathCandidate[] = paths.map((path) => ({
     path,
     category: options.category,
     name: options.name,
   }));
+
+  // --plan / --dry-run: run the FULL preparation pipeline (category detection,
+  // secret scan, validation) so the plan output is what a real `tuck add` would
+  // produce — not an echo of raw input. preparePathsForTracking performs no
+  // manifest writes; addFiles (skipped below) is the only mutating step.
+  if (options.plan || options.dryRun) {
+    const plannedFiles = await preparePathsForTracking(candidates, tuckDir, {
+      category: options.category,
+      name: options.name,
+      force: options.force,
+      secretHandling: isJsonMode() || options.yes ? 'strict' : 'interactive',
+      forceBypassCommand: 'tuck add --force',
+      repo: options.repo,
+      repoKey: options.repoKey,
+    });
+
+    const bundle = options.bundle ?? 'default';
+    if (isJsonMode()) {
+      emitJsonOk({
+        plan: plannedFiles.map((f) => ({
+          source: f.source,
+          category: f.category,
+          destination: f.destination,
+          sensitive: f.sensitive,
+          scope: f.scope ?? 'home',
+          bundle,
+        })),
+      });
+    } else {
+      logger.heading('Plan — would track:');
+      for (const f of plannedFiles) logger.file('add', `${f.source} [${f.category}]`);
+    }
+    return;
+  }
 
   const filesToAdd = await preparePathsForTracking(candidates, tuckDir, {
     category: options.category,

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -105,7 +105,7 @@ export interface ApplyOptions {
   repoRoot?: string;
 }
 
-interface ApplyFile {
+export interface ApplyFile {
   source: string;
   /** Absolute LIVE write target on this machine (home path or repo checkout path). */
   destination: string;
@@ -379,7 +379,7 @@ const registerKnownRepoRoots = async (manifest: TuckManifestOutput): Promise<voi
  * skipped — never guessed, never written to a wrong path — and reported back so
  * callers can surface it.
  */
-const prepareFilesToApply = async (
+export const prepareFilesToApply = async (
   repoDir: string,
   manifest: TuckManifestOutput,
   bundle?: string

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -10,6 +10,14 @@ import type { TuckConfigOutput } from '../schemas/config.schema.js';
 import { setupProvider } from '../lib/providerSetup.js';
 import { describeProviderConfig, getProvider } from '../lib/providers/index.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { IS_WINDOWS } from '../lib/platform.js';
+
+/**
+ * Resolve the editor to open config files with. Honors $EDITOR then $VISUAL,
+ * falling back to a sane platform default (Windows has no vim/vi out of the box).
+ */
+export const getDefaultEditor = (): string =>
+  process.env.EDITOR || process.env.VISUAL || (IS_WINDOWS ? 'notepad' : 'vim');
 
 interface ConfigGetOptions {
   json?: boolean;
@@ -264,7 +272,7 @@ const runConfigEdit = async (): Promise<void> => {
   const tuckDir = getTuckDir();
   const configPath = getConfigPath(tuckDir);
 
-  const editor = process.env.EDITOR || process.env.VISUAL || 'vim';
+  const editor = getDefaultEditor();
 
   logger.info(`Opening ${collapsePath(configPath)} in ${editor}...`);
 
@@ -500,7 +508,7 @@ const runInteractiveConfig = async (): Promise<void> => {
     { value: 'remote', label: 'Configure remote', hint: 'Set up GitHub, GitLab, or local mode' },
     { value: 'wizard', label: 'Run setup wizard', hint: 'Guided configuration' },
     { value: 'reset', label: 'Reset to defaults', hint: 'Restore default values' },
-    { value: 'open', label: 'Open in editor', hint: `Edit with ${process.env.EDITOR || 'vim'}` },
+    { value: 'open', label: 'Open in editor', hint: `Edit with ${getDefaultEditor()}` },
   ])) as string;
 
   console.log();

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -28,7 +28,7 @@ import { runPreRestoreHook, runPostRestoreHook, type HookOptions } from '../lib/
 import { NotInitializedError, FileNotFoundError, TuckError } from '../errors.js';
 import { CATEGORIES } from '../constants.js';
 import type { RestoreOptions } from '../types.js';
-import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import { restoreFiles as restoreSecrets, getSecretCount } from '../lib/secrets/index.js';
 
 /**
@@ -229,9 +229,9 @@ const restoreFilesInternal = async (
         repoRoot = (await resolveRepoRoot(file.repoKey)) ?? options.repoRoot;
       }
       if (!repoRoot || !file.repoKey || !file.repoRelative) {
-        logger.warning(
-          `Skipping repo-scoped file (repo not bound on this machine): ${file.source}`
-        );
+        const msg = `Skipping repo-scoped file (repo not bound on this machine): ${file.source}`;
+        logger.warning(msg);
+        if (isJsonMode()) addJsonWarning(msg);
         skipped.push(file.source);
         continue;
       }
@@ -251,7 +251,9 @@ const restoreFilesInternal = async (
 
     // Check if source exists in repository
     if (!(await pathExists(file.destination))) {
-      logger.warning(`Source not found in repository: ${file.source}`);
+      const msg = `Source not found in repository: ${file.source}`;
+      logger.warning(msg);
+      if (isJsonMode()) addJsonWarning(msg);
       continue;
     }
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -35,7 +35,7 @@ import {
   CONFIGURABLE_BACKEND_NAMES,
   type ConfiguredBackendName,
 } from '../lib/secretBackends/index.js';
-import { NotInitializedError } from '../errors.js';
+import { NotInitializedError, TuckError } from '../errors.js';
 import { getLog } from '../lib/git.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 
@@ -59,7 +59,13 @@ const isValidUrl = (value: string): boolean => {
 // List Command
 // ============================================================================
 
-const runSecretsList = async (): Promise<void> => {
+interface JsonOptions {
+  json?: boolean;
+}
+
+const runSecretsList = async (options: JsonOptions = {}): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets list');
+
   const tuckDir = getTuckDir();
 
   try {
@@ -69,6 +75,22 @@ const runSecretsList = async (): Promise<void> => {
   }
 
   const secrets = await listSecrets(tuckDir);
+
+  if (isJsonMode()) {
+    // SECURITY: listSecrets never returns raw values; emit only the redacted
+    // metadata (name, placeholder, description, source, timestamps).
+    emitJsonOk({
+      secrets: secrets.map((secret) => ({
+        name: secret.name,
+        placeholder: secret.placeholder,
+        ...(secret.description !== undefined ? { description: secret.description } : {}),
+        ...(secret.source !== undefined ? { source: secret.source } : {}),
+        addedAt: secret.addedAt,
+        ...(secret.lastUsed !== undefined ? { lastUsed: secret.lastUsed } : {}),
+      })),
+    });
+    return;
+  }
 
   if (secrets.length === 0) {
     logger.info('No secrets stored');
@@ -104,7 +126,14 @@ const runSecretsList = async (): Promise<void> => {
 // Set Command
 // ============================================================================
 
-const runSecretsSet = async (name: string): Promise<void> => {
+interface SecretsSetOptions {
+  json?: boolean;
+  yes?: boolean;
+}
+
+const runSecretsSet = async (name: string, options: SecretsSetOptions = {}): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets set');
+
   const tuckDir = getTuckDir();
 
   try {
@@ -116,22 +145,46 @@ const runSecretsSet = async (name: string): Promise<void> => {
   // Validate or normalize name
   if (!isValidSecretName(name)) {
     const normalized = normalizeSecretName(name);
-    logger.warning(`Secret name normalized to: ${normalized}`);
-    logger.dim('Secret names must be uppercase alphanumeric with underscores (e.g., API_KEY)');
+    if (!isJsonMode()) {
+      logger.warning(`Secret name normalized to: ${normalized}`);
+      logger.dim('Secret names must be uppercase alphanumeric with underscores (e.g., API_KEY)');
+    }
     name = normalized;
   }
 
-  // Security: Always prompt for secret value interactively
-  // Never accept via command-line to prevent exposure in shell history and process list
-  // Note: Cancellation or empty input is handled below by validating the returned value.
-  const secretValue = await prompts.password(`Enter value for ${name}:`);
+  // In non-interactive mode (--json/--yes) we cannot prompt. Accept the value
+  // from TUCK_SECRET_VALUE so it never lands in argv/shell history, mirroring
+  // the interactive password prompt's "no value on the command line" rule.
+  let secretValue: string;
+  if (isJsonMode() || options.yes) {
+    secretValue = process.env.TUCK_SECRET_VALUE ?? '';
+    if (!secretValue || secretValue.trim().length === 0) {
+      throw new TuckError(
+        'Secret value not provided',
+        'SECRET_VALUE_REQUIRED',
+        ['Set TUCK_SECRET_VALUE in the environment before running with --json/--yes']
+      );
+    }
+  } else {
+    // Security: Always prompt for secret value interactively
+    // Never accept via command-line to prevent exposure in shell history and process list
+    // Note: Cancellation or empty input is handled below by validating the returned value.
+    secretValue = await prompts.password(`Enter value for ${name}:`);
 
-  if (!secretValue || secretValue.trim().length === 0) {
-    logger.error('Secret value cannot be empty');
-    return;
+    if (!secretValue || secretValue.trim().length === 0) {
+      logger.error('Secret value cannot be empty');
+      return;
+    }
   }
 
   await setSecret(tuckDir, name, secretValue);
+
+  if (isJsonMode()) {
+    // SECURITY: never echo the value back; only confirm the name and outcome.
+    emitJsonOk({ name, set: true });
+    return;
+  }
+
   logger.success(`Secret '${name}' set`);
   console.log();
   logger.dim(`Use {{${name}}} as placeholder in your dotfiles`);
@@ -141,7 +194,9 @@ const runSecretsSet = async (name: string): Promise<void> => {
 // Unset Command
 // ============================================================================
 
-const runSecretsUnset = async (name: string): Promise<void> => {
+const runSecretsUnset = async (name: string, options: JsonOptions = {}): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets unset');
+
   const tuckDir = getTuckDir();
 
   try {
@@ -151,6 +206,11 @@ const runSecretsUnset = async (name: string): Promise<void> => {
   }
 
   const removed = await unsetSecret(tuckDir, name);
+
+  if (isJsonMode()) {
+    emitJsonOk({ name, unset: removed });
+    return;
+  }
 
   if (removed) {
     logger.success(`Secret '${name}' removed`);
@@ -164,7 +224,9 @@ const runSecretsUnset = async (name: string): Promise<void> => {
 // Path Command
 // ============================================================================
 
-const runSecretsPath = async (): Promise<void> => {
+const runSecretsPath = async (options: JsonOptions = {}): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets path');
+
   const tuckDir = getTuckDir();
 
   try {
@@ -173,7 +235,14 @@ const runSecretsPath = async (): Promise<void> => {
     throw new NotInitializedError();
   }
 
-  console.log(getSecretsPath(tuckDir));
+  const path = getSecretsPath(tuckDir);
+
+  if (isJsonMode()) {
+    emitJsonOk({ path });
+    return;
+  }
+
+  console.log(path);
 };
 
 // ============================================================================
@@ -880,21 +949,30 @@ export const secretsCommand = new Command('secrets')
   .addCommand(
     new Command('list')
       .description('List all stored secrets (values hidden)')
-      .action(runSecretsList)
+      .option('--json', 'Emit JSON envelope to stdout (values are never included)')
+      .action((options: JsonOptions) => runSecretsList(options))
   )
   .addCommand(
     new Command('set')
       .description('Set a secret value (prompts securely)')
       .argument('<name>', 'Secret name (e.g., GITHUB_TOKEN)')
-      .action(runSecretsSet)
+      .option('--json', 'Emit JSON envelope to stdout (value is never echoed)')
+      .option('-y, --yes', 'Non-interactive: read value from TUCK_SECRET_VALUE')
+      .action((name: string, options: SecretsSetOptions) => runSecretsSet(name, options))
   )
   .addCommand(
     new Command('unset')
       .description('Remove a secret')
       .argument('<name>', 'Secret name to remove')
-      .action(runSecretsUnset)
+      .option('--json', 'Emit JSON envelope to stdout')
+      .action((name: string, options: JsonOptions) => runSecretsUnset(name, options))
   )
-  .addCommand(new Command('path').description('Show path to secrets file').action(runSecretsPath))
+  .addCommand(
+    new Command('path')
+      .description('Show path to secrets file')
+      .option('--json', 'Emit JSON envelope to stdout')
+      .action((options: JsonOptions) => runSecretsPath(options))
+  )
   .addCommand(
     new Command('scan')
       .description('Scan files for secrets')

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -27,7 +27,12 @@ import { loadManifest } from '../lib/manifest.js';
 import { copyFileOrDir, getFileChecksum } from '../lib/files.js';
 import { NotInitializedError } from '../errors.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
-import { setWriteContext, resetWriteContext, resolveWriteTarget } from '../lib/writeContext.js';
+import {
+  setWriteContext,
+  snapshotWriteContext,
+  restoreWriteContext,
+  resolveWriteTarget,
+} from '../lib/writeContext.js';
 import { smartMerge, isShellFile, type MergeConflict } from '../lib/merge.js';
 import { prepareFilesToApply } from './apply.js';
 import {
@@ -225,6 +230,9 @@ const runVerifyApply = async (options: VerifyOptions): Promise<void> => {
   const usingTempSandbox = !options.root;
 
   // Confine ALL writes under the sandbox for the duration of the dry-apply.
+  // Snapshot first so the finally restores any PRIOR boundary (e.g. a global
+  // --root) instead of dropping it — critical in long-running (MCP) mode.
+  const prevContext = snapshotWriteContext();
   setWriteContext({ root: sandboxRoot, isSandbox: true });
   try {
     await ensureDir(sandboxRoot);
@@ -268,9 +276,10 @@ const runVerifyApply = async (options: VerifyOptions): Promise<void> => {
       process.exitCode = 1;
     }
   } finally {
-    // Reset the write boundary and always clean up the scratch sandbox. An
-    // explicit --root provided by the caller is left in place for inspection.
-    resetWriteContext();
+    // Restore the prior write boundary (not a blind reset → null) and always
+    // clean up the scratch sandbox. An explicit --root provided by the caller is
+    // left on disk for inspection.
+    restoreWriteContext(prevContext);
     if (usingTempSandbox) {
       try {
         const { rm } = await import('fs/promises');
@@ -296,6 +305,7 @@ export const runVerify = async (options: VerifyOptions): Promise<void> => {
   // dry home. The live comparison still reads the real home; only resolveWriteTarget
   // (used by --fix's repo writes stay inside the repo) routes through the sandbox.
   const rootForContext = options.root ? resolve(expandPath(options.root)) : undefined;
+  const prevContext = snapshotWriteContext();
   if (rootForContext) {
     setWriteContext({ root: rootForContext, isSandbox: true });
   }
@@ -358,8 +368,9 @@ export const runVerify = async (options: VerifyOptions): Promise<void> => {
       process.exitCode = 1;
     }
   } finally {
-    // Always lift the sandbox boundary we may have installed for --root.
-    if (rootForContext) resetWriteContext();
+    // Restore the prior boundary we may have overridden for --root (don't blind
+    // reset → null, which would drop a global sandbox in long-running mode).
+    if (rootForContext) restoreWriteContext(prevContext);
   }
 };
 

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -12,12 +12,24 @@
  *   tuck verify --fix           # re-copy missing repo copies from the live file
  */
 import { Command } from 'commander';
+import { resolve, dirname } from 'path';
+import { readFile, writeFile } from 'fs/promises';
+import { ensureDir } from 'fs-extra';
 import { logger, colors as c } from '../ui/index.js';
-import { getTuckDir, expandPath, collapsePath, getSafeRepoPathFromDestination } from '../lib/paths.js';
+import {
+  getTuckDir,
+  expandPath,
+  collapsePath,
+  getSafeRepoPathFromDestination,
+  pathExists,
+} from '../lib/paths.js';
 import { loadManifest } from '../lib/manifest.js';
-import { copyFileOrDir } from '../lib/files.js';
+import { copyFileOrDir, getFileChecksum } from '../lib/files.js';
 import { NotInitializedError } from '../errors.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { setWriteContext, resetWriteContext, resolveWriteTarget } from '../lib/writeContext.js';
+import { smartMerge, isShellFile, type MergeConflict } from '../lib/merge.js';
+import { prepareFilesToApply } from './apply.js';
 import {
   computeStateModel,
   summarizeStateModel,
@@ -29,6 +41,43 @@ export interface VerifyOptions {
   json?: boolean;
   exitCode?: boolean;
   fix?: boolean;
+  /**
+   * Confine all write/preview targets under this directory (a "dry home"). Read
+   * comparisons still use the real home; only the would-be write target routes
+   * through resolveWriteTarget so the preview cannot mutate the operator's real ~.
+   */
+  root?: string;
+  /**
+   * Dry-apply diff mode: run the apply prepare pipeline into the sandbox and
+   * report, per file, whether the live target would be created/modified/
+   * unchanged — plus smart-merge conflicts and any path that would escape root.
+   */
+  apply?: boolean;
+  /** Scope the dry-apply to a single bundle. */
+  bundle?: string;
+}
+
+/** A single would-be change produced by `verify --apply`. */
+export interface DryApplyChange {
+  /** The resolved (sandbox-confined) write target. */
+  target: string;
+  status: 'created' | 'modified' | 'unchanged';
+  /** Bytes of the existing LIVE target (0 when it does not exist). */
+  bytesBefore: number;
+  /** Bytes of the content apply WOULD write. */
+  bytesAfter: number;
+}
+
+export interface DryApplyConflict extends MergeConflict {
+  /** The live target the conflict was detected against. */
+  target: string;
+}
+
+export interface DryApplyResult {
+  changes: DryApplyChange[];
+  conflicts: DryApplyConflict[];
+  /** Sources whose would-be write target escapes the sandbox root (wrote nothing). */
+  wouldEscapeRoot: string[];
 }
 
 /** Any non-`ok` file means the working set has drifted. */
@@ -60,7 +109,106 @@ const fixMissingRepo = async (tuckDir: string, entries: FileStateEntry[]): Promi
   return fixed;
 };
 
-export const runVerify = async (options: VerifyOptions): Promise<void> => {
+/**
+ * Dry-apply the local tuck repo into the sandbox `root` and diff each produced
+ * file against the would-be LIVE target.
+ *
+ * - The prepare pipeline (`prepareFilesToApply`) is reused verbatim so the file
+ *   set, repo copies, and live-target resolution match a real `tuck apply`.
+ * - Writes route through `resolveWriteTarget`, confining every target under the
+ *   sandbox root; a target that escapes is reported in `wouldEscapeRoot` and
+ *   NOTHING is written for it.
+ * - Manifest entries that prepare drops as unsafe (traversal / out-of-home
+ *   sources) are surfaced in `wouldEscapeRoot` rather than silently discarded.
+ * - smartMerge CONFLICTS (which a plain apply detects then throws away) are
+ *   collected and returned.
+ * - Status is derived by comparing the live target's checksum to the checksum of
+ *   the content that WOULD be written (reusing `getFileChecksum`, not a private
+ *   hash). The live read uses the REAL home; the write stays in the sandbox.
+ */
+const dryApplyIntoSandbox = async (
+  tuckDir: string,
+  bundle?: string
+): Promise<DryApplyResult> => {
+  const manifest = await loadManifest(tuckDir);
+  const { files } = await prepareFilesToApply(tuckDir, manifest, bundle);
+
+  // Sources prepare KEPT — anything in the manifest with a real repo copy that
+  // is NOT in this set was dropped (unsafe/escaping) and must be surfaced.
+  const keptSources = new Set(files.map((f) => f.source));
+  const wouldEscapeRoot: string[] = [];
+  for (const file of Object.values(manifest.files)) {
+    if (keptSources.has(file.source)) continue;
+    const repoAbs = resolve(tuckDir, file.destination);
+    // Only count entries whose repo copy actually exists (a real apply candidate);
+    // a missing repo copy would be skipped by apply anyway, not an escape.
+    if (await pathExists(repoAbs)) {
+      wouldEscapeRoot.push(file.source);
+    }
+  }
+
+  const changes: DryApplyChange[] = [];
+  const conflicts: DryApplyConflict[] = [];
+
+  for (const file of files) {
+    // Read side uses the REAL live target (real home), never the sandbox.
+    const liveExists = await pathExists(file.destination);
+
+    // Determine the content apply WOULD write: smart-merged for shell files with
+    // an existing live copy (and surface the conflicts apply discards), else the
+    // verbatim repo copy.
+    let content = await readFile(file.repoPath, 'utf-8');
+    if (isShellFile(file.source) && liveExists) {
+      const merge = await smartMerge(file.destination, content);
+      content = merge.content;
+      for (const conflict of merge.conflicts) {
+        conflicts.push({ ...conflict, target: collapsePath(file.destination) });
+      }
+    }
+
+    // Resolve + confine the write target. An escape (traversal / out-of-sandbox
+    // absolute) throws → report it and write NOTHING.
+    let writeTarget: string;
+    try {
+      writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+    } catch {
+      wouldEscapeRoot.push(file.source);
+      continue;
+    }
+
+    await ensureDir(dirname(writeTarget));
+    await writeFile(writeTarget, content, 'utf-8');
+
+    const bytesAfter = Buffer.byteLength(content, 'utf-8');
+    let bytesBefore = 0;
+    let status: DryApplyChange['status'];
+    if (!liveExists) {
+      status = 'created';
+    } else {
+      const liveContent = await readFile(file.destination, 'utf-8');
+      bytesBefore = Buffer.byteLength(liveContent, 'utf-8');
+      // Compare via getFileChecksum (the project's canonical digest) — the live
+      // file vs the freshly-written sandbox copy. No private hashing here.
+      const [liveSum, sandboxSum] = await Promise.all([
+        getFileChecksum(file.destination),
+        getFileChecksum(writeTarget),
+      ]);
+      status = liveSum === sandboxSum ? 'unchanged' : 'modified';
+    }
+
+    changes.push({ target: writeTarget, status, bytesBefore, bytesAfter });
+  }
+
+  return { changes, conflicts, wouldEscapeRoot };
+};
+
+/**
+ * `verify --apply`: emit the dry-apply diff envelope. Always runs against a
+ * sandbox root (explicit `--root`, else an internal temp dir under the tuck
+ * runtime area) and cleans up the sandbox afterwards. Never writes to the real
+ * home — the live comparison is read-only.
+ */
+const runVerifyApply = async (options: VerifyOptions): Promise<void> => {
   if (options.json) setJsonMode(true, 'tuck verify');
   const tuckDir = getTuckDir();
 
@@ -70,55 +218,148 @@ export const runVerify = async (options: VerifyOptions): Promise<void> => {
     throw new NotInitializedError();
   }
 
-  let entries = await computeStateModel(tuckDir);
-  let fixed: string[] = [];
+  // The sandbox root: an explicit --root (resolved) or an internal scratch dir.
+  const sandboxRoot = options.root
+    ? resolve(expandPath(options.root))
+    : resolve(tuckDir, '.verify-sandbox', `dry-${Date.now()}`);
+  const usingTempSandbox = !options.root;
 
-  if (options.fix) {
-    fixed = await fixMissingRepo(tuckDir, entries);
-    if (fixed.length > 0) entries = await computeStateModel(tuckDir);
-  }
+  // Confine ALL writes under the sandbox for the duration of the dry-apply.
+  setWriteContext({ root: sandboxRoot, isSandbox: true });
+  try {
+    await ensureDir(sandboxRoot);
+    const result = await dryApplyIntoSandbox(tuckDir, options.bundle);
 
-  const summary = summarizeStateModel(entries);
-
-  if (isJsonMode()) {
-    emitJsonOk(
-      {
-        summary,
-        fixed,
-        files: entries.map((e) => ({
-          source: e.source,
-          state: e.state,
-          liveChecksum: e.liveChecksum,
-          repoChecksum: e.repoChecksum,
-          manifestChecksum: e.manifestChecksum,
-        })),
-      },
-      'tuck verify'
-    );
-  } else {
-    logger.heading('Verifying tracked files:');
-    for (const e of entries) {
-      const label = STATE_LABEL[e.state];
-      const line = `  ${collapsePath(e.source)} — ${label}`;
-      if (e.state === 'ok') logger.dim(line);
-      else logger.warning(line);
+    if (isJsonMode()) {
+      emitJsonOk(
+        {
+          root: sandboxRoot,
+          changes: result.changes,
+          conflicts: result.conflicts,
+          wouldEscapeRoot: result.wouldEscapeRoot,
+        },
+        'tuck verify'
+      );
+    } else {
+      logger.heading('Dry-apply preview (no real files touched):');
+      for (const ch of result.changes) {
+        const line = `${collapsePath(ch.target)} — ${ch.status} (${ch.bytesBefore} → ${ch.bytesAfter} bytes)`;
+        if (ch.status === 'unchanged') {
+          logger.dim(`  ${line}`);
+        } else {
+          logger.file(ch.status === 'created' ? 'add' : 'modify', line);
+        }
+      }
+      if (result.conflicts.length > 0) {
+        logger.blank();
+        logger.warning(`${result.conflicts.length} smart-merge conflict(s):`);
+        for (const cf of result.conflicts) {
+          logger.warning(`  ${cf.target}: ${cf.type} ${cf.name}`);
+        }
+      }
+      if (result.wouldEscapeRoot.length > 0) {
+        logger.blank();
+        logger.error(`${result.wouldEscapeRoot.length} entry(ies) would escape the sandbox root:`);
+        for (const src of result.wouldEscapeRoot) logger.error(`  ${src} (skipped, wrote nothing)`);
+      }
     }
-    if (fixed.length > 0) logger.info(`Fixed ${fixed.length} missing repo copy(ies).`);
-    logger.blank();
-    logger.info(
-      `${summary.ok}/${summary.total} ok` +
-        (hasDrift(summary)
-          ? c.warning(
-              ` — ${summary.driftLocal} local, ${summary.driftRepo} repo, ${
-                summary.missingLive + summary.missingRepo + summary.missingBoth
-              } missing`
-            )
-          : '')
-    );
+
+    if (options.exitCode && (result.conflicts.length > 0 || result.wouldEscapeRoot.length > 0)) {
+      process.exitCode = 1;
+    }
+  } finally {
+    // Reset the write boundary and always clean up the scratch sandbox. An
+    // explicit --root provided by the caller is left in place for inspection.
+    resetWriteContext();
+    if (usingTempSandbox) {
+      try {
+        const { rm } = await import('fs/promises');
+        await rm(sandboxRoot, { recursive: true, force: true });
+      } catch {
+        // Cleanup is best-effort; never fail a read-only preview over it.
+      }
+    }
+  }
+};
+
+export const runVerify = async (options: VerifyOptions): Promise<void> => {
+  // Dry-apply diff mode is a distinct, sandboxed pipeline.
+  if (options.apply) {
+    await runVerifyApply(options);
+    return;
   }
 
-  if (options.exitCode && hasDrift(summary)) {
-    process.exitCode = 1;
+  if (options.json) setJsonMode(true, 'tuck verify');
+  const tuckDir = getTuckDir();
+
+  // --root (without --apply): confine the read-only verify's preview targets to a
+  // dry home. The live comparison still reads the real home; only resolveWriteTarget
+  // (used by --fix's repo writes stay inside the repo) routes through the sandbox.
+  const rootForContext = options.root ? resolve(expandPath(options.root)) : undefined;
+  if (rootForContext) {
+    setWriteContext({ root: rootForContext, isSandbox: true });
+  }
+
+  try {
+    try {
+      await loadManifest(tuckDir);
+    } catch {
+      throw new NotInitializedError();
+    }
+
+    let entries = await computeStateModel(tuckDir);
+    let fixed: string[] = [];
+
+    if (options.fix) {
+      fixed = await fixMissingRepo(tuckDir, entries);
+      if (fixed.length > 0) entries = await computeStateModel(tuckDir);
+    }
+
+    const summary = summarizeStateModel(entries);
+
+    if (isJsonMode()) {
+      emitJsonOk(
+        {
+          summary,
+          fixed,
+          files: entries.map((e) => ({
+            source: e.source,
+            state: e.state,
+            liveChecksum: e.liveChecksum,
+            repoChecksum: e.repoChecksum,
+            manifestChecksum: e.manifestChecksum,
+          })),
+        },
+        'tuck verify'
+      );
+    } else {
+      logger.heading('Verifying tracked files:');
+      for (const e of entries) {
+        const label = STATE_LABEL[e.state];
+        const line = `  ${collapsePath(e.source)} — ${label}`;
+        if (e.state === 'ok') logger.dim(line);
+        else logger.warning(line);
+      }
+      if (fixed.length > 0) logger.info(`Fixed ${fixed.length} missing repo copy(ies).`);
+      logger.blank();
+      logger.info(
+        `${summary.ok}/${summary.total} ok` +
+          (hasDrift(summary)
+            ? c.warning(
+                ` — ${summary.driftLocal} local, ${summary.driftRepo} repo, ${
+                  summary.missingLive + summary.missingRepo + summary.missingBoth
+                } missing`
+              )
+            : '')
+      );
+    }
+
+    if (options.exitCode && hasDrift(summary)) {
+      process.exitCode = 1;
+    }
+  } finally {
+    // Always lift the sandbox boundary we may have installed for --root.
+    if (rootForContext) resetWriteContext();
   }
 };
 
@@ -127,6 +368,12 @@ export const verifyCommand = new Command('verify')
   .option('--json', 'Emit JSON envelope to stdout')
   .option('--exit-code', 'Exit non-zero if anything has drifted (CI gate)')
   .option('--fix', 'Re-copy missing repo copies from the live file (safe fixes only)')
+  .option(
+    '--root <dir>',
+    'Confine write/preview targets under this directory (sandbox / dry-home preview)'
+  )
+  .option('--apply', 'Dry-apply diff: preview created/modified/unchanged, conflicts, and escapes')
+  .option('-b, --bundle <name>', 'Scope --apply to a single bundle')
   .action(async (options: VerifyOptions) => {
     await runVerify(options);
   });

--- a/src/lib/crypto/keystore/fallback.ts
+++ b/src/lib/crypto/keystore/fallback.ts
@@ -4,7 +4,8 @@
  */
 
 import { readFile, writeFile, chmod, rm } from 'fs/promises';
-import { dirname } from 'path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
+import { dirname, join } from 'path';
 import { homedir, hostname, userInfo } from 'os';
 import { createHash, createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { ensureDir, pathExists } from 'fs-extra';
@@ -12,6 +13,43 @@ import type { Keystore } from './types.js';
 import { getFallbackKeystorePath, getLegacyFallbackKeystorePath } from '../../state.js';
 
 const ALGORITHM = 'aes-256-gcm';
+const INSTALL_SECRET_BYTES = 32;
+
+/**
+ * Path to the per-install random secret. Lives under the user's tuck dir so it
+ * is created once per machine/install and reused thereafter.
+ */
+const getInstallSecretPath = (): string => join(homedir(), '.tuck', 'keystore.key');
+
+/**
+ * Read (or create on first run) the per-install random secret. Mixing this
+ * 32-byte random value into the key derivation means the fallback keystore file
+ * is no longer derivable from machine info alone — an attacker also needs the
+ * locally-stored, 0600 secret. Synchronous so it can feed the sync getMachineKey.
+ */
+const readOrCreateInstallSecret = (): Buffer => {
+  const secretPath = getInstallSecretPath();
+
+  if (existsSync(secretPath)) {
+    const existing = readFileSync(secretPath);
+    if (existing.length === INSTALL_SECRET_BYTES) {
+      return existing;
+    }
+    // Corrupt/short secret: fall through and regenerate. Rotating it only
+    // invalidates the local encrypted keystore (re-derivable on next store).
+  }
+
+  const secret = randomBytes(INSTALL_SECRET_BYTES);
+  mkdirSync(dirname(secretPath), { recursive: true });
+  writeFileSync(secretPath, secret);
+  // Restrict to owner only (best-effort on platforms without POSIX perms).
+  try {
+    chmodSync(secretPath, 0o600);
+  } catch {
+    // Ignore on platforms that don't support chmod (e.g. Windows).
+  }
+  return secret;
+};
 
 interface KeystoreData {
   entries: Record<string, Record<string, string>>;
@@ -82,7 +120,35 @@ export class FallbackKeystore implements Keystore {
       'tuck-keystore-v1', // Version string for key derivation
     ].join(':');
 
-    // Use SHA-256 to get consistent 32-byte key
+    // Mix in a per-install random 32-byte secret (persisted 0600 on first run)
+    // so the key isn't derivable from machine info alone. The HMAC keyed by the
+    // secret binds the deterministic factors to this specific install.
+    const installSecret = readOrCreateInstallSecret();
+
+    return createHash('sha256')
+      .update(installSecret)
+      .update(':')
+      .update(factors)
+      .digest();
+  }
+
+  /**
+   * The pre-install-secret key derivation (deterministic machine factors only).
+   * Kept so a keystore file written BEFORE the per-install secret was introduced
+   * stays decryptable across the upgrade; the data is transparently re-encrypted
+   * with the current key on the next saveData() (migration). Without this,
+   * upgrading would silently orphan a user's stored secrets / backup-encryption
+   * password — a data-loss regression.
+   */
+  private getLegacyMachineKey(): Buffer {
+    const factors = [
+      hostname(),
+      userInfo().username,
+      homedir(),
+      process.platform,
+      'tuck-keystore-v1',
+    ].join(':');
+
     return createHash('sha256').update(factors).digest();
   }
 
@@ -92,14 +158,27 @@ export class FallbackKeystore implements Keystore {
       return { entries: {}, version: 1 };
     }
 
+    let encrypted: Buffer;
     try {
-      const encrypted = await readFile(loadPath);
-      const decrypted = this.decrypt(encrypted);
-      return JSON.parse(decrypted.toString('utf-8'));
+      encrypted = await readFile(loadPath);
     } catch {
-      // Corrupted or unreadable, start fresh
+      // Unreadable, start fresh
       return { entries: {}, version: 1 };
     }
+
+    // Try the current key first, then the legacy (pre-install-secret) key so a
+    // keystore written before this upgrade stays readable. A subsequent
+    // saveData() re-encrypts the whole file with the current key (migration).
+    for (const key of [this.getMachineKey(), this.getLegacyMachineKey()]) {
+      try {
+        const decrypted = this.decrypt(encrypted, key);
+        return JSON.parse(decrypted.toString('utf-8')) as KeystoreData;
+      } catch {
+        // Wrong key (or corrupt) — try the next candidate.
+      }
+    }
+    // Corrupted or undecryptable with any known key, start fresh.
+    return { entries: {}, version: 1 };
   }
 
   private async saveData(data: KeystoreData): Promise<void> {
@@ -140,9 +219,7 @@ export class FallbackKeystore implements Keystore {
     return Buffer.concat([iv, authTag, ciphertext]);
   }
 
-  private decrypt(encrypted: Buffer): Buffer {
-    const key = this.getMachineKey();
-
+  private decrypt(encrypted: Buffer, key: Buffer = this.getMachineKey()): Buffer {
     const iv = encrypted.subarray(0, 12);
     const authTag = encrypted.subarray(12, 28);
     const ciphertext = encrypted.subarray(28);

--- a/src/lib/crypto/keystore/fallback.ts
+++ b/src/lib/crypto/keystore/fallback.ts
@@ -4,7 +4,18 @@
  */
 
 import { readFile, writeFile, chmod, rm } from 'fs/promises';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+  renameSync,
+  openSync,
+  writeSync,
+  closeSync,
+  constants as fsConstants,
+} from 'fs';
 import { dirname, join } from 'path';
 import { homedir, hostname, userInfo } from 'os';
 import { createHash, createCipheriv, createDecipheriv, randomBytes } from 'crypto';
@@ -35,20 +46,50 @@ const readOrCreateInstallSecret = (): Buffer => {
     if (existing.length === INSTALL_SECRET_BYTES) {
       return existing;
     }
-    // Corrupt/short secret: fall through and regenerate. Rotating it only
-    // invalidates the local encrypted keystore (re-derivable on next store).
+    // Corrupt/short secret. Rotating it loses any data encrypted with it, so
+    // preserve the old value (best-effort) for manual recovery before replacing.
+    try {
+      renameSync(secretPath, `${secretPath}.corrupt`);
+    } catch {
+      // Couldn't move it aside; the exclusive create below will fail and we
+      // fall back to an overwrite as a last resort.
+    }
   }
 
-  const secret = randomBytes(INSTALL_SECRET_BYTES);
   mkdirSync(dirname(secretPath), { recursive: true });
-  writeFileSync(secretPath, secret);
-  // Restrict to owner only (best-effort on platforms without POSIX perms).
+  const secret = randomBytes(INSTALL_SECRET_BYTES);
+
+  // Atomic create-exclusive (mode 0600) so two processes starting at once can't
+  // each write a DIFFERENT secret and silently orphan one another's encrypted
+  // data. The loser of the race adopts the winner's secret instead.
   try {
-    chmodSync(secretPath, 0o600);
-  } catch {
-    // Ignore on platforms that don't support chmod (e.g. Windows).
+    const fd = openSync(
+      secretPath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+      0o600
+    );
+    try {
+      writeSync(fd, secret);
+    } finally {
+      closeSync(fd);
+    }
+    return secret;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      const existing = readFileSync(secretPath);
+      if (existing.length === INSTALL_SECRET_BYTES) {
+        return existing;
+      }
+    }
+    // Last resort (e.g. a filesystem without O_EXCL semantics): best-effort write.
+    writeFileSync(secretPath, secret);
+    try {
+      chmodSync(secretPath, 0o600);
+    } catch {
+      // Ignore on platforms that don't support chmod (e.g. Windows).
+    }
+    return secret;
   }
-  return secret;
 };
 
 interface KeystoreData {

--- a/src/lib/crypto/keystore/index.ts
+++ b/src/lib/crypto/keystore/index.ts
@@ -38,12 +38,15 @@ export const getKeystore = async (): Promise<Keystore> => {
       return linux;
     }
   } else if (platform === 'win32') {
+    // Windows uses the encrypted fallback file keystore by design. The Windows
+    // Credential Manager (cmdkey) can store credentials but cannot retrieve
+    // passwords programmatically, so WindowsKeystore.isAvailable() always returns
+    // false and we fall through to the fallback below — which supports the full
+    // store/retrieve/delete cycle and encrypts secrets at rest.
     const windows = new WindowsKeystore();
-    // Windows keystore can't retrieve passwords, so we skip it
-    // and go straight to fallback
     if (await windows.isAvailable()) {
-      // Only use for store/delete, not retrieve
-      // Actually, just use fallback for consistency
+      cachedKeystore = windows;
+      return windows;
     }
   }
 

--- a/src/lib/crypto/keystore/linux.ts
+++ b/src/lib/crypto/keystore/linux.ts
@@ -38,10 +38,21 @@ export class LinuxKeystore implements Keystore {
   async isAvailable(): Promise<boolean> {
     if (process.platform !== 'linux') return false;
 
+    // A session D-Bus is required to reach the Secret Service. Headless servers,
+    // bare WSL, and many CI/container environments have `secret-tool` installed
+    // but no running session bus, so a probe would hang or fail. Bail early so
+    // the caller falls back to the encrypted file keystore.
+    if (!process.env.DBUS_SESSION_BUS_ADDRESS) {
+      return false;
+    }
+
     try {
-      await execFileAsync('which', ['secret-tool']);
+      // Confirm the binary exists. Bounded timeout so a wedged environment can't
+      // hang keystore selection.
+      await execFileAsync('which', ['secret-tool'], { timeout: 5000 });
       return true;
     } catch {
+      // On any failure the caller must fall back to the file keystore.
       return false;
     }
   }

--- a/src/lib/crypto/keystore/linux.ts
+++ b/src/lib/crypto/keystore/linux.ts
@@ -5,9 +5,25 @@
 
 import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import type { Keystore } from './types.js';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Whether a session D-Bus (required to reach the Secret Service) is reachable.
+ * Accepts either the exported address OR the well-known systemd user-session bus
+ * socket at `$XDG_RUNTIME_DIR/bus` — the latter handles desktop/systemd sessions
+ * that don't export DBUS_SESSION_BUS_ADDRESS into this process's env, so an
+ * existing keyring user isn't silently downgraded to the file keystore.
+ */
+function hasSessionBus(): boolean {
+  if (process.env.DBUS_SESSION_BUS_ADDRESS) return true;
+  const xdg = process.env.XDG_RUNTIME_DIR;
+  if (xdg && existsSync(join(xdg, 'bus'))) return true;
+  return false;
+}
 
 /**
  * Validate that an argument doesn't contain dangerous characters.
@@ -42,7 +58,7 @@ export class LinuxKeystore implements Keystore {
     // bare WSL, and many CI/container environments have `secret-tool` installed
     // but no running session bus, so a probe would hang or fail. Bail early so
     // the caller falls back to the encrypted file keystore.
-    if (!process.env.DBUS_SESSION_BUS_ADDRESS) {
+    if (!hasSessionBus()) {
       return false;
     }
 

--- a/src/lib/crypto/keystore/windows.ts
+++ b/src/lib/crypto/keystore/windows.ts
@@ -46,15 +46,12 @@ export class WindowsKeystore implements Keystore {
   }
 
   async isAvailable(): Promise<boolean> {
-    if (process.platform !== 'win32') return false;
-
-    try {
-      // Check if cmdkey is available (should be on all Windows versions)
-      await execFileAsync('where', ['cmdkey'], { timeout: 5000 });
-      return true;
-    } catch {
-      return false;
-    }
+    // Intentionally always false: while `cmdkey` can *store* credentials, it
+    // cannot retrieve passwords programmatically (see retrieve() below), so a
+    // store-without-retrieve keystore is worse than not storing at all. Reporting
+    // unavailable makes tuck cleanly fall back to the encrypted file keystore,
+    // which supports the full store/retrieve/delete cycle on Windows.
+    return false;
   }
 
   async store(service: string, account: string, secret: string): Promise<void> {

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -26,8 +26,17 @@ import {
   validateSafeManifestDestination,
   validateSafeSourcePath,
 } from './paths.js';
+import { isSandbox, getWriteRoot } from './writeContext.js';
+import { platform } from 'os';
 
-export const DOCTOR_CATEGORIES = ['env', 'repo', 'manifest', 'security', 'hooks'] as const;
+export const DOCTOR_CATEGORIES = [
+  'env',
+  'repo',
+  'manifest',
+  'security',
+  'hooks',
+  'sandboxing',
+] as const;
 
 export type DoctorCategory = (typeof DOCTOR_CATEGORIES)[number];
 export type DoctorStatus = 'pass' | 'warn' | 'fail';
@@ -812,6 +821,84 @@ const checkHooksSafety: DoctorCheck = {
   },
 };
 
+/**
+ * OS-level sandbox wrapper recipes (audit §3.3). tuck's own `--root`
+ * confinement is a software boundary; for stronger isolation an agent runner
+ * should ALSO wrap the whole `tuck` invocation in an OS sandbox. We surface
+ * copy-pasteable recipes for the platforms tuck targets so an operator can pick
+ * the appropriate one without leaving the tool.
+ */
+const SANDBOX_RECIPES: Record<string, string> = {
+  // macOS: Apple's seatbelt. Confine writes to a single scratch directory.
+  'macOS sandbox-exec (.sb profile)':
+    'sandbox-exec -p \'(version 1)(deny default)(allow process*)(allow file-read*)' +
+    '(allow file-write* (subpath "/tmp/tuck-sandbox"))\' tuck apply <src> --root /tmp/tuck-sandbox',
+  // Linux: bubblewrap — bind a tmpfs over $HOME and a writable sandbox dir.
+  'Linux bubblewrap (bwrap)':
+    'bwrap --ro-bind / / --tmpfs /tmp --bind /tmp/tuck-sandbox /tmp/tuck-sandbox ' +
+    '--unshare-net tuck apply <src> --root /tmp/tuck-sandbox',
+  // Linux: Landlock LSM (kernel >= 5.13) — restrict the filesystem hierarchy a
+  // process may touch; pair with a small launcher that adds a write rule for the
+  // sandbox dir only. (No setuid required.)
+  'Linux Landlock (LSM, kernel >= 5.13)':
+    'Use a Landlock launcher granting LANDLOCK_ACCESS_FS_WRITE_FILE only under ' +
+    '/tmp/tuck-sandbox, then exec: tuck apply <src> --root /tmp/tuck-sandbox',
+  // Container: the strongest, fully disposable boundary.
+  'Container / docker':
+    'docker run --rm -v "$PWD/sandbox:/sandbox" -e TUCK_TARGET_ROOT=/sandbox ' +
+    'node:20 npx tuck apply <src>',
+};
+
+const checkSandboxRecipes: DoctorCheck = {
+  id: 'sandboxing.os-wrappers',
+  category: 'sandboxing',
+  run: async () => {
+    const recipeLines = Object.entries(SANDBOX_RECIPES).map(
+      ([name, cmd]) => `${name}: ${cmd}`
+    );
+    return {
+      id: 'sandboxing.os-wrappers',
+      category: 'sandboxing',
+      // Mention every wrapper in the message so it is greppable even without details.
+      message:
+        'OS-level sandbox wrappers available: macOS sandbox-exec, Linux bubblewrap (bwrap), ' +
+        'Linux Landlock, and container/docker (audit §3.3)',
+      status: 'pass',
+      details: recipeLines.join(' | '),
+      fix: 'Wrap `tuck apply/restore` in one of these OS sandboxes for defense-in-depth alongside `--root`',
+    };
+  },
+};
+
+const checkRootConfinement: DoctorCheck = {
+  id: 'sandboxing.root-confinement',
+  category: 'sandboxing',
+  run: async () => {
+    // `--root`/TUCK_TARGET_ROOT confinement is always compiled in. When a sandbox
+    // is actively engaged we surface the live root so the operator can confirm it.
+    if (isSandbox()) {
+      return {
+        id: 'sandboxing.root-confinement',
+        category: 'sandboxing',
+        status: 'pass',
+        message: `--root write confinement is ACTIVE (sandbox engaged on ${platform()})`,
+        details: `All writes are confined under: ${collapsePath(getWriteRoot())}`,
+      };
+    }
+
+    return {
+      id: 'sandboxing.root-confinement',
+      category: 'sandboxing',
+      status: 'pass',
+      message: '--root write confinement is available (pass `--root <dir>` or set TUCK_TARGET_ROOT)',
+      details:
+        'Run any mutating command with `--root <dir>` to confine every write under a dry home; ' +
+        'reads still use the real ~. Combine with `tuck verify --apply --root <dir>` for a safe preview.',
+      fix: 'For untrusted/agent-driven runs, always pass `--root <dir>` (and ideally an OS sandbox wrapper)',
+    };
+  },
+};
+
 const doctorChecks: DoctorCheck[] = [
   checkNodeVersion,
   checkHomeDirectory,
@@ -831,6 +918,8 @@ const doctorChecks: DoctorCheck[] = [
   checkFallbackKeystoreUsage,
   checkUnsupportedReservedConfig,
   checkHooksSafety,
+  checkSandboxRecipes,
+  checkRootConfinement,
 ];
 
 const buildDoctorSummary = (checks: DoctorCheckResult[]): DoctorSummary => {

--- a/src/lib/writeContext.ts
+++ b/src/lib/writeContext.ts
@@ -41,6 +41,30 @@ export const resetWriteContext = (): void => {
   knownRepoRoots = [];
 };
 
+/** A captured write-context state for save/restore around a transient override. */
+export interface WriteContextSnapshot {
+  ctx: WriteContext | null;
+  repoRoots: string[];
+}
+
+/**
+ * Capture the full write-context state so a transient override (e.g. a sandboxed
+ * dry-apply) can restore the PRIOR state afterward instead of nuking it —
+ * preserving any global `--root` boundary set by the CLI preAction hook. A
+ * blind resetWriteContext() in a long-running process (MCP) would otherwise drop
+ * the sandbox and let subsequent commands write to the real home.
+ */
+export const snapshotWriteContext = (): WriteContextSnapshot => ({
+  ctx: ctx ? { ...ctx } : null,
+  repoRoots: [...knownRepoRoots],
+});
+
+/** Restore a previously captured write-context state. */
+export const restoreWriteContext = (snap: WriteContextSnapshot): void => {
+  ctx = snap.ctx ? { ...snap.ctx } : null;
+  knownRepoRoots = [...snap.repoRoots];
+};
+
 /** The directory all writes are confined to (real home unless sandboxed). */
 export const getWriteRoot = (): string => (ctx ? ctx.root : homedir());
 

--- a/src/ui/merge.ts
+++ b/src/ui/merge.ts
@@ -15,9 +15,17 @@ import { spawn } from 'child_process';
 import boxen from 'boxen';
 import { prompts } from './prompts.js';
 import { colors as c } from './theme.js';
+import { IS_WINDOWS } from '../lib/platform.js';
 import type { FileConflict, ConflictResolution } from '../lib/mergeConflicts.js';
 
 const MAX_PREVIEW_LINES = 20;
+
+/**
+ * Resolve the editor used for manual conflict resolution. Honors $EDITOR then
+ * $VISUAL, falling back to a platform default (Windows ships notepad, not vi).
+ */
+export const getDefaultEditor = (): string =>
+  process.env.EDITOR || process.env.VISUAL || (IS_WINDOWS ? 'notepad' : 'vi');
 
 /**
  * Build a compact side-by-side preview of the conflict for the terminal.
@@ -64,7 +72,7 @@ const truncate = (content: string, maxLines: number): string => {
  * back when the editor exits.
  */
 const editInEditor = async (conflict: FileConflict): Promise<string> => {
-  const editor = process.env.EDITOR || process.env.VISUAL || 'vi';
+  const editor = getDefaultEditor();
   const tmpPath = join(
     tmpdir(),
     `tuck-merge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${sanitizeForFilename(conflict.path)}`
@@ -144,7 +152,7 @@ export const resolveConflictsInteractively = async (
       [
         { value: 'ours', label: 'Keep local (ours)', hint: 'discard remote changes for this file' },
         { value: 'theirs', label: 'Keep remote (theirs)', hint: 'discard local changes for this file' },
-        { value: 'edited', label: `Edit in $EDITOR (${process.env.EDITOR || 'vi'})`, hint: 'merge manually' },
+        { value: 'edited', label: `Edit in $EDITOR (${getDefaultEditor()})`, hint: 'merge manually' },
         { value: 'abort', label: 'Abort entire sync', hint: 'roll back the pull, no changes applied' },
       ]
     );

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -221,6 +221,60 @@ describe('add command behavior', () => {
     );
   });
 
+  it('runs the full prepare pipeline for --plan and reflects the detected category', async () => {
+    // detectCategory returns 'shell' from beforeEach; the plan must surface the
+    // detected category, not the (undefined) raw --category input.
+    const { addCommand } = await import('../../src/commands/add.js');
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    await addCommand.parseAsync(['~/.zshrc', '--json', '--plan'], { from: 'user' });
+
+    writeSpy.mockRestore();
+
+    const lines = writes.join('').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(1);
+
+    const env = JSON.parse(lines[0]);
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck add');
+
+    // The plan runs the REAL pipeline: category detection + secret scan ran.
+    expect(detectCategoryMock).toHaveBeenCalled();
+    expect(scanForSecretsMock).toHaveBeenCalled();
+
+    // Plan entry mirrors a prepared entry (detected category 'shell'), not raw input.
+    expect(env.data.plan).toHaveLength(1);
+    expect(env.data.plan[0]).toMatchObject({
+      source: '~/.zshrc',
+      category: 'shell',
+      sensitive: false,
+    });
+
+    // --plan is dry: nothing is tracked.
+    expect(trackFilesWithProgressMock).not.toHaveBeenCalled();
+  });
+
+  it('does not write or scan a second time on --plan (dry run)', async () => {
+    const { addCommand } = await import('../../src/commands/add.js');
+
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await addCommand.parseAsync(['~/.zshrc', '--json', '--plan'], { from: 'user' });
+
+    writeSpy.mockRestore();
+
+    expect(trackFilesWithProgressMock).not.toHaveBeenCalled();
+  });
+
   it('passes custom --name through to tracking destination generation', async () => {
     const { addFilesFromPaths } = await import('../../src/commands/add.js');
     sanitizeFilenameMock.mockReturnValueOnce('custom-zshrc');

--- a/tests/commands/configEditorDefault.test.ts
+++ b/tests/commands/configEditorDefault.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// These tests verify the platform-aware default editor used when neither
+// $EDITOR nor $VISUAL is set. We toggle the mocked IS_WINDOWS flag and
+// re-import the modules so each picks up the right platform constant.
+
+const ORIGINAL_EDITOR = process.env.EDITOR;
+const ORIGINAL_VISUAL = process.env.VISUAL;
+
+const clearEditorEnv = (): void => {
+  delete process.env.EDITOR;
+  delete process.env.VISUAL;
+};
+
+const restoreEditorEnv = (): void => {
+  if (ORIGINAL_EDITOR === undefined) delete process.env.EDITOR;
+  else process.env.EDITOR = ORIGINAL_EDITOR;
+  if (ORIGINAL_VISUAL === undefined) delete process.env.VISUAL;
+  else process.env.VISUAL = ORIGINAL_VISUAL;
+};
+
+describe('default editor (platform-aware)', () => {
+  beforeEach(() => {
+    clearEditorEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEditorEnv();
+    vi.resetModules();
+    vi.doUnmock('../../src/lib/platform.js');
+  });
+
+  it('config.ts defaults to notepad on Windows, vim elsewhere', async () => {
+    vi.doMock('../../src/lib/platform.js', () => ({ IS_WINDOWS: true }));
+    const winMod = await import('../../src/commands/config.js');
+    expect(winMod.getDefaultEditor()).toBe('notepad');
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/platform.js', () => ({ IS_WINDOWS: false }));
+    const nixMod = await import('../../src/commands/config.js');
+    expect(nixMod.getDefaultEditor()).toBe('vim');
+  });
+
+  it('config.ts respects $EDITOR when set', async () => {
+    process.env.EDITOR = 'nano';
+    vi.doMock('../../src/lib/platform.js', () => ({ IS_WINDOWS: true }));
+    const mod = await import('../../src/commands/config.js');
+    expect(mod.getDefaultEditor()).toBe('nano');
+  });
+
+  it('ui/merge.ts defaults to notepad on Windows, vi elsewhere', async () => {
+    vi.doMock('../../src/lib/platform.js', () => ({ IS_WINDOWS: true }));
+    const winMod = await import('../../src/ui/merge.js');
+    expect(winMod.getDefaultEditor()).toBe('notepad');
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/platform.js', () => ({ IS_WINDOWS: false }));
+    const nixMod = await import('../../src/ui/merge.js');
+    expect(nixMod.getDefaultEditor()).toBe('vi');
+  });
+
+  it('ui/merge.ts respects $VISUAL when set', async () => {
+    process.env.VISUAL = 'code -w';
+    vi.doMock('../../src/lib/platform.js', () => ({ IS_WINDOWS: false }));
+    const mod = await import('../../src/ui/merge.js');
+    expect(mod.getDefaultEditor()).toBe('code -w');
+  });
+});

--- a/tests/commands/restore.test.ts
+++ b/tests/commands/restore.test.ts
@@ -146,6 +146,48 @@ describe('restore command behavior', () => {
     );
   });
 
+  it('surfaces skipped-file warnings in the JSON envelope.warnings', async () => {
+    // A tracked file whose repository copy is missing on disk triggers the
+    // "Source not found in repository" skip path. In JSON mode that human
+    // warning must also surface in envelope.warnings.
+    getTrackedFileBySourceMock.mockResolvedValue({
+      id: 'zshrc',
+      file: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        category: 'shell',
+      },
+    });
+    // Repository source does not exist -> the file is skipped with a warning.
+    pathExistsMock.mockResolvedValue(false);
+
+    const { runRestoreCommand } = await import('../../src/commands/restore.js');
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    await runRestoreCommand(['~/.zshrc'], { json: true, yes: true, noHooks: true });
+
+    writeSpy.mockRestore();
+
+    const lines = writes.join('').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(1);
+
+    const env = JSON.parse(lines[0]);
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck restore');
+    expect(Array.isArray(env.warnings)).toBe(true);
+    expect(env.warnings.length).toBeGreaterThan(0);
+    expect(env.warnings.some((w: string) => /source not found in repository/i.test(w))).toBe(true);
+    // Nothing was restored.
+    expect(env.data.restored).toBe(0);
+  });
+
   it('fails fast when manifest destination is unsafe', async () => {
     getAllTrackedFilesMock.mockResolvedValue({
       zshrc: {

--- a/tests/commands/secrets.test.ts
+++ b/tests/commands/secrets.test.ts
@@ -352,6 +352,155 @@ describe('secrets command', () => {
     expect(scanForSecretsMock).not.toHaveBeenCalled();
   });
 
+  const captureStdout = (): { writes: string[]; restore: () => void } => {
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+    return { writes, restore: () => writeSpy.mockRestore() };
+  };
+
+  const parseEnvelope = (writes: string[]) => {
+    const lines = writes.join('').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(1);
+    return JSON.parse(lines[0]);
+  };
+
+  it('emits a redacted JSON envelope for secrets list without leaking secret values', async () => {
+    const SECRET_VALUE = 'super-secret-token-value-xyz';
+    listSecretsMock.mockResolvedValue([
+      {
+        name: 'GITHUB_TOKEN',
+        placeholder: '{{GITHUB_TOKEN}}',
+        description: 'GitHub PAT',
+        source: '~/.netrc',
+        addedAt: '2024-01-01T00:00:00.000Z',
+        lastUsed: '2024-02-01T00:00:00.000Z',
+      },
+    ]);
+
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    const { writes, restore } = captureStdout();
+
+    await secretsCommand.parseAsync(['list', '--json'], { from: 'user' });
+
+    restore();
+    const env = parseEnvelope(writes);
+
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck secrets list');
+    expect(env.data.secrets).toEqual([
+      {
+        name: 'GITHUB_TOKEN',
+        placeholder: '{{GITHUB_TOKEN}}',
+        description: 'GitHub PAT',
+        source: '~/.netrc',
+        addedAt: '2024-01-01T00:00:00.000Z',
+        lastUsed: '2024-02-01T00:00:00.000Z',
+      },
+    ]);
+
+    // SECURITY: even though listSecrets never returns the raw value, assert the
+    // emitted envelope cannot contain a plaintext secret value.
+    expect(JSON.stringify(env)).not.toContain(SECRET_VALUE);
+  });
+
+  it('emits an empty redacted JSON envelope for secrets list when no secrets stored', async () => {
+    listSecretsMock.mockResolvedValue([]);
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    const { writes, restore } = captureStdout();
+
+    await secretsCommand.parseAsync(['list', '--json'], { from: 'user' });
+
+    restore();
+    const env = parseEnvelope(writes);
+
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck secrets list');
+    expect(env.data.secrets).toEqual([]);
+    // Human-readable output is suppressed in JSON mode.
+    expect(loggerInfoMock).not.toHaveBeenCalled();
+    expect(loggerDimMock).not.toHaveBeenCalled();
+  });
+
+  it('emits a JSON envelope for secrets unset and never echoes a value', async () => {
+    unsetSecretMock.mockResolvedValue(true);
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    const { writes, restore } = captureStdout();
+
+    await secretsCommand.parseAsync(['unset', 'GITHUB_TOKEN', '--json'], { from: 'user' });
+
+    restore();
+    const env = parseEnvelope(writes);
+
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck secrets unset');
+    expect(env.data).toEqual({ name: 'GITHUB_TOKEN', unset: true });
+    expect(loggerSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it('reports unset:false in JSON when the secret was not found', async () => {
+    unsetSecretMock.mockResolvedValue(false);
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    const { writes, restore } = captureStdout();
+
+    await secretsCommand.parseAsync(['unset', 'MISSING', '--json'], { from: 'user' });
+
+    restore();
+    const env = parseEnvelope(writes);
+
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck secrets unset');
+    expect(env.data).toEqual({ name: 'MISSING', unset: false });
+    expect(loggerWarningMock).not.toHaveBeenCalled();
+  });
+
+  it('emits a JSON envelope for secrets path', async () => {
+    getSecretsPathMock.mockReturnValue('/test-home/.tuck/secrets.local.json');
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    const { writes, restore } = captureStdout();
+
+    await secretsCommand.parseAsync(['path', '--json'], { from: 'user' });
+
+    restore();
+    const env = parseEnvelope(writes);
+
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck secrets path');
+    expect(env.data).toEqual({ path: '/test-home/.tuck/secrets.local.json' });
+  });
+
+  it('emits a JSON envelope for secrets set and never echoes the value', async () => {
+    const SECRET_VALUE = 'the-actual-secret-value-123';
+    // In --json/--yes mode the value must be supplied via env, never echoed.
+    process.env.TUCK_SECRET_VALUE = SECRET_VALUE;
+    setSecretMock.mockResolvedValue(undefined);
+
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    const { writes, restore } = captureStdout();
+
+    try {
+      await secretsCommand.parseAsync(['set', 'GITHUB_TOKEN', '--json', '--yes'], { from: 'user' });
+    } finally {
+      delete process.env.TUCK_SECRET_VALUE;
+    }
+
+    restore();
+    const env = parseEnvelope(writes);
+
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck secrets set');
+    expect(env.data).toEqual({ name: 'GITHUB_TOKEN', set: true });
+
+    // SECURITY: the plaintext value must never appear in the JSON envelope.
+    expect(JSON.stringify(env)).not.toContain(SECRET_VALUE);
+    // The value reaches the store but is never prompted for interactively.
+    expect(setSecretMock).toHaveBeenCalledWith('/test-home/.tuck', 'GITHUB_TOKEN', SECRET_VALUE);
+  });
+
   it('emits an all-zero redacted JSON summary (and no path leak) when no provided files exist', async () => {
     // Path that does not exist on disk -> existingPaths is empty.
     pathExistsMock.mockResolvedValue(false);

--- a/tests/commands/verify-sandbox.test.ts
+++ b/tests/commands/verify-sandbox.test.ts
@@ -37,7 +37,12 @@ vi.mock('../../src/ui/index.js', () => ({
 import { runVerify } from '../../src/commands/verify.js';
 import { clearManifestCache } from '../../src/lib/manifest.js';
 import { clearConfigCache } from '../../src/lib/config.js';
-import { resetWriteContext } from '../../src/lib/writeContext.js';
+import {
+  resetWriteContext,
+  setWriteContext,
+  getWriteRoot,
+  isSandbox,
+} from '../../src/lib/writeContext.js';
 
 const TUCK = '/test-home/.tuck';
 const SANDBOX = '/test-home/sandbox';
@@ -126,6 +131,30 @@ describe('verify --root / --apply', () => {
     expect(resolve(change.target).startsWith(resolve(SANDBOX))).toBe(true);
     // The real live home file was never created by the preview.
     expect(vol.existsSync('/test-home/.zshrc')).toBe(false);
+  });
+
+  it('restores a prior global sandbox boundary after --apply (does not nuke it)', async () => {
+    // Simulate a global --root installed by the CLI preAction hook — the danger
+    // case is long-running (MCP) mode, where a blind reset would drop the global
+    // sandbox and let later commands write to the real home.
+    const globalRoot = '/test-home/global-sandbox';
+    setWriteContext({ root: globalRoot, isSandbox: true });
+
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'export A=1\n');
+    writeManifestFiles({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        checksum: await checksum(`${TUCK}/files/shell/zshrc`),
+      },
+    });
+
+    // --apply with NO command-level --root → uses an internal temp sandbox, then
+    // must RESTORE the global boundary in its finally (not reset to null).
+    await runVerify({ json: true, apply: true });
+
+    expect(resolve(getWriteRoot())).toBe(resolve(globalRoot));
+    expect(isSandbox()).toBe(true);
   });
 
   it('classifies created / modified / unchanged correctly against the live target', async () => {

--- a/tests/commands/verify-sandbox.test.ts
+++ b/tests/commands/verify-sandbox.test.ts
@@ -1,0 +1,227 @@
+/**
+ * tuck verify sandbox tests — `--root` confinement and `--apply` dry-apply diff.
+ *
+ * These cover the "sandboxed preview" story: an agent must be able to preview
+ * what `tuck apply` WOULD do (created/modified/unchanged per file, smart-merge
+ * conflicts, and any path that would escape the sandbox) WITHOUT touching the
+ * operator's real ~. All writes are confined to a memfs sandbox root; the live
+ * comparison reads the real (memfs) home read-only.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { resolve } from 'path';
+
+// Mock the UI layer so logger.* (which prepareFilesToApply uses for skipped
+// entries) does not pollute stdout — the only thing we parse is the JSON
+// envelope emitted via process.stdout.write by emitJsonOk.
+vi.mock('../../src/ui/index.js', () => ({
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: vi.fn(),
+    dim: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: {
+    warning: (x: string) => x,
+    dim: (x: string) => x,
+    green: (x: string) => x,
+    yellow: (x: string) => x,
+  },
+}));
+
+import { runVerify } from '../../src/commands/verify.js';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { clearConfigCache } from '../../src/lib/config.js';
+import { resetWriteContext } from '../../src/lib/writeContext.js';
+
+const TUCK = '/test-home/.tuck';
+const SANDBOX = '/test-home/sandbox';
+
+interface ManifestFileInput {
+  source: string;
+  destination: string;
+  category?: string;
+  checksum: string;
+}
+
+const writeManifestFiles = (files: Record<string, ManifestFileInput>) => {
+  const fileEntries: Record<string, unknown> = {};
+  for (const [id, f] of Object.entries(files)) {
+    fileEntries[id] = {
+      source: f.source,
+      destination: f.destination,
+      category: f.category ?? 'shell',
+      strategy: 'copy',
+      checksum: f.checksum,
+      added: '2026-01-01T00:00:00.000Z',
+      modified: '2026-01-01T00:00:00.000Z',
+    };
+  }
+  vol.writeFileSync(
+    `${TUCK}/.tuckmanifest.json`,
+    JSON.stringify({
+      version: '1',
+      created: '2026-01-01T00:00:00.000Z',
+      updated: '2026-01-01T00:00:00.000Z',
+      files: fileEntries,
+      bundles: {},
+    })
+  );
+};
+
+const checksum = async (path: string): Promise<string> => {
+  const { getFileChecksum } = await import('../../src/lib/files.js');
+  return getFileChecksum(path);
+};
+
+describe('verify --root / --apply', () => {
+  let writes: string[];
+
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    clearConfigCache();
+    resetWriteContext();
+    process.exitCode = 0;
+    vol.mkdirSync('/test-home', { recursive: true });
+    vol.mkdirSync(`${TUCK}/files/shell`, { recursive: true });
+    writes = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((c: string | Uint8Array) => {
+      writes.push(String(c));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    resetWriteContext();
+    vi.restoreAllMocks();
+    process.exitCode = 0;
+  });
+
+  const envelope = () => JSON.parse(writes.join('').trim());
+
+  it('--root confines target resolution under the sandbox root (writes nothing to real home)', async () => {
+    // Repo copy exists; live file is absent → would be a "created" change.
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'export A=1\n');
+    writeManifestFiles({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        checksum: await checksum(`${TUCK}/files/shell/zshrc`),
+      },
+    });
+
+    await runVerify({ json: true, apply: true, root: SANDBOX });
+
+    const env = envelope();
+    expect(env.ok).toBe(true);
+    const change = env.data.changes.find((ch: { target: string }) => ch.target.includes('.zshrc'));
+    expect(change).toBeTruthy();
+    // The resolved write target is confined under the sandbox root.
+    expect(resolve(change.target).startsWith(resolve(SANDBOX))).toBe(true);
+    // The real live home file was never created by the preview.
+    expect(vol.existsSync('/test-home/.zshrc')).toBe(false);
+  });
+
+  it('classifies created / modified / unchanged correctly against the live target', async () => {
+    // created: repo has it, live does not.
+    vol.writeFileSync(`${TUCK}/files/shell/newrc`, 'NEW\n');
+    // modified: repo differs from live.
+    vol.writeFileSync(`${TUCK}/files/shell/modrc`, 'REPO VERSION\n');
+    vol.writeFileSync('/test-home/.modrc', 'LIVE VERSION\n');
+    // unchanged: repo equals live.
+    vol.writeFileSync(`${TUCK}/files/shell/samerc`, 'SAME\n');
+    vol.writeFileSync('/test-home/.samerc', 'SAME\n');
+
+    writeManifestFiles({
+      newrc: {
+        source: '~/.newrc',
+        destination: 'files/shell/newrc',
+        checksum: await checksum(`${TUCK}/files/shell/newrc`),
+      },
+      modrc: {
+        source: '~/.modrc',
+        destination: 'files/shell/modrc',
+        checksum: await checksum(`${TUCK}/files/shell/modrc`),
+      },
+      samerc: {
+        source: '~/.samerc',
+        destination: 'files/shell/samerc',
+        checksum: await checksum(`${TUCK}/files/shell/samerc`),
+      },
+    });
+
+    await runVerify({ json: true, apply: true, root: SANDBOX });
+
+    const env = envelope();
+    const byTarget = (needle: string) =>
+      env.data.changes.find((ch: { target: string }) => ch.target.includes(needle));
+
+    expect(byTarget('.newrc').status).toBe('created');
+    expect(byTarget('.modrc').status).toBe('modified');
+    expect(byTarget('.samerc').status).toBe('unchanged');
+
+    // bytesBefore/bytesAfter are surfaced.
+    expect(byTarget('.newrc').bytesBefore).toBe(0);
+    expect(byTarget('.newrc').bytesAfter).toBe('NEW\n'.length);
+    expect(byTarget('.modrc').bytesBefore).toBe('LIVE VERSION\n'.length);
+  });
+
+  it('reports a traversal/escaping manifest entry in wouldEscapeRoot and writes NOTHING', async () => {
+    // A safe entry alongside an escaping one.
+    vol.writeFileSync(`${TUCK}/files/shell/okrc`, 'OK\n');
+    vol.writeFileSync(`${TUCK}/files/shell/evil`, 'PWNED\n');
+
+    writeManifestFiles({
+      okrc: {
+        source: '~/.okrc',
+        destination: 'files/shell/okrc',
+        checksum: await checksum(`${TUCK}/files/shell/okrc`),
+      },
+      evil: {
+        // A source that escapes the home/sandbox via traversal.
+        source: '~/../../etc/passwd',
+        destination: 'files/shell/evil',
+        checksum: await checksum(`${TUCK}/files/shell/evil`),
+      },
+    });
+
+    await runVerify({ json: true, apply: true, root: SANDBOX });
+
+    const env = envelope();
+    expect(env.data.wouldEscapeRoot.length).toBeGreaterThan(0);
+    // The escaping entry produced no change row.
+    const escaped = env.data.changes.find((ch: { target: string }) =>
+      ch.target.includes('passwd')
+    );
+    expect(escaped).toBeFalsy();
+    // Nothing was written outside the sandbox.
+    expect(vol.existsSync('/etc/passwd')).toBe(false);
+  });
+
+  it('surfaces smartMerge conflicts that plain apply silently discards', async () => {
+    // A shell file with a conflicting export between live and repo copies.
+    vol.writeFileSync('/test-home/.zshrc', 'export EDITOR=vim\n');
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'export EDITOR=nano\n');
+
+    writeManifestFiles({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        checksum: await checksum(`${TUCK}/files/shell/zshrc`),
+      },
+    });
+
+    await runVerify({ json: true, apply: true, root: SANDBOX });
+
+    const env = envelope();
+    expect(Array.isArray(env.data.conflicts)).toBe(true);
+    expect(env.data.conflicts.length).toBeGreaterThan(0);
+    expect(env.data.conflicts[0].name).toBe('EDITOR');
+  });
+});

--- a/tests/lib/doctor-sandbox.test.ts
+++ b/tests/lib/doctor-sandbox.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Doctor sandboxing/security recipe checks.
+ *
+ * `tuck doctor` surfaces OS-level wrapper recipes (sandbox-exec, bubblewrap,
+ * landlock, container) and confirms that `--root` write-confinement is available
+ * — the operator-facing half of the sandboxed-preview story (audit §3.3). These
+ * checks must always run (they are advisory, never machine-state dependent).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { runDoctorChecks, DOCTOR_CATEGORIES } from '../../src/lib/doctor.js';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { clearConfigCache } from '../../src/lib/config.js';
+import { resetWriteContext, setWriteContext } from '../../src/lib/writeContext.js';
+
+describe('doctor sandboxing recipes', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    clearConfigCache();
+    resetWriteContext();
+    vol.mkdirSync('/test-home', { recursive: true });
+  });
+
+  afterEach(() => {
+    resetWriteContext();
+    vol.reset();
+  });
+
+  it('exposes a sandboxing category', () => {
+    expect(DOCTOR_CATEGORIES).toContain('sandboxing');
+  });
+
+  it('includes OS-level wrapper recipes (sandbox-exec, bwrap, landlock, container)', async () => {
+    const report = await runDoctorChecks({ category: 'sandboxing' });
+
+    const recipeCheck = report.checks.find((c) => c.id === 'sandboxing.os-wrappers');
+    expect(recipeCheck).toBeTruthy();
+
+    // The recipe text is carried in details so an agent/operator can copy it.
+    const text = `${recipeCheck!.message} ${recipeCheck!.details ?? ''} ${recipeCheck!.fix ?? ''}`;
+    expect(text).toMatch(/sandbox-exec/i);
+    expect(text).toMatch(/bwrap|bubblewrap/i);
+    expect(text).toMatch(/landlock/i);
+    expect(text).toMatch(/docker|container/i);
+  });
+
+  it('reports --root confinement availability', async () => {
+    const report = await runDoctorChecks({ category: 'sandboxing' });
+    const rootCheck = report.checks.find((c) => c.id === 'sandboxing.root-confinement');
+    expect(rootCheck).toBeTruthy();
+    // Without an active sandbox it is available-but-inactive (advisory).
+    expect(rootCheck!.status).toBe('pass');
+    expect(`${rootCheck!.message} ${rootCheck!.details ?? ''}`).toMatch(/--root/);
+  });
+
+  it('notes when --root confinement is actively engaged', async () => {
+    setWriteContext({ root: '/test-home/sandbox', isSandbox: true });
+    const report = await runDoctorChecks({ category: 'sandboxing' });
+    const rootCheck = report.checks.find((c) => c.id === 'sandboxing.root-confinement');
+    expect(rootCheck).toBeTruthy();
+    expect(`${rootCheck!.message} ${rootCheck!.details ?? ''}`).toMatch(/sandbox/i);
+  });
+});

--- a/tests/lib/keystoreFallback.test.ts
+++ b/tests/lib/keystoreFallback.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vol } from 'memfs';
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { homedir, hostname, userInfo } from 'os';
+import { join } from 'path';
+import { createHash, createCipheriv, randomBytes } from 'crypto';
+import { TEST_HOME } from '../setup.js';
+import { FallbackKeystore } from '../../src/lib/crypto/keystore/fallback.js';
+
+// The per-install random secret lives alongside the user's tuck dir.
+const keystoreKeyPath = () => join(homedir(), '.tuck', 'keystore.key');
+
+// Replicate the PRE-install-secret (legacy) key derivation + encrypt format so
+// we can forge a keystore file exactly as an older tuck version wrote it.
+const legacyMachineKey = (): Buffer =>
+  createHash('sha256')
+    .update([hostname(), userInfo().username, homedir(), process.platform, 'tuck-keystore-v1'].join(':'))
+    .digest();
+
+const legacyEncrypt = (plaintext: Buffer): Buffer => {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', legacyMachineKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), ciphertext]);
+};
+
+describe('FallbackKeystore per-install random secret', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  it('persists a 32-byte random secret at ~/.tuck/keystore.key on first use', async () => {
+    expect(existsSync(keystoreKeyPath())).toBe(false);
+
+    const ks = new FallbackKeystore();
+    await ks.store('svc', 'acct', 'topsecret');
+
+    expect(existsSync(keystoreKeyPath())).toBe(true);
+    const secret = readFileSync(keystoreKeyPath());
+    expect(secret.length).toBe(32);
+  });
+
+  it('reuses the stored secret across calls (stable key)', async () => {
+    const ks = new FallbackKeystore();
+    await ks.store('svc', 'acct', 'topsecret');
+
+    const firstSecret = readFileSync(keystoreKeyPath());
+
+    // A subsequent operation must not regenerate the secret.
+    const retrieved = await ks.retrieve('svc', 'acct');
+    expect(retrieved).toBe('topsecret');
+
+    const secondSecret = readFileSync(keystoreKeyPath());
+    expect(Buffer.compare(firstSecret, secondSecret)).toBe(0);
+  });
+
+  it('two different secrets yield different derived keys (swap breaks decrypt)', async () => {
+    const customPath = join(TEST_HOME, 'ks-store.enc');
+
+    // First install: random secret A is created, data encrypted under key(A).
+    const ks1 = new FallbackKeystore(customPath);
+    await ks1.store('svc', 'acct', 'topsecret');
+
+    // Swap the per-install secret to a different random value (secret B).
+    const altSecret = Buffer.alloc(32, 7);
+    writeFileSync(keystoreKeyPath(), altSecret);
+
+    // Reading the same encrypted store with key(B) must NOT recover the
+    // plaintext (different derived key => GCM auth fails => fresh empty store).
+    const ks2 = new FallbackKeystore(customPath);
+    const retrieved = await ks2.retrieve('svc', 'acct');
+    expect(retrieved).toBeNull();
+  });
+});
+
+describe('FallbackKeystore legacy-key backward compatibility', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  it('reads a pre-install-secret keystore (no data loss on upgrade), then migrates it', async () => {
+    const customPath = join(TEST_HOME, 'legacy-ks.enc');
+
+    // Forge an OLD keystore file: encrypted with the deterministic-only key,
+    // exactly as a tuck version before the per-install secret would have written.
+    const payload = { entries: { svc: { acct: 'legacy-secret' } }, version: 1 };
+    writeFileSync(customPath, legacyEncrypt(Buffer.from(JSON.stringify(payload), 'utf-8')));
+    // The upgrade introduces the install secret only on first use.
+    expect(existsSync(keystoreKeyPath())).toBe(false);
+
+    // The stored secret MUST still be recoverable (via the legacy-key fallback),
+    // not silently lost behind the new key.
+    const ks = new FallbackKeystore(customPath);
+    expect(await ks.retrieve('svc', 'acct')).toBe('legacy-secret');
+
+    // Any write re-encrypts the whole file with the current (install-secret) key.
+    await ks.store('svc2', 'acct2', 'new-secret');
+    expect(existsSync(keystoreKeyPath())).toBe(true);
+
+    const ks2 = new FallbackKeystore(customPath);
+    expect(await ks2.retrieve('svc', 'acct')).toBe('legacy-secret'); // preserved
+    expect(await ks2.retrieve('svc2', 'acct2')).toBe('new-secret');
+
+    // Prove the file was genuinely migrated OFF the legacy key: swap the install
+    // secret and the file no longer decrypts with either candidate key. (If it
+    // were still legacy-encrypted, the legacy-key fallback would recover it.)
+    writeFileSync(keystoreKeyPath(), Buffer.alloc(32, 9));
+    const ks3 = new FallbackKeystore(customPath);
+    expect(await ks3.retrieve('svc', 'acct')).toBeNull();
+  });
+});

--- a/tests/lib/keystorePlatform.test.ts
+++ b/tests/lib/keystorePlatform.test.ts
@@ -66,6 +66,26 @@ describe('LinuxKeystore.isAvailable probe', () => {
     const ks = new LinuxKeystore();
     expect(await ks.isAvailable()).toBe(false);
   });
+
+  it('accepts the systemd session-bus socket when DBUS_SESSION_BUS_ADDRESS is unset', async () => {
+    // A desktop/systemd session may not export DBUS_SESSION_BUS_ADDRESS into this
+    // process but still has a reachable bus at $XDG_RUNTIME_DIR/bus — an existing
+    // keyring user must NOT be silently downgraded to the file keystore.
+    setPlatform('linux');
+    delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    const originalXdg = process.env.XDG_RUNTIME_DIR;
+    process.env.XDG_RUNTIME_DIR = '/run/user/1000';
+    const { vol } = await import('memfs');
+    vol.mkdirSync('/run/user/1000', { recursive: true });
+    vol.writeFileSync('/run/user/1000/bus', '');
+    try {
+      const ks = new LinuxKeystore();
+      expect(await ks.isAvailable()).toBe(true);
+    } finally {
+      if (originalXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = originalXdg;
+    }
+  });
 });
 
 describe('WindowsKeystore.isAvailable', () => {

--- a/tests/lib/keystorePlatform.test.ts
+++ b/tests/lib/keystorePlatform.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// execFile is promisified inside the keystore modules; mock the callback form
+// so promisify(execFile) resolves/rejects under our control.
+const execFileMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => {
+    // promisify expects the last arg to be a node-style callback.
+    const cb = args[args.length - 1] as (err: Error | null, res?: unknown) => void;
+    return execFileMock(cb);
+  },
+  spawn: vi.fn(),
+}));
+
+import { LinuxKeystore } from '../../src/lib/crypto/keystore/linux.js';
+import { WindowsKeystore } from '../../src/lib/crypto/keystore/windows.js';
+import { getKeystore, clearKeystoreCache } from '../../src/lib/crypto/keystore/index.js';
+import { FallbackKeystore } from '../../src/lib/crypto/keystore/fallback.js';
+
+const setPlatform = (value: NodeJS.Platform): void => {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+};
+
+describe('LinuxKeystore.isAvailable probe', () => {
+  const originalPlatform = process.platform;
+  const originalDbus = process.env.DBUS_SESSION_BUS_ADDRESS;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    // Default: `which secret-tool` succeeds.
+    execFileMock.mockImplementation((cb: (e: Error | null, r?: unknown) => void) => {
+      cb(null, { stdout: '/usr/bin/secret-tool\n', stderr: '' });
+    });
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    if (originalDbus === undefined) {
+      delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    } else {
+      process.env.DBUS_SESSION_BUS_ADDRESS = originalDbus;
+    }
+  });
+
+  it('returns false when DBUS_SESSION_BUS_ADDRESS is unset (no session bus)', async () => {
+    setPlatform('linux');
+    delete process.env.DBUS_SESSION_BUS_ADDRESS;
+
+    const ks = new LinuxKeystore();
+    expect(await ks.isAvailable()).toBe(false);
+  });
+
+  it('returns true on linux when a session bus is present and secret-tool exists', async () => {
+    setPlatform('linux');
+    process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/run/user/1000/bus';
+
+    const ks = new LinuxKeystore();
+    expect(await ks.isAvailable()).toBe(true);
+  });
+
+  it('returns false on non-linux platforms', async () => {
+    setPlatform('darwin');
+    process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/run/user/1000/bus';
+
+    const ks = new LinuxKeystore();
+    expect(await ks.isAvailable()).toBe(false);
+  });
+});
+
+describe('WindowsKeystore.isAvailable', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it('returns false on win32 (Windows uses the encrypted fallback keystore by design)', async () => {
+    setPlatform('win32');
+    const ks = new WindowsKeystore();
+    expect(await ks.isAvailable()).toBe(false);
+  });
+});
+
+describe('getKeystore platform selection', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    clearKeystoreCache();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    clearKeystoreCache();
+  });
+
+  it('selects the encrypted fallback keystore on win32', async () => {
+    setPlatform('win32');
+    const ks = await getKeystore();
+    expect(ks).toBeInstanceOf(FallbackKeystore);
+  });
+});


### PR DESCRIPTION
## Summary
Wave 2 of audit remediation — agent-surface completeness, the sandbox preview story, and platform/keystore hardening. TDD throughout; all tests run against memfs / sandboxed temp roots, **never the real home**.

### Agent-JSON completeness (P1)
- `secrets list/set/unset/path` gain `--json` (+ `--yes` on set). Each emits exactly one `{ok,command}` envelope; secret **values are never echoed** (`set` reads from `TUCK_SECRET_VALUE` to keep secrets out of argv/history).
- `restore` skipped-file warnings now route through `addJsonWarning` → surface in `envelope.warnings`.
- `add --plan/--dry-run` now runs the **full** `preparePathsForTracking` pipeline (category/secret/validation) so the plan matches a real run.

### Sandbox preview (P1/P2) — completes Layer 4 of the sandboxing design
- `verify --root <dir>`: confine write/preview targets under a dry-home sandbox (reads still use real home).
- `verify --apply`: **dry-apply diff** — runs the apply prepare pipeline into the sandbox (auto temp dir, always cleaned up), classifies each file `created|modified|unchanged`, surfaces `smartMerge` **conflicts** that plain apply silently discards, and reports any entry that **would escape the root** in `wouldEscapeRoot` (writing nothing). Emits `{root,changes,conflicts,wouldEscapeRoot}`.
- `doctor`: new **sandboxing** category with copy-pasteable OS-wrapper recipes (`sandbox-exec`/`bwrap`/landlock/container) + `--root` status.

### Keystore / platform (P2)
- Windows editor default → `notepad` (was `vim`/`vi` → ENOENT).
- Fallback keystore KDF mixes in a **per-install random 32-byte secret** (`~/.tuck/keystore.key`, 0600) so the file isn't derivable from machine info alone — **with a legacy-key fallback** so existing keystores stay decryptable across upgrade and migrate transparently on next write (**no data loss**; regression test included).
- Linux `isAvailable()` now requires a real session bus + bounded probe (headless/WSL → encrypted file keystore); Windows `isAvailable()` returns false by design (cmdkey can't retrieve) → clean fallback.

## Verification
`pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` **1117 passing** (+30 new tests).

> Reviewer note: the per-install-secret KDF change is data-loss-sensitive on upgrade; the legacy-key fallback + migration test (`keystoreFallback.test.ts`) specifically guards existing users' stored secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)