### PR TITLE
feat(provider): wave-3 — provider-neutral lifecycle (less GitHub coupling)

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -24,7 +24,8 @@ import { isGhInstalled, ghCloneRepo, repoExists } from '../lib/github.js';
 import { createPreApplySnapshot } from '../lib/timemachine.js';
 import { smartMerge, isShellFile, generateMergePreview } from '../lib/merge.js';
 import { CATEGORIES } from '../constants.js';
-import { tuckManifestSchema, type TuckManifestOutput } from '../schemas/manifest.schema.js';
+import { type TuckManifestOutput } from '../schemas/manifest.schema.js';
+import { loadManifestFile } from '../lib/manifestFile.js';
 import { findPlaceholders, restoreContent, restoreFiles as restoreSecrets, getAllSecrets, getSecretCount } from '../lib/secrets/index.js';
 import { createResolver } from '../lib/secretBackends/index.js';
 import { loadConfig } from '../lib/config.js';
@@ -168,11 +169,31 @@ const buildProviderCloneUrl = (
 };
 
 /**
+ * How {@link cloneSource} should materialize a resolved source.
+ *
+ * - `custom`  → clone through the CUSTOM provider's cloneRepo (file:// / full
+ *   git URLs / explicit `custom:` prefix). Carries the provider's clone
+ *   timeout/maxBuffer and never touches any github code path.
+ * - `git`     → clone a provider-BUILT URL (gitlab/github) through the capped
+ *   git.ts cloneRepo.
+ * - `github-repo-id` → a bare owner/repo resolved against github: gh-clone when
+ *   the CLI is present, otherwise a github URL BUILT via provider.buildRepoUrl
+ *   (never a hard-coded literal) cloned through git.ts.
+ */
+type CloneTransport = 'custom' | 'git' | 'github-repo-id';
+
+interface ResolvedSource {
+  repoId: string;
+  isUrl: boolean;
+  local?: 'dir' | 'tarball';
+  /** Clone transport for non-local sources (ignored when `local` is set). */
+  cloneVia?: CloneTransport;
+}
+
+/**
  * Resolve a source (username or repo URL) to a full repository identifier
  */
-const resolveSource = async (
-  source: string
-): Promise<{ repoId: string; isUrl: boolean; local?: 'dir' | 'tarball' }> => {
+const resolveSource = async (source: string): Promise<ResolvedSource> => {
   const configuredRemote = (await loadConfig(getTuckDir()))?.remote ?? { mode: 'local' as const };
   const providerPrefixMatch = source.match(/^(github|gitlab|custom):(.*)$/u);
 
@@ -180,12 +201,15 @@ const resolveSource = async (
     const providerMode = providerPrefixMatch[1] as Extract<ProviderMode, 'github' | 'gitlab' | 'custom'>;
     const repoId = providerPrefixMatch[2];
 
+    // custom:<URL> → provider-neutral clone (custom provider). github/gitlab →
+    // a provider-BUILT URL cloned through the capped git.ts path.
+    if (providerMode === 'custom') {
+      return { repoId, isUrl: true, cloneVia: 'custom' };
+    }
     return {
-      repoId:
-        providerMode === 'custom'
-          ? repoId
-          : buildProviderCloneUrl(providerMode, repoId, configuredRemote),
+      repoId: buildProviderCloneUrl(providerMode, repoId, configuredRemote),
       isUrl: true,
+      cloneVia: 'git',
     };
   }
 
@@ -199,21 +223,34 @@ const resolveSource = async (
     };
   }
 
-  // Check if it's a full URL
+  // A file:// URL or full git URL (https/git@). These are provider-neutral and
+  // route through the CUSTOM provider's capped clone — never github.
   if (source.includes('://') || source.startsWith('git@')) {
-    return { repoId: source, isUrl: true };
+    return { repoId: source, isUrl: true, cloneVia: 'custom' };
   }
 
-  // Check if it's a repo identifier (owner/repo or group/subgroup/repo)
+  // Check if it's a repo identifier (owner/repo or group/subgroup/repo).
+  // Resolve against the CONFIGURED provider first, building the URL via that
+  // provider's buildRepoUrl — never an unconditional github.com.
   if (source.includes('/')) {
     if (configuredRemote.mode === 'gitlab') {
       return {
         repoId: buildProviderCloneUrl('gitlab', source, configuredRemote),
         isUrl: true,
+        cloneVia: 'git',
+      };
+    }
+    if (configuredRemote.mode === 'github') {
+      return {
+        repoId: buildProviderCloneUrl('github', source, configuredRemote),
+        isUrl: true,
+        cloneVia: 'git',
       };
     }
 
-    return { repoId: source, isUrl: false };
+    // No (or local) configured provider → fall back to github resolution, but
+    // still build the URL via the provider, never a hard-coded literal.
+    return { repoId: source, isUrl: false, cloneVia: 'github-repo-id' };
   }
 
   // Assume it's a username, try to find their dotfiles repo
@@ -232,10 +269,13 @@ const resolveSource = async (
       const dotfilesRepo = await provider.findDotfilesRepo(source);
       if (dotfilesRepo) {
         logger.success(`Found repository: ${dotfilesRepo}`);
-        return {
-          repoId: mode === 'github' ? dotfilesRepo : buildProviderCloneUrl(mode, dotfilesRepo, configuredRemote),
-          isUrl: mode !== 'github',
-        };
+        return mode === 'github'
+          ? { repoId: dotfilesRepo, isUrl: false, cloneVia: 'github-repo-id' }
+          : {
+              repoId: buildProviderCloneUrl(mode, dotfilesRepo, configuredRemote),
+              isUrl: true,
+              cloneVia: 'git',
+            };
       }
     } catch {
       continue;
@@ -258,10 +298,13 @@ const resolveSource = async (
               ).repoExists(repoId)
         ) {
           logger.success(`Found repository: ${repoId}`);
-          return {
-            repoId: mode === 'github' ? repoId : buildProviderCloneUrl(mode, repoId, configuredRemote),
-            isUrl: mode !== 'github',
-          };
+          return mode === 'github'
+            ? { repoId, isUrl: false, cloneVia: 'github-repo-id' }
+            : {
+                repoId: buildProviderCloneUrl(mode, repoId, configuredRemote),
+                isUrl: true,
+                cloneVia: 'git',
+              };
         }
       } catch {
         continue;
@@ -273,13 +316,15 @@ const resolveSource = async (
 };
 
 /**
- * Clone the source repository to a temporary directory
+ * Clone the source repository to a temporary directory.
+ *
+ * The clone is routed by {@link ResolvedSource.cloneVia} so a provider-neutral
+ * source (file:// / full git URL / `custom:`) goes through the CUSTOM provider's
+ * capped clone instead of any github code path, and a bare owner/repo never
+ * builds a hard-coded `https://github.com/...` literal.
  */
-const cloneSource = async (
-  repoId: string,
-  isUrl: boolean,
-  local?: 'dir' | 'tarball'
-): Promise<string> => {
+const cloneSource = async (resolved: ResolvedSource): Promise<string> => {
+  const { repoId, isUrl, local, cloneVia } = resolved;
   const tempDir = join(tmpdir(), `tuck-apply-${Date.now()}`);
   await ensureDir(tempDir);
 
@@ -295,18 +340,32 @@ const cloneSource = async (
     return tempDir;
   }
 
-  if (isUrl) {
-    await cloneRepo(repoId, tempDir);
-  } else {
-    // Use gh CLI to clone if available, otherwise construct URL
+  if (cloneVia === 'custom') {
+    // file:// / full git URL / explicit custom: — clone through the custom
+    // provider (its timeout/maxBuffer), provider-neutral, never github.
+    await getProvider('custom').cloneRepo(repoId, tempDir);
+    return tempDir;
+  }
+
+  if (cloneVia === 'github-repo-id' || (!cloneVia && !isUrl)) {
+    // Bare owner/repo resolved against github: gh-clone when the CLI is present,
+    // otherwise a github URL BUILT via the provider (never a hard-coded literal)
+    // cloned through the capped git.ts path.
     if (await isGhInstalled()) {
       await ghCloneRepo(repoId, tempDir);
     } else {
-      const url = `https://github.com/${repoId}.git`;
+      const slashIndex = repoId.indexOf('/');
+      const owner = repoId.slice(0, slashIndex);
+      const repoName = repoId.slice(slashIndex + 1);
+      const url = getProvider('github').buildRepoUrl(owner, repoName, 'https');
       await cloneRepo(url, tempDir);
     }
+    return tempDir;
   }
 
+  // cloneVia === 'git' (or a legacy isUrl source): a provider-built URL cloned
+  // through the capped git.ts path.
+  await cloneRepo(repoId, tempDir);
   return tempDir;
 };
 
@@ -321,9 +380,9 @@ const readClonedManifest = async (repoDir: string): Promise<TuckManifestOutput |
   }
 
   try {
-    const content = await readFile(manifestPath, 'utf-8');
-    const parsed = JSON.parse(content) as unknown;
-    return tuckManifestSchema.parse(parsed);
+    // A cloned/remote manifest is untrusted: load it through the shared,
+    // schema-validating loader so a hostile manifest is rejected before use.
+    return await loadManifestFile(manifestPath);
   } catch {
     return null;
   }
@@ -784,26 +843,24 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
   prompts.intro('tuck apply');
 
   // Resolve the source
-  let repoId: string;
-  let isUrl: boolean;
-  let local: 'dir' | 'tarball' | undefined;
+  let resolved: ResolvedSource;
+  const repoId = source; // Snapshot label: the original source the user typed.
 
   try {
-    const resolved = await resolveSource(source);
-    repoId = resolved.repoId;
-    isUrl = resolved.isUrl;
-    local = resolved.local;
+    resolved = await resolveSource(source);
   } catch (error) {
     prompts.log.error(error instanceof Error ? error.message : String(error));
     return;
   }
+
+  const { local } = resolved;
 
   // Clone the repository
   let repoDir: string;
   try {
     const spinner = prompts.spinner();
     spinner.start(local ? 'Reading local source...' : 'Cloning repository...');
-    repoDir = await cloneSource(repoId, isUrl, local);
+    repoDir = await cloneSource(resolved);
     spinner.stop(local ? 'Source ready' : 'Repository cloned');
   } catch (error) {
     prompts.log.error(`Failed to clone: ${error instanceof Error ? error.message : String(error)}`);
@@ -996,11 +1053,12 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
   if (options.json) setJsonMode(true, 'tuck apply');
 
   // Resolve the source
-  const { repoId, isUrl, local } = await resolveSource(source);
+  const resolved = await resolveSource(source);
+  const { local } = resolved;
 
   // Clone (or materialize a local source).
   logger.info(local ? 'Reading local source...' : 'Cloning repository...');
-  const repoDir = await cloneSource(repoId, isUrl, local);
+  const repoDir = await cloneSource(resolved);
 
   try {
     // Read the manifest
@@ -1050,7 +1108,7 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
 
       if (existingPaths.length > 0) {
         logger.info('Creating backup snapshot...');
-        const snapshot = await createPreApplySnapshot(existingPaths, repoId);
+        const snapshot = await createPreApplySnapshot(existingPaths, source);
         logger.success(`Backup created: ${snapshot.id}`);
       }
     }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -4,7 +4,7 @@ import { prompts, logger, banner, colors as c } from '../ui/index.js';
 import { getTuckDir, getConfigPath, collapsePath } from '../lib/paths.js';
 import { loadConfig, saveConfig, resetConfig } from '../lib/config.js';
 import { loadManifest } from '../lib/manifest.js';
-import { addRemote, removeRemote, hasRemote } from '../lib/git.js';
+import { upsertRemote } from '../lib/git.js';
 import { NotInitializedError, ConfigError } from '../errors.js';
 import type { TuckConfigOutput } from '../schemas/config.schema.js';
 import { setupProvider } from '../lib/providerSetup.js';
@@ -582,22 +582,25 @@ export const runConfigRemote = async (): Promise<void> => {
 
   await saveConfig(updatedConfig, tuckDir);
 
-  // If a remote URL was provided, update git remote
+  // Track whether a remote URL was ACTUALLY configured so the final message
+  // reflects reality (and never prints a false "Remote configured" success).
+  let configuredRemoteUrl: string | null = result.remoteUrl ?? null;
+
+  // If a remote URL was provided, update the git remote.
   if (result.remoteUrl) {
     try {
-      // Check if origin already exists
-      if (await hasRemote(tuckDir)) {
-        // Remove existing remote
-        await removeRemote(tuckDir, 'origin');
-      }
-      // Add new remote
-      await addRemote(tuckDir, 'origin', result.remoteUrl);
+      // Idempotent upsert: set-url if origin exists, else add. This avoids the
+      // remove-then-add race (a transient state with NO origin) that the old
+      // code created when reconfiguring an existing repo.
+      await upsertRemote(tuckDir, 'origin', result.remoteUrl);
       prompts.log.success('Git remote updated');
     } catch (error) {
       prompts.log.warning(
         `Could not update git remote: ${error instanceof Error ? error.message : String(error)}`
       );
       prompts.log.info(`Manually add remote: git remote add origin ${result.remoteUrl}`);
+      // The remote wasn't actually wired up; don't claim it was.
+      configuredRemoteUrl = null;
     }
   }
 
@@ -606,19 +609,15 @@ export const runConfigRemote = async (): Promise<void> => {
   // helper that `tuck init` uses. This deduplicates the old ad-hoc
   // createRepo/getPreferredRepoUrl flow and ensures gitlab/custom go through
   // their own provider instead of a github-shaped path.
+  //
+  // The helper now UPSERTS `origin` itself (no pre-remove dance here), so a
+  // reconfiguration won't hit the remove-then-add race.
   if (result.mode !== 'local' && !result.remoteUrl) {
-    // Clear any pre-existing origin first so the shared helper's `addRemote`
-    // (which adds 'origin') succeeds when reconfiguring an existing repo.
-    if (await hasRemote(tuckDir)) {
-      await removeRemote(tuckDir, 'origin').catch(() => {
-        /* best effort: a missing/locked remote shouldn't block setup */
-      });
-    }
-
     const provider = getProvider(result.mode, result.config);
     const { remoteUrl } = await setupRemoteForProvider(provider, tuckDir);
 
     if (remoteUrl) {
+      configuredRemoteUrl = remoteUrl;
       // The shared helper already wired up `origin`; persist the config so the
       // remote selection survives across runs.
       updatedConfig.remote = {
@@ -629,7 +628,17 @@ export const runConfigRemote = async (): Promise<void> => {
   }
 
   console.log();
-  prompts.log.success(`Remote configured: ${describeProviderConfig(result.config)}`);
+  // Final message must mirror reality. For a remote-requiring provider, only
+  // claim success if a remote URL was genuinely configured; otherwise warn with
+  // an actionable next step instead of a silent false "Remote configured".
+  if (result.mode !== 'local' && !configuredRemoteUrl) {
+    prompts.log.warning(
+      `Provider set to ${describeProviderConfig(result.config)}, but no remote was configured — ` +
+        'run `tuck config remote` again or add one manually'
+    );
+  } else {
+    prompts.log.success(`Remote configured: ${describeProviderConfig(result.config)}`);
+  }
   prompts.outro('Done!');
 };
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -9,6 +9,7 @@ import { NotInitializedError, ConfigError } from '../errors.js';
 import type { TuckConfigOutput } from '../schemas/config.schema.js';
 import { setupProvider } from '../lib/providerSetup.js';
 import { describeProviderConfig, getProvider } from '../lib/providers/index.js';
+import { setupRemoteForProvider } from '../lib/remoteSetup.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 import { IS_WINDOWS } from '../lib/platform.js';
 
@@ -538,9 +539,11 @@ const runInteractiveConfig = async (): Promise<void> => {
 };
 
 /**
- * Run the remote provider configuration flow
+ * Run the remote provider configuration flow.
+ *
+ * Exported for unit testing the provider-agnostic remote-setup dedup.
  */
-const runConfigRemote = async (): Promise<void> => {
+export const runConfigRemote = async (): Promise<void> => {
   banner();
   prompts.intro('tuck config remote');
 
@@ -598,72 +601,30 @@ const runConfigRemote = async (): Promise<void> => {
     }
   }
 
-  // If switching to a provider that can create repos, offer to create one
-  if (result.mode !== 'local' && result.mode !== 'custom' && !result.remoteUrl) {
-    const shouldCreateRepo = await prompts.confirm(
-      'Would you like to create a repository now?',
-      true
-    );
-
-    if (shouldCreateRepo) {
-      const provider = getProvider(result.mode, result.config);
-
-      const repoName = await prompts.text('Repository name:', {
-        defaultValue: 'dotfiles',
-        placeholder: 'dotfiles',
-        validate: (value) => {
-          if (!value) return 'Repository name is required';
-          // Ensure name starts and ends with alphanumeric
-          if (!/^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/.test(value)) {
-            return 'Repository name must start and end with alphanumeric characters';
-          }
-          return undefined;
-        },
+  // If no remote URL was configured yet and the provider needs one (github /
+  // gitlab / custom), route through the SAME provider-agnostic remote-setup
+  // helper that `tuck init` uses. This deduplicates the old ad-hoc
+  // createRepo/getPreferredRepoUrl flow and ensures gitlab/custom go through
+  // their own provider instead of a github-shaped path.
+  if (result.mode !== 'local' && !result.remoteUrl) {
+    // Clear any pre-existing origin first so the shared helper's `addRemote`
+    // (which adds 'origin') succeeds when reconfiguring an existing repo.
+    if (await hasRemote(tuckDir)) {
+      await removeRemote(tuckDir, 'origin').catch(() => {
+        /* best effort: a missing/locked remote shouldn't block setup */
       });
+    }
 
-      const visibility = await prompts.select('Repository visibility:', [
-        { value: 'private', label: 'Private (recommended)', hint: 'Only you can see it' },
-        { value: 'public', label: 'Public', hint: 'Anyone can see it' },
-      ]);
+    const provider = getProvider(result.mode, result.config);
+    const { remoteUrl } = await setupRemoteForProvider(provider, tuckDir);
 
-      try {
-        const spinner = prompts.spinner();
-        spinner.start('Creating repository...');
-
-        const repo = await provider.createRepo({
-          name: repoName,
-          description: 'My dotfiles managed with tuck',
-          isPrivate: visibility === 'private',
-        });
-
-        spinner.stop(`Repository created: ${repo.fullName}`);
-
-        // Get preferred URL and add as remote
-        const remoteUrl = await provider.getPreferredRepoUrl(repo);
-
-        try {
-          if (await hasRemote(tuckDir)) {
-            await removeRemote(tuckDir, 'origin');
-          }
-          await addRemote(tuckDir, 'origin', remoteUrl);
-          prompts.log.success('Remote configured');
-        } catch (error) {
-          prompts.log.warning(
-            `Could not add remote: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-
-        // Update config with repo name
-        updatedConfig.remote = {
-          ...updatedConfig.remote,
-          repoName,
-        };
-        await saveConfig(updatedConfig, tuckDir);
-      } catch (error) {
-        prompts.log.error(
-          `Failed to create repository: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
+    if (remoteUrl) {
+      // The shared helper already wired up `origin`; persist the config so the
+      // remote selection survives across runs.
+      updatedConfig.remote = {
+        ...updatedConfig.remote,
+      };
+      await saveConfig(updatedConfig, tuckDir);
     }
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,6 +14,7 @@ import {
 } from '../lib/paths.js';
 import { saveConfig } from '../lib/config.js';
 import { createManifest } from '../lib/manifest.js';
+import { loadManifestFile } from '../lib/manifestFile.js';
 import type { TuckManifest, RemoteConfig } from '../types.js';
 import {
   initRepo,
@@ -31,6 +32,7 @@ import {
 } from '../lib/providerSetup.js';
 import { getProvider, describeProviderConfig, buildRemoteConfig } from '../lib/providers/index.js';
 import type { ProviderMode } from '../lib/providers/types.js';
+import { setupRemoteForProvider } from '../lib/remoteSetup.js';
 import {
   isGhInstalled,
   isGhAuthenticated,
@@ -57,7 +59,7 @@ import {
 import { detectDotfiles, DetectedFile, DETECTION_CATEGORIES } from '../lib/detect.js';
 import { copy } from 'fs-extra';
 import { tmpdir } from 'os';
-import { readFile, rm } from 'fs/promises';
+import { rm } from 'fs/promises';
 import { AlreadyInitializedError } from '../errors.js';
 import { CATEGORIES } from '../constants.js';
 import { defaultConfig } from '../schemas/config.schema.js';
@@ -220,33 +222,20 @@ export const validateRemoteUrlForMode = (
 };
 
 /**
- * Set up a remote for a non-GitHub provider (GitLab / custom) using the
- * GitProvider abstraction: show the provider's setup instructions, then accept
- * a repository URL validated against THAT provider. Returns the configured URL
- * or null. This replaces the old behavior of routing every provider through
- * GitHub-specific setup.
+ * Set up a remote for the CHOSEN provider (GitLab / custom / github) using the
+ * shared, provider-agnostic {@link setupRemoteForProvider}. This routes each
+ * provider through ITS OWN setup instructions + URL validation + URL builder,
+ * instead of funneling everything through GitHub-specific code that hard-coded
+ * github.com and rejected GitLab/custom URLs.
+ *
+ * Returns the configured URL or null. Exported for unit testing the gitlab path.
  */
-const setupRemoteForProvider = async (
+export const setupRemoteForChosenProvider = async (
   mode: ProviderMode,
   tuckDir: string
 ): Promise<string | null> => {
-  const provider = getProvider(mode);
-  console.log();
-  prompts.note(provider.getSetupInstructions(), 'Repository Setup');
-  console.log();
-
-  const created = await prompts.confirm('Have you created the repository?', true);
-  if (!created) return null;
-
-  const url = await prompts.text('Paste your repository URL:', {
-    placeholder: mode === 'gitlab' ? 'git@gitlab.com:user/dotfiles.git' : 'https://host/user/dotfiles.git',
-    validate: (value) => validateRemoteUrlForMode(mode, value),
-  });
-
-  if (!url) return null;
-  await addRemote(tuckDir, 'origin', url);
-  prompts.log.success('Remote added successfully');
-  return url;
+  const { remoteUrl } = await setupRemoteForProvider(getProvider(mode), tuckDir);
+  return remoteUrl;
 };
 
 /**
@@ -854,8 +843,10 @@ const analyzeRepository = async (repoDir: string): Promise<RepositoryAnalysis> =
   // Check for valid tuck manifest
   if (await pathExists(manifestPath)) {
     try {
-      const content = await readFile(manifestPath, 'utf-8');
-      const manifest = JSON.parse(content) as TuckManifest;
+      // A cloned manifest is UNTRUSTED input: load it through the shared,
+      // schema-validating loader so a hostile/malformed manifest is rejected
+      // (caught below as "corrupted or invalid") before any import acts on it.
+      const manifest = (await loadManifestFile(manifestPath)) as unknown as TuckManifest;
 
       // Validate manifest has files
       if (manifest.files && Object.keys(manifest.files).length > 0) {
@@ -1476,7 +1467,7 @@ const runInteractiveInit = async (): Promise<void> => {
     if (wantsRemote && providerResult.mode !== 'github') {
       // GitLab / custom: use the provider abstraction instead of forcing the
       // user through GitHub (the old funnel rejected their URLs outright).
-      remoteUrl = await setupRemoteForProvider(providerResult.mode, tuckDir);
+      remoteUrl = await setupRemoteForChosenProvider(providerResult.mode, tuckDir);
     } else if (wantsRemote) {
       // Try GitHub auto-setup
       const ghResult = await setupGitHubRepo(tuckDir);

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -15,6 +15,8 @@ import { NotInitializedError, GitError } from '../errors.js';
 import type { PushOptions } from '../types.js';
 import { logForcePush } from '../lib/audit.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { loadConfig } from '../lib/config.js';
+import { assertRemoteAvailable } from '../lib/providers/index.js';
 
 const runInteractivePush = async (tuckDir: string): Promise<void> => {
   prompts.intro('tuck push');
@@ -91,6 +93,12 @@ const runInteractivePush = async (tuckDir: string): Promise<void> => {
   // Push
   const needsUpstream = !status.tracking;
 
+  // Provider gate: refuse to push in local-only mode regardless of any stray
+  // 'origin' remote that may be present. This is authoritative over the mere
+  // existence of a git remote.
+  const config = await loadConfig(tuckDir);
+  assertRemoteAvailable(config.remote, 'push');
+
   try {
     await withSpinner('Pushing...', async () => {
       await push(tuckDir, {
@@ -164,6 +172,11 @@ const runPush = async (options: PushOptions): Promise<void> => {
   if (!hasRemoteRepo) {
     throw new GitError('No remote configured', "Run 'tuck init -r <url>' or add a remote manually");
   }
+
+  // Provider gate: refuse to push in local-only mode even if a stray 'origin'
+  // remote exists. The provider mode in config is authoritative.
+  const config = await loadConfig(tuckDir);
+  assertRemoteAvailable(config.remote, 'push');
 
   const branch = await getCurrentBranch(tuckDir);
   // Capture how far ahead of the remote we are, for the JSON envelope only.

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -41,6 +41,8 @@ import {
 } from '../lib/files.js';
 import { addToTuckignore, loadTuckignore, isIgnored } from '../lib/tuckignore.js';
 import { checkLocalMode } from '../lib/remoteChecks.js';
+import { loadConfig } from '../lib/config.js';
+import { assertRemoteAvailable } from '../lib/providers/index.js';
 import { runPreSyncHook, runPostSyncHook, type HookOptions } from '../lib/hooks.js';
 import { NotInitializedError, SecretsDetectedError, MergeConflictsError } from '../errors.js';
 import { setJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
@@ -937,6 +939,11 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
 const pushWithSpinner = async (tuckDir: string, _options: SyncOptions): Promise<boolean> => {
   const spinner = prompts.spinner();
   try {
+    // Provider gate: refuse to push in local-only mode even if a stray 'origin'
+    // remote is present. The configured provider mode is authoritative.
+    const config = await loadConfig(tuckDir);
+    assertRemoteAvailable(config.remote, 'push');
+
     const status = await getStatus(tuckDir);
     const needsUpstream = !status.tracking;
     const branch = status.branch;
@@ -1080,6 +1087,10 @@ export const runSyncCommand = async (
     const message = messageArg || options.message;
     const result = await syncFiles(tuckDir, changes, { ...options, message });
     if (options.push !== false && !(await checkLocalMode(tuckDir)) && (await hasRemote(tuckDir))) {
+      // Provider gate: local-only mode refuses the push regardless of any stray
+      // 'origin' remote. The configured provider mode is authoritative.
+      const config = await loadConfig(tuckDir);
+      assertRemoteAvailable(config.remote, 'push');
       try {
         await push(tuckDir);
       } catch (err) {
@@ -1146,6 +1157,10 @@ export const runSyncCommand = async (
     // Push by default unless --no-push
     // Commander converts --no-push to push: false, default is push: true
     if (options.push !== false && !(await checkLocalMode(tuckDir)) && (await hasRemote(tuckDir))) {
+      // Provider gate: local-only mode refuses the push regardless of any stray
+      // 'origin' remote. The configured provider mode is authoritative.
+      const config = await loadConfig(tuckDir);
+      assertRemoteAvailable(config.remote, 'push');
       await withSpinner('Pushing to remote...', async () => {
         await push(tuckDir);
       });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,9 +1,17 @@
-import simpleGit, { SimpleGit, StatusResult } from 'simple-git';
+import simpleGit, { SimpleGit, StatusResult, SimpleGitOptions } from 'simple-git';
 import { GitError } from '../errors.js';
 import { pathExists } from './paths.js';
 import { join } from 'path';
 import { readdir } from 'fs/promises';
 import { REPO_STAGE_BLOCKLIST } from './state.js';
+import { GIT_OPERATION_TIMEOUTS } from './validation.js';
+
+/**
+ * Upper bound on the buffered output of a single git child process. Mirrors
+ * CustomProvider.cloneRepo so a hostile/huge remote cannot make tuck buffer
+ * unbounded data into memory during a clone.
+ */
+const CLONE_MAX_BUFFER = 10 * 1024 * 1024; // 10MB
 
 export interface GitStatus {
   isRepo: boolean;
@@ -49,7 +57,15 @@ export const initRepo = async (dir: string): Promise<void> => {
 
 export const cloneRepo = async (url: string, dir: string): Promise<void> => {
   try {
-    const git = simpleGit();
+    // Bound the clone: a hung or hostile remote must never let `tuck init` /
+    // `tuck apply` hang forever. `timeout.block` forcibly closes the git child
+    // process if it stops producing output, and `maxBuffer` caps how much output
+    // we buffer (mirrors CustomProvider.cloneRepo).
+    const cloneOptions: Partial<SimpleGitOptions> & { maxBuffer: number } = {
+      timeout: { block: GIT_OPERATION_TIMEOUTS.CLONE },
+      maxBuffer: CLONE_MAX_BUFFER,
+    };
+    const git = simpleGit(cloneOptions);
     await git.clone(url, dir);
   } catch (error) {
     throw new GitError(`Failed to clone repository from ${url}`, String(error));

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,10 +1,14 @@
-import simpleGit, { SimpleGit, StatusResult, SimpleGitOptions } from 'simple-git';
+import simpleGit, { SimpleGit, StatusResult } from 'simple-git';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { GitError } from '../errors.js';
 import { pathExists } from './paths.js';
 import { join } from 'path';
 import { readdir } from 'fs/promises';
 import { REPO_STAGE_BLOCKLIST } from './state.js';
 import { GIT_OPERATION_TIMEOUTS } from './validation.js';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Upper bound on the buffered output of a single git child process. Mirrors
@@ -58,15 +62,17 @@ export const initRepo = async (dir: string): Promise<void> => {
 export const cloneRepo = async (url: string, dir: string): Promise<void> => {
   try {
     // Bound the clone: a hung or hostile remote must never let `tuck init` /
-    // `tuck apply` hang forever. `timeout.block` forcibly closes the git child
-    // process if it stops producing output, and `maxBuffer` caps how much output
-    // we buffer (mirrors CustomProvider.cloneRepo).
-    const cloneOptions: Partial<SimpleGitOptions> & { maxBuffer: number } = {
-      timeout: { block: GIT_OPERATION_TIMEOUTS.CLONE },
+    // `tuck apply` hang forever, nor buffer unbounded output into memory.
+    //
+    // We shell out to `git clone` via Node's `execFile` (mirroring
+    // CustomProvider.cloneRepo) instead of simple-git, because simple-git v3
+    // does NOT forward `maxBuffer` to the underlying child process — only its
+    // `timeout.block` is honored, so the memory bound would silently be a no-op.
+    // `execFile`'s own `timeout` kills the process and `maxBuffer` caps output.
+    await execFileAsync('git', ['clone', url, dir], {
+      timeout: GIT_OPERATION_TIMEOUTS.CLONE,
       maxBuffer: CLONE_MAX_BUFFER,
-    };
-    const git = simpleGit(cloneOptions);
-    await git.clone(url, dir);
+    });
   } catch (error) {
     throw new GitError(`Failed to clone repository from ${url}`, String(error));
   }
@@ -87,6 +93,38 @@ export const removeRemote = async (dir: string, name: string): Promise<void> => 
     await git.removeRemote(name);
   } catch (error) {
     throw new GitError('Failed to remove remote', String(error));
+  }
+};
+
+/**
+ * Point an existing remote at a new URL (`git remote set-url <name> <url>`).
+ */
+export const setRemoteUrl = async (dir: string, name: string, url: string): Promise<void> => {
+  try {
+    const git = createGit(dir);
+    await git.remote(['set-url', name, url]);
+  } catch (error) {
+    throw new GitError('Failed to set remote url', String(error));
+  }
+};
+
+/**
+ * Idempotently configure a remote: if it already exists, update its URL in
+ * place; otherwise add it. This avoids the remove-then-add race (a transient
+ * state with NO origin) that breaks concurrent/repeated reconfiguration.
+ */
+export const upsertRemote = async (dir: string, name: string, url: string): Promise<void> => {
+  try {
+    if (await hasRemote(dir, name)) {
+      await setRemoteUrl(dir, name, url);
+    } else {
+      await addRemote(dir, name, url);
+    }
+  } catch (error) {
+    if (error instanceof GitError) {
+      throw error;
+    }
+    throw new GitError('Failed to upsert remote', String(error));
   }
 };
 

--- a/src/lib/manifestFile.ts
+++ b/src/lib/manifestFile.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared loader for a cloned/remote manifest file.
+ *
+ * A manifest that came from a clone (or any remote) is UNTRUSTED input: it can
+ * be hand-crafted by a hostile repo to smuggle malformed or unsafe entries.
+ * This module is the single choke point that JSON.parses AND zod-validates such
+ * a manifest, so callers (init's analyzeRepository, apply's clone read) always
+ * act on a schema-valid object rather than a half-typed blob.
+ */
+import { readFile } from 'fs/promises';
+import { tuckManifestSchema, type TuckManifestOutput } from '../schemas/manifest.schema.js';
+
+/**
+ * Read, JSON-parse, and zod-validate a manifest file.
+ *
+ * @param manifestPath Absolute path to a `.tuckmanifest.json` file.
+ * @returns The parsed, schema-validated manifest.
+ * @throws SyntaxError if the file is not valid JSON.
+ * @throws ZodError if the parsed value does not satisfy the manifest schema.
+ */
+export const loadManifestFile = async (manifestPath: string): Promise<TuckManifestOutput> => {
+  const content = await readFile(manifestPath, 'utf-8');
+  const parsed = JSON.parse(content) as unknown;
+  return tuckManifestSchema.parse(parsed);
+};

--- a/src/lib/remoteSetup.ts
+++ b/src/lib/remoteSetup.ts
@@ -1,0 +1,115 @@
+/**
+ * Remote Setup (provider-agnostic)
+ *
+ * Drives the "set up a remote repository" step of `tuck init` and
+ * `tuck config remote` purely through the {@link GitProvider} interface.
+ *
+ * Previously this step funneled EVERY chosen provider through GitHub-specific
+ * code (`setupGitHubRepo` / `validateGitHubUrl`), which hard-coded
+ * `git@github.com` / `github.com` and rejected any GitLab or custom URL. As a
+ * result GitLab/custom repo creation only worked via `tuck config remote`,
+ * never via `tuck init`.
+ *
+ * `setupRemoteForProvider` removes that funnel: it uses the provider's own
+ * `getSetupInstructions`, `validateUrl`, and `buildRepoUrl`, so github, gitlab,
+ * custom, and local each behave correctly. There is no hard-coded host here.
+ */
+
+import { prompts } from '../ui/index.js';
+import { addRemote } from './git.js';
+import type { GitProvider } from './providers/types.js';
+
+/** Result of configuring a remote for the chosen provider. */
+export interface RemoteSetupResult {
+  /** The configured remote URL, or null if no remote was set up. */
+  remoteUrl: string | null;
+  /** Whether an initial push was performed (always false here; push is handled by the caller). */
+  pushed: boolean;
+}
+
+export interface SetupRemoteOptions {
+  /** Default repository name used to build the example/placeholder URL. */
+  repoName?: string;
+}
+
+/**
+ * Build an example repository URL for the prompt placeholder using the
+ * provider's own URL builder. Falls back to a generic placeholder when the
+ * provider cannot build URLs (e.g. custom/local providers throw).
+ */
+const buildPlaceholderUrl = (
+  provider: GitProvider,
+  repoName: string,
+  protocol: 'ssh' | 'https'
+): string => {
+  try {
+    return provider.buildRepoUrl('username', repoName, protocol);
+  } catch {
+    return protocol === 'ssh'
+      ? 'git@host:user/dotfiles.git'
+      : 'https://host/user/dotfiles.git';
+  }
+};
+
+/**
+ * Set up a git remote for the given provider using the provider abstraction.
+ *
+ * Behavior by provider:
+ * - `local` (or any provider where `requiresRemote === false`): no-op,
+ *   returns `{ remoteUrl: null, pushed: false }`.
+ * - `github` / `gitlab` / `custom`: shows the provider's setup instructions,
+ *   asks whether the repo was created, then prompts for a URL validated by the
+ *   provider's own `validateUrl` and wires it up as `origin`.
+ *
+ * Never assumes github.com and never calls GitHub-specific validation.
+ */
+export const setupRemoteForProvider = async (
+  provider: GitProvider,
+  tuckDir: string,
+  opts: SetupRemoteOptions = {}
+): Promise<RemoteSetupResult> => {
+  // Local mode (or any provider that doesn't require a remote): nothing to do.
+  if (!provider.requiresRemote || provider.mode === 'local') {
+    return { remoteUrl: null, pushed: false };
+  }
+
+  const repoName = opts.repoName ?? 'dotfiles';
+
+  console.log();
+  prompts.note(provider.getSetupInstructions(), 'Repository Setup');
+  console.log();
+
+  const created = await prompts.confirm('Have you created the repository?', true);
+  if (!created) {
+    return { remoteUrl: null, pushed: false };
+  }
+
+  // Prefer an SSH example for providers that can build one; gracefully fall
+  // back for custom/local which throw from buildRepoUrl.
+  const placeholder = buildPlaceholderUrl(provider, repoName, 'ssh');
+
+  const url = await prompts.text('Paste your repository URL:', {
+    placeholder,
+    validate: (value: string) => {
+      if (!value || !value.trim()) return 'Repository URL is required';
+      return provider.validateUrl(value)
+        ? undefined
+        : `Please enter a valid ${provider.displayName} URL`;
+    },
+  });
+
+  if (!url) {
+    return { remoteUrl: null, pushed: false };
+  }
+
+  try {
+    await addRemote(tuckDir, 'origin', url);
+    prompts.log.success('Remote added successfully');
+    return { remoteUrl: url, pushed: false };
+  } catch (error) {
+    prompts.log.error(
+      `Failed to add remote: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return { remoteUrl: null, pushed: false };
+  }
+};

--- a/src/lib/remoteSetup.ts
+++ b/src/lib/remoteSetup.ts
@@ -16,7 +16,7 @@
  */
 
 import { prompts } from '../ui/index.js';
-import { addRemote } from './git.js';
+import { upsertRemote } from './git.js';
 import type { GitProvider } from './providers/types.js';
 
 /** Result of configuring a remote for the chosen provider. */
@@ -52,14 +52,93 @@ const buildPlaceholderUrl = (
 };
 
 /**
+ * Safely probe whether the provider's CLI is both installed and authenticated.
+ *
+ * `isCliInstalled`/`isAuthenticated` may be absent on a partial provider or may
+ * throw (CLI invocation failure); any problem is treated as "not available" so
+ * we fall back to the manual flow rather than crashing the wizard.
+ */
+const cliAvailable = async (provider: GitProvider): Promise<boolean> => {
+  if (!provider.cliName) return false;
+  try {
+    const installed =
+      typeof provider.isCliInstalled === 'function'
+        ? await provider.isCliInstalled().catch(() => false)
+        : false;
+    if (!installed) return false;
+    const authed =
+      typeof provider.isAuthenticated === 'function'
+        ? await provider.isAuthenticated().catch(() => false)
+        : false;
+    return authed;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Provider-neutral auto-create: prompt to create a repository through the
+ * provider's own CLI (gh for GitHub, glab for GitLab — same code path), then
+ * upsert the resulting URL as `origin`.
+ *
+ * Returns the configured result on success, or `null` to signal the caller to
+ * fall through to the manual paste-URL flow (user declined, or createRepo /
+ * getPreferredRepoUrl failed — never throws).
+ */
+const tryAutoCreate = async (
+  provider: GitProvider,
+  tuckDir: string,
+  defaultRepoName: string
+): Promise<RemoteSetupResult | null> => {
+  const wantsAuto = await prompts.confirm(
+    `Create a ${provider.displayName} repository automatically?`,
+    true
+  );
+  if (!wantsAuto) return null;
+
+  const name = await prompts.text('Repository name:', {
+    placeholder: defaultRepoName,
+    defaultValue: defaultRepoName,
+    validate: (value: string) =>
+      value && value.trim() ? undefined : 'Repository name is required',
+  });
+  const repoName = (name && name.trim()) || defaultRepoName;
+
+  const isPrivate = await prompts.confirm('Make it private?', true);
+
+  try {
+    const repo = await provider.createRepo({
+      name: repoName,
+      isPrivate,
+      description: 'Dotfiles managed by tuck',
+    });
+    const url = await provider.getPreferredRepoUrl(repo);
+    await upsertRemote(tuckDir, 'origin', url);
+    prompts.log.success(`Created ${provider.displayName} repository`);
+    return { remoteUrl: url, pushed: false };
+  } catch (error) {
+    // Auto-create failed: warn and fall back to the manual flow (do not throw).
+    prompts.log.warning(
+      `Could not create repository automatically: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
+};
+
+/**
  * Set up a git remote for the given provider using the provider abstraction.
  *
  * Behavior by provider:
  * - `local` (or any provider where `requiresRemote === false`): no-op,
  *   returns `{ remoteUrl: null, pushed: false }`.
- * - `github` / `gitlab` / `custom`: shows the provider's setup instructions,
- *   asks whether the repo was created, then prompts for a URL validated by the
- *   provider's own `validateUrl` and wires it up as `origin`.
+ * - `github` / `gitlab`: if the provider's CLI is installed AND authenticated,
+ *   offers to create the repo automatically (provider-neutral — gh and glab use
+ *   the identical code path). On decline/failure, falls back to the manual flow.
+ * - `custom` / CLI-less / unauthenticated: shows the provider's setup
+ *   instructions, asks whether the repo was created, then prompts for a URL
+ *   validated by the provider's own `validateUrl` and wires it up as `origin`.
  *
  * Never assumes github.com and never calls GitHub-specific validation.
  */
@@ -74,6 +153,17 @@ export const setupRemoteForProvider = async (
   }
 
   const repoName = opts.repoName ?? 'dotfiles';
+
+  // Provider-neutral AUTO-CREATE: if the provider's CLI is installed and
+  // authenticated, offer to create the repo for the user. This gives GitLab
+  // (glab) the same first-class experience GitHub (gh) already had.
+  if (await cliAvailable(provider)) {
+    const auto = await tryAutoCreate(provider, tuckDir, repoName);
+    if (auto) {
+      return auto;
+    }
+    // Declined or failed → fall through to the manual flow below.
+  }
 
   console.log();
   prompts.note(provider.getSetupInstructions(), 'Repository Setup');
@@ -103,7 +193,9 @@ export const setupRemoteForProvider = async (
   }
 
   try {
-    await addRemote(tuckDir, 'origin', url);
+    // Upsert (set-url if origin exists, else add) so reconfiguring an existing
+    // repo doesn't hit the remove-then-add race.
+    await upsertRemote(tuckDir, 'origin', url);
     prompts.log.success('Remote added successfully');
     return { remoteUrl: url, pushed: false };
   } catch (error) {

--- a/tests/commands/apply-provider.test.ts
+++ b/tests/commands/apply-provider.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Provider-neutral apply source resolution.
+ *
+ * `tuck apply <source>` must NOT hard-code github.com. Two behaviours under test:
+ *
+ *  1. A file:// (custom) source clones through the CUSTOM provider's cloneRepo
+ *     (which carries the clone timeout/maxBuffer), never through any github code
+ *     path. We mock that provider clone to populate a memfs temp repo, then prove
+ *     apply read+applied it with zero github involvement.
+ *
+ *  2. A bare owner/repo resolves its clone URL via the CONFIGURED provider's
+ *     buildRepoUrl (here: gitlab), never via a literal `https://github.com/...`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+
+const gitCloneRepoMock = vi.fn();
+const customCloneRepoMock = vi.fn();
+const configuredBuildRepoUrlMock = vi.fn();
+const configuredCloneRepoMock = vi.fn();
+const ghCloneRepoMock = vi.fn();
+const isGhInstalledMock = vi.fn().mockResolvedValue(false);
+const loadConfigMock = vi.fn();
+
+const loggerSuccessMock = vi.fn();
+const loggerInfoMock = vi.fn();
+const loggerWarningMock = vi.fn();
+
+const findPlaceholdersMock = vi.fn();
+const restoreContentMock = vi.fn();
+
+// A custom provider whose cloneRepo we can assert on (stands in for file:// /
+// full-URL / tarball clones routed away from github).
+const customProviderStub = {
+  mode: 'custom' as const,
+  cloneRepo: customCloneRepoMock,
+  buildRepoUrl: vi.fn(),
+};
+
+// The "configured" provider (gitlab here) — bare owner/repo must build its URL
+// through buildRepoUrl, never a hard-coded github literal.
+const configuredProviderStub = {
+  mode: 'gitlab' as const,
+  cloneRepo: configuredCloneRepoMock,
+  buildRepoUrl: configuredBuildRepoUrlMock,
+};
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('merge'),
+    multiselect: vi.fn().mockResolvedValue([]),
+    cancel: vi.fn(),
+  },
+  logger: {
+    info: loggerInfoMock,
+    success: loggerSuccessMock,
+    warning: loggerWarningMock,
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: vi.fn(),
+    dim: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: {
+    yellow: (x: string) => x,
+    dim: (x: string) => x,
+    bold: (x: string) => x,
+    green: (x: string) => x,
+    cyan: (x: string) => x,
+  },
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  cloneRepo: gitCloneRepoMock,
+}));
+
+vi.mock('../../src/lib/github.js', () => ({
+  isGhInstalled: isGhInstalledMock,
+  findDotfilesRepo: vi.fn().mockResolvedValue(null),
+  ghCloneRepo: ghCloneRepoMock,
+  repoExists: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../../src/lib/providers/index.js', () => ({
+  getProvider: (mode: string) => (mode === 'custom' ? customProviderStub : configuredProviderStub),
+}));
+
+vi.mock('../../src/lib/timemachine.js', () => ({
+  createPreApplySnapshot: vi.fn().mockResolvedValue({ id: 'snap' }),
+}));
+
+vi.mock('../../src/lib/merge.js', () => ({
+  smartMerge: vi.fn(async (_d: string, content: string) => ({ content, preservedBlocks: 0 })),
+  isShellFile: vi.fn().mockReturnValue(false),
+  generateMergePreview: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  findPlaceholders: findPlaceholdersMock,
+  restoreContent: restoreContentMock,
+  restoreFiles: vi.fn().mockResolvedValue({ totalRestored: 0, allUnresolved: [] }),
+  getAllSecrets: vi.fn().mockResolvedValue({}),
+  getSecretCount: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('../../src/lib/secretBackends/index.js', () => ({
+  createResolver: vi.fn(),
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../src/lib/platform.js', () => ({
+  IS_WINDOWS: false,
+}));
+
+const writeManifestRepo = (dir: string, contents: string): void => {
+  const manifest = createMockManifest({
+    files: {
+      safe: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+    },
+  });
+  vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+  vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+  vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), contents);
+};
+
+describe('apply provider-neutral source resolution', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+    isGhInstalledMock.mockResolvedValue(false);
+    findPlaceholdersMock.mockReturnValue([]);
+    restoreContentMock.mockImplementation((content: string) => ({
+      restoredContent: content,
+      unresolved: [],
+    }));
+    // Configured provider is gitlab — bare owner/repo must route through it.
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'gitlab' }, security: { secretBackend: 'local' } });
+    configuredBuildRepoUrlMock.mockReturnValue('https://gitlab.com/team/dotfiles.git');
+
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('clones a file:// source via the custom provider, never github', async () => {
+    // The custom provider clone populates the temp repo dir (no real network).
+    customCloneRepoMock.mockImplementation(async (_url: string, dir: string) => {
+      vol.mkdirSync(dir, { recursive: true });
+      writeManifestRepo(dir, 'export FROM_FILE_URL=1');
+    });
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('file:///srv/dotfiles.git', { replace: true });
+
+    // Routed through the custom provider's capped clone, with the file:// URL.
+    expect(customCloneRepoMock).toHaveBeenCalledTimes(1);
+    expect(customCloneRepoMock).toHaveBeenCalledWith(
+      'file:///srv/dotfiles.git',
+      expect.any(String)
+    );
+
+    // Absolutely no github path was taken.
+    expect(gitCloneRepoMock).not.toHaveBeenCalled();
+    expect(ghCloneRepoMock).not.toHaveBeenCalled();
+    expect(isGhInstalledMock).not.toHaveBeenCalled();
+
+    // The cloned manifest was read and the file applied.
+    expect(vol.readFileSync(join(TEST_HOME, '.zshrc'), 'utf-8')).toBe('export FROM_FILE_URL=1');
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Applied 1 files');
+  });
+
+  it('resolves a bare owner/repo URL via the configured provider buildRepoUrl, not github.com', async () => {
+    gitCloneRepoMock.mockImplementation(async (_url: string, dir: string) => {
+      vol.mkdirSync(dir, { recursive: true });
+      writeManifestRepo(dir, 'export FROM_GITLAB=1');
+    });
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('team/dotfiles', { replace: true });
+
+    // The configured (gitlab) provider built the URL — github.com never appears.
+    expect(configuredBuildRepoUrlMock).toHaveBeenCalledWith('team', 'dotfiles', 'https');
+    expect(ghCloneRepoMock).not.toHaveBeenCalled();
+    // Whatever clone transport is used, it must receive the provider-built URL,
+    // never a hard-coded https://github.com/team/dotfiles.git.
+    const cloneCalls = [
+      ...gitCloneRepoMock.mock.calls,
+      ...configuredCloneRepoMock.mock.calls,
+      ...customCloneRepoMock.mock.calls,
+    ];
+    expect(cloneCalls.length).toBeGreaterThan(0);
+    for (const call of cloneCalls) {
+      expect(call[0]).toBe('https://gitlab.com/team/dotfiles.git');
+      expect(String(call[0])).not.toContain('github.com');
+    }
+
+    expect(vol.readFileSync(join(TEST_HOME, '.zshrc'), 'utf-8')).toBe('export FROM_GITLAB=1');
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Applied 1 files');
+  });
+});

--- a/tests/commands/config-remote-provider.test.ts
+++ b/tests/commands/config-remote-provider.test.ts
@@ -1,0 +1,140 @@
+/**
+ * config remote dedup tests.
+ *
+ * `tuck config remote` had its own ad-hoc remote-setup flow (createRepo +
+ * getPreferredRepoUrl + addRemote) separate from init. It now delegates to the
+ * SAME shared, provider-agnostic setupRemoteForProvider(provider, tuckDir), so
+ * gitlab/custom go through their own provider rather than a github-shaped path.
+ *
+ * We assert at the seam: when setupProvider() returns a gitlab provider with no
+ * remoteUrl, runConfigRemote calls the shared helper with THAT gitlab provider
+ * and wires up the gitlab URL it returns.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const setupRemoteForProviderMock = vi.fn();
+const setupProviderMock = vi.fn();
+const getProviderMock = vi.fn();
+const addRemoteMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const removeRemoteMock = vi.fn();
+const saveConfigMock = vi.fn();
+const loadConfigMock = vi.fn();
+
+vi.mock('../../src/lib/remoteSetup.js', () => ({
+  setupRemoteForProvider: (...args: unknown[]) => setupRemoteForProviderMock(...args),
+}));
+
+vi.mock('../../src/lib/providerSetup.js', () => ({
+  setupProvider: (...args: unknown[]) => setupProviderMock(...args),
+}));
+
+vi.mock('../../src/lib/providers/index.js', () => ({
+  getProvider: (...args: unknown[]) => getProviderMock(...args),
+  describeProviderConfig: vi.fn(() => 'GitLab'),
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  addRemote: (...args: unknown[]) => addRemoteMock(...args),
+  removeRemote: (...args: unknown[]) => removeRemoteMock(...args),
+  hasRemote: (...args: unknown[]) => hasRemoteMock(...args),
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+  saveConfig: (...args: unknown[]) => saveConfigMock(...args),
+  resetConfig: vi.fn(),
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  getConfigPath: vi.fn((d: string) => `${d}/.tuckrc.json`),
+  collapsePath: vi.fn((p: string) => p),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: vi.fn(),
+}));
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn(async () => true),
+    select: vi.fn(),
+    text: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+  },
+  logger: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  colors: {
+    dim: (x: string) => x,
+    bold: { cyan: (x: string) => x },
+    cyan: (x: string) => x,
+    green: (x: string) => x,
+    yellow: (x: string) => x,
+    white: (x: string) => x,
+  },
+}));
+
+describe('runConfigRemote dedup via setupRemoteForProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'local' } });
+    hasRemoteMock.mockResolvedValue(false);
+    saveConfigMock.mockResolvedValue(undefined);
+  });
+
+  it('delegates the gitlab no-remoteUrl path to the shared setupRemoteForProvider', async () => {
+    const gitlabProvider = {
+      mode: 'gitlab',
+      displayName: 'GitLab',
+      requiresRemote: true,
+    };
+    getProviderMock.mockReturnValue(gitlabProvider);
+
+    // setupProvider resolves a gitlab provider but NO remoteUrl (the old ad-hoc
+    // createRepo branch). The dedup must route this through the shared helper.
+    setupProviderMock.mockResolvedValue({
+      success: true,
+      mode: 'gitlab',
+      config: { mode: 'gitlab', username: 'me' },
+      provider: gitlabProvider,
+    });
+
+    const gitlabUrl = 'git@gitlab.com:me/dotfiles.git';
+    setupRemoteForProviderMock.mockResolvedValue({ remoteUrl: gitlabUrl, pushed: false });
+
+    const { runConfigRemote } = await import('../../src/commands/config.js');
+    await runConfigRemote();
+
+    // The shared helper was called with the gitlab provider (the dedup). The
+    // helper itself owns the addRemote('origin', gitlabUrl) wiring.
+    expect(setupRemoteForProviderMock).toHaveBeenCalledWith(gitlabProvider, '/test-home/.tuck');
+    expect(getProviderMock).toHaveBeenCalledWith('gitlab', { mode: 'gitlab', username: 'me' });
+
+    // config.ts must NOT itself add a github.com remote on the gitlab path.
+    const directRemoteUrls = addRemoteMock.mock.calls.map((c) => c[2]);
+    expect(directRemoteUrls.every((u: string) => !String(u).includes('github.com'))).toBe(true);
+  });
+
+  it('does not call the shared helper for local mode (no remote needed)', async () => {
+    const localProvider = { mode: 'local', displayName: 'Local Only', requiresRemote: false };
+    getProviderMock.mockReturnValue(localProvider);
+    setupProviderMock.mockResolvedValue({
+      success: true,
+      mode: 'local',
+      config: { mode: 'local' },
+      provider: localProvider,
+    });
+
+    const { runConfigRemote } = await import('../../src/commands/config.js');
+    await runConfigRemote();
+
+    expect(setupRemoteForProviderMock).not.toHaveBeenCalled();
+    expect(addRemoteMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/config-remote-provider.test.ts
+++ b/tests/commands/config-remote-provider.test.ts
@@ -16,10 +16,18 @@ const setupRemoteForProviderMock = vi.fn();
 const setupProviderMock = vi.fn();
 const getProviderMock = vi.fn();
 const addRemoteMock = vi.fn();
+const upsertRemoteMock = vi.fn();
 const hasRemoteMock = vi.fn();
 const removeRemoteMock = vi.fn();
 const saveConfigMock = vi.fn();
 const loadConfigMock = vi.fn();
+
+// Hoisted so the ui mock factory can wire them up and tests can assert on the
+// final success/warning message that runConfigRemote prints.
+const { logSuccessMock, logWarningMock } = vi.hoisted(() => ({
+  logSuccessMock: vi.fn(),
+  logWarningMock: vi.fn(),
+}));
 
 vi.mock('../../src/lib/remoteSetup.js', () => ({
   setupRemoteForProvider: (...args: unknown[]) => setupRemoteForProviderMock(...args),
@@ -36,6 +44,7 @@ vi.mock('../../src/lib/providers/index.js', () => ({
 
 vi.mock('../../src/lib/git.js', () => ({
   addRemote: (...args: unknown[]) => addRemoteMock(...args),
+  upsertRemote: (...args: unknown[]) => upsertRemoteMock(...args),
   removeRemote: (...args: unknown[]) => removeRemoteMock(...args),
   hasRemote: (...args: unknown[]) => hasRemoteMock(...args),
 }));
@@ -67,7 +76,7 @@ vi.mock('../../src/ui/index.js', () => ({
     note: vi.fn(),
     cancel: vi.fn(),
     spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
-    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    log: { info: vi.fn(), success: logSuccessMock, warning: logWarningMock, error: vi.fn() },
   },
   logger: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   colors: {
@@ -85,6 +94,8 @@ describe('runConfigRemote dedup via setupRemoteForProvider', () => {
     vi.clearAllMocks();
     loadConfigMock.mockResolvedValue({ remote: { mode: 'local' } });
     hasRemoteMock.mockResolvedValue(false);
+    upsertRemoteMock.mockResolvedValue(undefined);
+    addRemoteMock.mockResolvedValue(undefined);
     saveConfigMock.mockResolvedValue(undefined);
   });
 
@@ -136,5 +147,58 @@ describe('runConfigRemote dedup via setupRemoteForProvider', () => {
 
     expect(setupRemoteForProviderMock).not.toHaveBeenCalled();
     expect(addRemoteMock).not.toHaveBeenCalled();
+    expect(upsertRemoteMock).not.toHaveBeenCalled();
+  });
+
+  it('upserts (never remove+add) when reconfiguring an existing origin with a returned URL', async () => {
+    const gitlabProvider = { mode: 'gitlab', displayName: 'GitLab', requiresRemote: true };
+    getProviderMock.mockReturnValue(gitlabProvider);
+
+    // setupProvider returns a concrete remoteUrl (the line-586 branch), AND an
+    // origin already exists — the old code did remove+add (a race window with no
+    // origin); the fix must upsert in place.
+    hasRemoteMock.mockResolvedValue(true);
+    const gitlabUrl = 'git@gitlab.com:me/dotfiles.git';
+    setupProviderMock.mockResolvedValue({
+      success: true,
+      mode: 'gitlab',
+      remoteUrl: gitlabUrl,
+      config: { mode: 'gitlab', username: 'me' },
+      provider: gitlabProvider,
+    });
+
+    const { runConfigRemote } = await import('../../src/commands/config.js');
+    await runConfigRemote();
+
+    // Reconfigure path upserts the new URL in place; no remove+add race.
+    expect(upsertRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', gitlabUrl);
+    expect(removeRemoteMock).not.toHaveBeenCalled();
+    // With a real remote configured, the helper should not be needed.
+    expect(setupRemoteForProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('warns (does NOT claim success) when the helper configures no remote for a non-local provider', async () => {
+    const gitlabProvider = { mode: 'gitlab', displayName: 'GitLab', requiresRemote: true };
+    getProviderMock.mockReturnValue(gitlabProvider);
+
+    // setupProvider returns no remoteUrl → routes to the shared helper, which
+    // itself returns a NULL remoteUrl (user bailed / no repo created).
+    setupProviderMock.mockResolvedValue({
+      success: true,
+      mode: 'gitlab',
+      config: { mode: 'gitlab', username: 'me' },
+      provider: gitlabProvider,
+    });
+    setupRemoteForProviderMock.mockResolvedValue({ remoteUrl: null, pushed: false });
+
+    const { runConfigRemote } = await import('../../src/commands/config.js');
+    await runConfigRemote();
+
+    // The shared helper ran but configured nothing; the final message must be a
+    // warning, NOT a false "Remote configured" success.
+    expect(setupRemoteForProviderMock).toHaveBeenCalledWith(gitlabProvider, '/test-home/.tuck');
+    expect(logWarningMock).toHaveBeenCalled();
+    const successMessages = logSuccessMock.mock.calls.map((c) => String(c[0]));
+    expect(successMessages.some((m) => /remote configured/i.test(m))).toBe(false);
   });
 });

--- a/tests/commands/init-gitlab-remote.test.ts
+++ b/tests/commands/init-gitlab-remote.test.ts
@@ -1,0 +1,138 @@
+/**
+ * init gitlab/custom remote-setup reroute tests.
+ *
+ * `tuck init` used to funnel every chosen provider through GitHub-specific
+ * setup, hard-coding git@github.com / github.com and rejecting GitLab/custom
+ * URLs. The gitlab/custom branch now delegates to the shared, provider-agnostic
+ * setupRemoteForProvider(getProvider(mode), tuckDir), so the gitlab provider
+ * drives its own URL (never github.com).
+ *
+ * We assert at the seam: setupRemoteForChosenProvider('gitlab', dir) must call
+ * the shared helper with the GITLAB provider and return its gitlab URL, and the
+ * github provider/validators must not be involved.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const setupRemoteForProviderMock = vi.fn();
+const getProviderMock = vi.fn();
+
+// Stub the shared remote-setup module so we can assert init delegates to it
+// with the correct provider instance (the reroute under test).
+vi.mock('../../src/lib/remoteSetup.js', () => ({
+  setupRemoteForProvider: (...args: unknown[]) => setupRemoteForProviderMock(...args),
+}));
+
+vi.mock('../../src/lib/providers/index.js', () => ({
+  getProvider: (...args: unknown[]) => getProviderMock(...args),
+  describeProviderConfig: vi.fn(() => 'gitlab'),
+  buildRemoteConfig: vi.fn((mode: string) => ({ mode })),
+}));
+
+// Keep all heavy deps inert; only the reroute seam matters here.
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  nextSteps: vi.fn(),
+  withSpinner: vi.fn(async (_l: string, fn: () => Promise<unknown>) => fn()),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    text: vi.fn(),
+    confirm: vi.fn(),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn(), step: vi.fn() },
+  },
+  logger: { success: vi.fn(), info: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  colors: { brand: (x: string) => x, dim: (x: string) => x, bold: (x: string) => x, warning: (x: string) => x, muted: (x: string) => x },
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  initRepo: vi.fn(),
+  addRemote: vi.fn(),
+  cloneRepo: vi.fn(),
+  setDefaultBranch: vi.fn(),
+  stageAll: vi.fn(),
+  commit: vi.fn(),
+  push: vi.fn(),
+}));
+
+vi.mock('../../src/lib/github.js', () => ({
+  isGhInstalled: vi.fn(),
+  isGhAuthenticated: vi.fn(),
+  getAuthenticatedUser: vi.fn(),
+  createRepo: vi.fn(),
+  getPreferredRepoUrl: vi.fn(),
+  getPreferredRemoteProtocol: vi.fn(),
+  findDotfilesRepo: vi.fn(),
+  ghCloneRepo: vi.fn(),
+  checkSSHKeys: vi.fn(),
+  testSSHConnection: vi.fn(),
+  getSSHKeyInstructions: vi.fn(),
+  getFineGrainedTokenInstructions: vi.fn(),
+  getClassicTokenInstructions: vi.fn(),
+  getGitHubCLIInstallInstructions: vi.fn(),
+  storeGitHubCredentials: vi.fn(),
+  detectTokenType: vi.fn(),
+  configureGitCredentialHelperWithOptions: vi.fn(),
+  testStoredCredentials: vi.fn(),
+  diagnoseAuthIssue: vi.fn(),
+  MIN_GITHUB_TOKEN_LENGTH: 40,
+  GITHUB_TOKEN_PREFIXES: ['ghp_'],
+}));
+
+vi.mock('../../src/lib/providerSetup.js', () => ({
+  setupProvider: vi.fn(),
+  detectProviderFromUrl: vi.fn(() => 'local'),
+}));
+
+describe('init gitlab/custom remote reroute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes the gitlab path through the shared setupRemoteForProvider with the gitlab provider', async () => {
+    const gitlabProvider = {
+      mode: 'gitlab',
+      displayName: 'GitLab',
+      requiresRemote: true,
+      buildRepoUrl: vi.fn(
+        (u: string, r: string) => `git@gitlab.com:${u}/${r}.git`
+      ),
+      validateUrl: vi.fn((url: string) => url.includes('gitlab.com')),
+    };
+    getProviderMock.mockReturnValue(gitlabProvider);
+
+    const gitlabUrl = 'git@gitlab.com:user/dotfiles.git';
+    setupRemoteForProviderMock.mockResolvedValue({ remoteUrl: gitlabUrl, pushed: false });
+
+    const { setupRemoteForChosenProvider } = await import('../../src/commands/init.js');
+    const result = await setupRemoteForChosenProvider('gitlab', '/test-home/.tuck');
+
+    // The reroute resolved the GITLAB provider, not GitHub.
+    expect(getProviderMock).toHaveBeenCalledWith('gitlab');
+    // ...and handed that gitlab provider to the shared helper.
+    expect(setupRemoteForProviderMock).toHaveBeenCalledWith(gitlabProvider, '/test-home/.tuck');
+
+    // The URL that flows back is the gitlab URL, never github.com.
+    expect(result).toBe(gitlabUrl);
+    expect(result).not.toContain('github.com');
+  });
+
+  it('returns null when the shared helper configured no remote (no github fallback)', async () => {
+    const gitlabProvider = { mode: 'gitlab', displayName: 'GitLab', requiresRemote: true };
+    getProviderMock.mockReturnValue(gitlabProvider);
+    setupRemoteForProviderMock.mockResolvedValue({ remoteUrl: null, pushed: false });
+
+    const { setupRemoteForChosenProvider } = await import('../../src/commands/init.js');
+    const result = await setupRemoteForChosenProvider('gitlab', '/test-home/.tuck');
+
+    expect(result).toBeNull();
+    // The github auto-setup must never be consulted on the gitlab path.
+    const github = await import('../../src/lib/github.js');
+    expect(github.isGhInstalled).not.toHaveBeenCalled();
+    expect(github.createRepo).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/push-local-gate.test.ts
+++ b/tests/commands/push-local-gate.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Local-mode push gating via assertRemoteAvailable.
+ *
+ * When config.remote.mode === 'local', a push must be refused even if a stray
+ * git 'origin' remote is present. push.ts consults the provider gate
+ * (assertRemoteAvailable) — which throws LocalModeError in local mode — before
+ * ever invoking git push. In a non-local mode the push proceeds as normal.
+ */
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const loadManifestMock = vi.fn();
@@ -10,10 +19,8 @@ const getStatusMock = vi.fn();
 const getCurrentBranchMock = vi.fn();
 const addRemoteMock = vi.fn();
 const logForcePushMock = vi.fn();
-
-const loggerSuccessMock = vi.fn();
-const loggerInfoMock = vi.fn();
-const loggerWarningMock = vi.fn();
+const loadConfigMock = vi.fn();
+const assertRemoteAvailableMock = vi.fn();
 
 vi.mock('../../src/ui/index.js', () => ({
   prompts: {
@@ -21,7 +28,7 @@ vi.mock('../../src/ui/index.js', () => ({
     outro: vi.fn(),
     confirm: vi.fn().mockResolvedValue(true),
     confirmDangerous: vi.fn().mockResolvedValue(true),
-    text: vi.fn(),
+    text: vi.fn().mockResolvedValue('git@github.com:user/dotfiles.git'),
     cancel: vi.fn(),
     note: vi.fn(),
     log: {
@@ -32,9 +39,9 @@ vi.mock('../../src/ui/index.js', () => ({
     },
   },
   logger: {
-    success: loggerSuccessMock,
-    info: loggerInfoMock,
-    warning: loggerWarningMock,
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
   },
   withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
   colors: {
@@ -71,55 +78,69 @@ vi.mock('../../src/lib/audit.js', () => ({
   logForcePush: logForcePushMock,
 }));
 
-// push.ts loads config and consults the provider gate before pushing.
-const loadConfigMock = vi.fn();
-const assertRemoteAvailableMock = vi.fn();
 vi.mock('../../src/lib/config.js', () => ({
   loadConfig: loadConfigMock,
 }));
+
 vi.mock('../../src/lib/providers/index.js', () => ({
   assertRemoteAvailable: assertRemoteAvailableMock,
 }));
 
-describe('push --set-upstream (boolean trigger)', () => {
+describe('push command local-mode gating', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
 
     loadManifestMock.mockResolvedValue({ files: {} });
     checkLocalModeMock.mockResolvedValue(false);
-    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
-    assertRemoteAvailableMock.mockImplementation(() => {});
     showLocalModeWarningForPushMock.mockResolvedValue(undefined);
     pushMock.mockResolvedValue(undefined);
     hasRemoteMock.mockResolvedValue(true);
     getRemoteUrlMock.mockResolvedValue('git@github.com:user/dotfiles.git');
-    getStatusMock.mockResolvedValue({ ahead: 2, behind: 0, tracking: undefined });
+    getStatusMock.mockResolvedValue({ ahead: 2, behind: 0, tracking: 'origin/main' });
     getCurrentBranchMock.mockResolvedValue('main');
     addRemoteMock.mockResolvedValue(undefined);
     logForcePushMock.mockResolvedValue(undefined);
+    // Default: remote mode is github (non-local) and the gate is a no-op.
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
+    assertRemoteAvailableMock.mockImplementation(() => {});
   });
 
-  it('pushes the CURRENT branch, never a ref named after the flag value', async () => {
-    // The current branch is `main`. Passing `--set-upstream` must set upstream
-    // for `main` — it must NOT push a branch literally named "main" only by
-    // accident, and crucially must NOT push some other ref derived from a flag
-    // string. We prove this by making the current branch distinct from any
-    // plausible flag string.
-    getCurrentBranchMock.mockResolvedValue('feature/work');
+  it('refuses to push in local mode even when a stray origin remote exists', async () => {
+    // checkLocalMode is bypassed (stale/false) but config IS local-only and a
+    // stray origin is present — the provider gate must still refuse the push.
+    checkLocalModeMock.mockResolvedValue(false);
+    hasRemoteMock.mockResolvedValue(true);
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'local' } });
+    assertRemoteAvailableMock.mockImplementation((cfg: { mode: string }, op: string) => {
+      if (cfg.mode === 'local') {
+        throw new Error(`Cannot ${op} in local-only mode`);
+      }
+    });
+
+    const { pushCommand } = await import('../../src/commands/push.js');
+
+    await expect(pushCommand.parseAsync(['--set-upstream'], { from: 'user' })).rejects.toThrow(
+      /local-only mode/
+    );
+
+    // The provider gate was consulted with the push operation.
+    expect(assertRemoteAvailableMock).toHaveBeenCalledWith({ mode: 'local' }, 'push');
+    // git push was NEVER invoked.
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with the push in a non-local mode', async () => {
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
 
     const { pushCommand } = await import('../../src/commands/push.js');
     await pushCommand.parseAsync(['--set-upstream'], { from: 'user' });
 
+    expect(assertRemoteAvailableMock).toHaveBeenCalledWith({ mode: 'github' }, 'push');
     expect(pushMock).toHaveBeenCalledWith('/test-home/.tuck', {
       force: undefined,
       setUpstream: true,
-      branch: 'feature/work',
+      branch: 'main',
     });
-    // The flag value must never leak into the branch ref.
-    const call = pushMock.mock.calls[0][1];
-    expect(call.branch).toBe('feature/work');
-    expect(typeof call.setUpstream).toBe('boolean');
-    expect(loggerSuccessMock).toHaveBeenCalledWith('Pushed successfully!');
   });
 });

--- a/tests/commands/push.test.ts
+++ b/tests/commands/push.test.ts
@@ -83,6 +83,19 @@ vi.mock('../../src/lib/audit.js', () => ({
   logForcePush: logForcePushMock,
 }));
 
+// push.ts loads config and consults the provider gate before pushing. Mock both
+// so these tests exercise the (non-local) happy path without touching real config.
+const loadConfigMock = vi.fn();
+const assertRemoteAvailableMock = vi.fn();
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../src/lib/providers/index.js', () => ({
+  assertRemoteAvailable: assertRemoteAvailableMock,
+}));
+
 describe('push command', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -90,6 +103,8 @@ describe('push command', () => {
 
     loadManifestMock.mockResolvedValue({ files: {} });
     checkLocalModeMock.mockResolvedValue(false);
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
+    assertRemoteAvailableMock.mockImplementation(() => {});
     showLocalModeWarningForPushMock.mockResolvedValue(undefined);
     pushMock.mockResolvedValue(undefined);
     hasRemoteMock.mockResolvedValue(true);

--- a/tests/commands/sync-local-gate.test.ts
+++ b/tests/commands/sync-local-gate.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Local-mode push gating for `tuck sync`.
+ *
+ * The non-interactive (--yes / --json) sync path must consult the provider gate
+ * (assertRemoteAvailable) before pushing. In local-only mode the gate throws,
+ * so even a committed change with a stray origin remote is never pushed. In a
+ * non-local mode the push proceeds.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+const updateFileInManifestMock = vi.fn();
+const removeFileFromManifestMock = vi.fn();
+const getTrackedFileBySourceMock = vi.fn();
+const pathExistsMock = vi.fn();
+const copyFileOrDirMock = vi.fn();
+const getFileChecksumMock = vi.fn();
+const deleteFileOrDirMock = vi.fn();
+const loadTuckignoreMock = vi.fn();
+const isIgnoredMock = vi.fn();
+const validateSafeSourcePathMock = vi.fn();
+const validateSafeManifestDestinationMock = vi.fn();
+const validatePathWithinRootMock = vi.fn();
+const resolveLiveTargetMock = vi.fn();
+const runPreSyncHookMock = vi.fn();
+const runPostSyncHookMock = vi.fn();
+const stageAllMock = vi.fn();
+const commitMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const pushMock = vi.fn();
+const checkLocalModeMock = vi.fn();
+const loadConfigMock = vi.fn();
+const assertRemoteAvailableMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(false),
+    confirmDangerous: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('abort'),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      step: vi.fn(),
+      message: vi.fn(),
+    },
+  },
+  logger: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    file: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    dim: vi.fn(),
+  },
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  colors: { dim: (x: string) => x },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  pathExists: pathExistsMock,
+  collapsePath: vi.fn((p: string) => p),
+  validateSafeSourcePath: validateSafeSourcePathMock,
+  validateSafeManifestDestination: validateSafeManifestDestinationMock,
+  validatePathWithinRoot: validatePathWithinRootMock,
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  getAllTrackedFiles: getAllTrackedFilesMock,
+  updateFileInManifest: updateFileInManifestMock,
+  removeFileFromManifest: removeFileFromManifestMock,
+  getTrackedFileBySource: getTrackedFileBySourceMock,
+  clearManifestCache: vi.fn(),
+}));
+
+vi.mock('../../src/lib/repoScope.js', () => ({
+  resolveLiveTarget: resolveLiveTargetMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  stageAll: stageAllMock,
+  commit: commitMock,
+  getStatus: vi.fn().mockResolvedValue({ behind: 0, tracking: 'origin/main', branch: 'main' }),
+  push: pushMock,
+  hasRemote: hasRemoteMock,
+  fetch: vi.fn(),
+  pull: vi.fn(),
+}));
+
+vi.mock('../../src/lib/files.js', () => ({
+  copyFileOrDir: copyFileOrDirMock,
+  getFileChecksum: getFileChecksumMock,
+  deleteFileOrDir: deleteFileOrDirMock,
+  checkFileSizeThreshold: vi.fn().mockResolvedValue({ warn: false, block: false, size: 10 }),
+  formatFileSize: vi.fn((n: number) => `${n} B`),
+  SIZE_BLOCK_THRESHOLD: 100 * 1024 * 1024,
+}));
+
+vi.mock('../../src/lib/tuckignore.js', () => ({
+  addToTuckignore: vi.fn(),
+  loadTuckignore: loadTuckignoreMock,
+  isIgnored: isIgnoredMock,
+}));
+
+vi.mock('../../src/lib/hooks.js', () => ({
+  runPreSyncHook: runPreSyncHookMock,
+  runPostSyncHook: runPostSyncHookMock,
+}));
+
+vi.mock('../../src/lib/detect.js', () => ({
+  detectDotfiles: vi.fn().mockResolvedValue([]),
+  DETECTION_CATEGORIES: {},
+}));
+
+vi.mock('../../src/lib/fileTracking.js', () => ({
+  trackFilesWithProgress: vi.fn().mockResolvedValue({
+    succeeded: 0,
+    failed: 0,
+    errors: [],
+    sensitiveFiles: [],
+  }),
+}));
+
+vi.mock('../../src/lib/trackPipeline.js', () => ({
+  preparePathsForTracking: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  scanForSecrets: vi.fn().mockResolvedValue({ totalSecrets: 0, results: [] }),
+  isSecretScanningEnabled: vi.fn().mockResolvedValue(false),
+  shouldBlockOnSecrets: vi.fn().mockResolvedValue(true),
+  processSecretsForRedaction: vi.fn(),
+  redactFile: vi.fn(),
+}));
+
+vi.mock('../../src/commands/secrets.js', () => ({
+  displayScanResults: vi.fn(),
+}));
+
+vi.mock('../../src/lib/audit.js', () => ({
+  logForceSecretBypass: vi.fn(),
+}));
+
+vi.mock('../../src/lib/remoteChecks.js', () => ({
+  checkLocalMode: checkLocalModeMock,
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../src/lib/providers/index.js', () => ({
+  assertRemoteAvailable: assertRemoteAvailableMock,
+}));
+
+describe('sync command local-mode push gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    loadManifestMock.mockResolvedValue({ files: {} });
+    loadTuckignoreMock.mockResolvedValue(new Set());
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: { source: '~/.zshrc', destination: 'files/shell/zshrc', checksum: 'old' },
+    });
+    pathExistsMock.mockResolvedValue(true);
+    isIgnoredMock.mockResolvedValue(false);
+    getFileChecksumMock.mockResolvedValue('new'); // change detected
+    hasRemoteMock.mockResolvedValue(true); // stray origin present
+    commitMock.mockResolvedValue('abc123def456');
+    checkLocalModeMock.mockResolvedValue(false);
+    validateSafeSourcePathMock.mockImplementation(() => {});
+    validateSafeManifestDestinationMock.mockImplementation(() => {});
+    validatePathWithinRootMock.mockImplementation(() => {});
+    resolveLiveTargetMock.mockImplementation(async (file: { source: string }) =>
+      file.source.replace(/^~\//, '/test-home/')
+    );
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
+    assertRemoteAvailableMock.mockImplementation(() => {});
+  });
+
+  it('refuses to push in local mode even with a stray origin remote', async () => {
+    // The provider gate is authoritative: local mode throws the local-mode
+    // error, which IS the refusal — git push is never invoked. checkLocalMode
+    // is forced false here so the gate is the only thing standing between the
+    // committed change and a push.
+    checkLocalModeMock.mockResolvedValue(false);
+    hasRemoteMock.mockResolvedValue(true);
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'local' } });
+    assertRemoteAvailableMock.mockImplementation((cfg: { mode: string }, op: string) => {
+      if (cfg.mode === 'local') throw new Error(`Cannot ${op} in local-only mode`);
+    });
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+
+    await expect(
+      runSyncCommand(undefined, { yes: true, noHooks: true, pull: false } as never)
+    ).rejects.toThrow(/local-only mode/);
+
+    // Committed locally, but the provider gate blocked the push entirely.
+    expect(commitMock).toHaveBeenCalled();
+    expect(assertRemoteAvailableMock).toHaveBeenCalledWith({ mode: 'local' }, 'push');
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('pushes in a non-local mode after consulting the provider gate', async () => {
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand(undefined, { yes: true, noHooks: true, pull: false } as never);
+
+    expect(assertRemoteAvailableMock).toHaveBeenCalledWith({ mode: 'github' }, 'push');
+    expect(pushMock).toHaveBeenCalled();
+  });
+});

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -155,10 +155,23 @@ vi.mock('../../src/lib/remoteChecks.js', () => ({
   checkLocalMode: checkLocalModeMock,
 }));
 
+// sync.ts loads config and consults the provider gate before pushing. Mock both
+// so these tests exercise the (non-local) happy path without touching real config.
+const loadConfigMock = vi.fn();
+const assertRemoteAvailableMock = vi.fn();
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+vi.mock('../../src/lib/providers/index.js', () => ({
+  assertRemoteAvailable: assertRemoteAvailableMock,
+}));
+
 describe('sync command behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
+    assertRemoteAvailableMock.mockImplementation(() => {});
     loadManifestMock.mockResolvedValue({ files: {} });
     loadTuckignoreMock.mockResolvedValue(new Set());
     getAllTrackedFilesMock.mockResolvedValue({});

--- a/tests/lib/git-clone-timeout.test.ts
+++ b/tests/lib/git-clone-timeout.test.ts
@@ -2,10 +2,11 @@
  * cloneRepo timeout / maxBuffer guard tests.
  *
  * A hung or hostile remote must not let `tuck init` / `tuck apply` hang forever,
- * so cloneRepo configures the simple-git instance with a bounded timeout and a
- * maxBuffer limit (mirroring CustomProvider.cloneRepo). These tests assert the
- * git client is created with those guards wired up — the simple-git factory is
- * fully mocked so no real git process is ever spawned.
+ * and must not let a huge remote buffer unbounded output into memory. simple-git
+ * v3 does NOT forward `maxBuffer` to the child process, so cloneRepo shells out
+ * to git via Node's `execFile` directly (mirroring CustomProvider.cloneRepo),
+ * passing a bounded `timeout` and a `maxBuffer` limit. These tests fully mock
+ * `child_process.execFile` so no real git process is ever spawned.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -13,57 +14,77 @@ import { GIT_OPERATION_TIMEOUTS } from '../../src/lib/validation.js';
 
 // Hoisted so the vi.mock factory (which is itself hoisted to the top of the
 // file) can safely reference these without a TDZ error.
-const { cloneFn, simpleGitFactory } = vi.hoisted(() => {
-  const cloneFn = vi.fn();
-  const mockGitInstance = { clone: cloneFn };
-  // Capture the options the factory is constructed with.
-  const simpleGitFactory = vi.fn(() => mockGitInstance);
-  return { cloneFn, simpleGitFactory };
+const { execFileMock } = vi.hoisted(() => {
+  return { execFileMock: vi.fn() };
 });
 
-vi.mock('simple-git', () => ({
-  default: simpleGitFactory,
-  simpleGit: simpleGitFactory,
+// Mock child_process.execFile. promisify(execFile) calls execFile with a
+// trailing node-style callback; emulate that so the promisified form resolves
+// or rejects based on what the test configures.
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
 }));
 
 import { cloneRepo } from '../../src/lib/git.js';
 
+/**
+ * Configure execFileMock so the promisified wrapper resolves successfully.
+ */
+const resolveExecFile = () => {
+  execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+    const callback = typeof _opts === 'function' ? _opts : cb;
+    callback?.(null, { stdout: '', stderr: '' });
+  });
+};
+
 describe('cloneRepo timeout/maxBuffer guard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    cloneFn.mockResolvedValue(undefined);
+    resolveExecFile();
   });
 
-  it('creates the git client with a bounded clone timeout', async () => {
+  it('invokes git clone via execFile with a bounded clone timeout', async () => {
     await cloneRepo('https://github.com/user/repo.git', '/test-home/cloned');
 
-    expect(simpleGitFactory).toHaveBeenCalledTimes(1);
-    const config = simpleGitFactory.mock.calls[0][0] as {
-      timeout?: { block?: number };
-    };
-    expect(config).toBeDefined();
-    expect(config.timeout?.block).toBe(GIT_OPERATION_TIMEOUTS.CLONE);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = execFileMock.mock.calls[0] as [
+      string,
+      string[],
+      { timeout?: number; maxBuffer?: number },
+    ];
+    expect(cmd).toBe('git');
+    expect(args).toEqual(['clone', 'https://github.com/user/repo.git', '/test-home/cloned']);
+    expect(opts.timeout).toBe(GIT_OPERATION_TIMEOUTS.CLONE);
   });
 
-  it('creates the git client with a maxBuffer limit', async () => {
+  it('invokes git clone via execFile with a maxBuffer limit', async () => {
     await cloneRepo('https://github.com/user/repo.git', '/test-home/cloned');
 
-    const config = simpleGitFactory.mock.calls[0][0] as { maxBuffer?: number };
-    expect(typeof config.maxBuffer).toBe('number');
-    expect(config.maxBuffer).toBeGreaterThan(0);
+    const [, , opts] = execFileMock.mock.calls[0] as [
+      string,
+      string[],
+      { maxBuffer?: number },
+    ];
+    expect(typeof opts.maxBuffer).toBe('number');
+    expect(opts.maxBuffer).toBeGreaterThan(0);
   });
 
   it('clones the requested url into the target directory', async () => {
     await cloneRepo('https://github.com/user/repo.git', '/test-home/cloned');
 
-    expect(cloneFn).toHaveBeenCalledWith(
+    const [, args] = execFileMock.mock.calls[0] as [string, string[]];
+    expect(args).toEqual([
+      'clone',
       'https://github.com/user/repo.git',
-      '/test-home/cloned'
-    );
+      '/test-home/cloned',
+    ]);
   });
 
   it('wraps clone failures in a GitError', async () => {
-    cloneFn.mockRejectedValueOnce(new Error('boom'));
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const callback = typeof _opts === 'function' ? _opts : cb;
+      callback?.(new Error('boom'));
+    });
 
     await expect(
       cloneRepo('https://github.com/user/repo.git', '/test-home/cloned')

--- a/tests/lib/git-clone-timeout.test.ts
+++ b/tests/lib/git-clone-timeout.test.ts
@@ -1,0 +1,72 @@
+/**
+ * cloneRepo timeout / maxBuffer guard tests.
+ *
+ * A hung or hostile remote must not let `tuck init` / `tuck apply` hang forever,
+ * so cloneRepo configures the simple-git instance with a bounded timeout and a
+ * maxBuffer limit (mirroring CustomProvider.cloneRepo). These tests assert the
+ * git client is created with those guards wired up — the simple-git factory is
+ * fully mocked so no real git process is ever spawned.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GIT_OPERATION_TIMEOUTS } from '../../src/lib/validation.js';
+
+// Hoisted so the vi.mock factory (which is itself hoisted to the top of the
+// file) can safely reference these without a TDZ error.
+const { cloneFn, simpleGitFactory } = vi.hoisted(() => {
+  const cloneFn = vi.fn();
+  const mockGitInstance = { clone: cloneFn };
+  // Capture the options the factory is constructed with.
+  const simpleGitFactory = vi.fn(() => mockGitInstance);
+  return { cloneFn, simpleGitFactory };
+});
+
+vi.mock('simple-git', () => ({
+  default: simpleGitFactory,
+  simpleGit: simpleGitFactory,
+}));
+
+import { cloneRepo } from '../../src/lib/git.js';
+
+describe('cloneRepo timeout/maxBuffer guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cloneFn.mockResolvedValue(undefined);
+  });
+
+  it('creates the git client with a bounded clone timeout', async () => {
+    await cloneRepo('https://github.com/user/repo.git', '/test-home/cloned');
+
+    expect(simpleGitFactory).toHaveBeenCalledTimes(1);
+    const config = simpleGitFactory.mock.calls[0][0] as {
+      timeout?: { block?: number };
+    };
+    expect(config).toBeDefined();
+    expect(config.timeout?.block).toBe(GIT_OPERATION_TIMEOUTS.CLONE);
+  });
+
+  it('creates the git client with a maxBuffer limit', async () => {
+    await cloneRepo('https://github.com/user/repo.git', '/test-home/cloned');
+
+    const config = simpleGitFactory.mock.calls[0][0] as { maxBuffer?: number };
+    expect(typeof config.maxBuffer).toBe('number');
+    expect(config.maxBuffer).toBeGreaterThan(0);
+  });
+
+  it('clones the requested url into the target directory', async () => {
+    await cloneRepo('https://github.com/user/repo.git', '/test-home/cloned');
+
+    expect(cloneFn).toHaveBeenCalledWith(
+      'https://github.com/user/repo.git',
+      '/test-home/cloned'
+    );
+  });
+
+  it('wraps clone failures in a GitError', async () => {
+    cloneFn.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      cloneRepo('https://github.com/user/repo.git', '/test-home/cloned')
+    ).rejects.toMatchObject({ code: 'GIT_ERROR' });
+  });
+});

--- a/tests/lib/git-errors.test.ts
+++ b/tests/lib/git-errors.test.ts
@@ -41,6 +41,12 @@ vi.mock('simple-git', () => {
   };
 });
 
+// cloneRepo shells out via child_process.execFile; mock it so its failure path
+// is driven without spawning a real git process. The trailing callback receives
+// an error to emulate a failed clone.
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+vi.mock('child_process', () => ({ execFile: execFileMock }));
+
 // Import after mocking
 import {
   initRepo,
@@ -68,6 +74,12 @@ describe('git-errors', () => {
     vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
     mockGitInstance = createErrorMockGit('Git operation failed');
     vi.clearAllMocks();
+    // execFile (used by cloneRepo) rejects via its node-style callback to
+    // emulate a failed `git clone` without spawning a real process.
+    execFileMock.mockImplementation((_cmd, _args, opts, cb) => {
+      const callback = typeof opts === 'function' ? opts : cb;
+      callback?.(new Error('Git operation failed'));
+    });
   });
 
   afterEach(() => {

--- a/tests/lib/git.test.ts
+++ b/tests/lib/git.test.ts
@@ -62,6 +62,12 @@ vi.mock('simple-git', () => {
   };
 });
 
+// cloneRepo shells out to `git clone` via child_process.execFile (simple-git
+// does not honor maxBuffer), so mock execFile to emulate a successful run and
+// guarantee no real git process is ever spawned.
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+vi.mock('child_process', () => ({ execFile: execFileMock }));
+
 // Import after mocking
 import {
   initRepo,
@@ -81,6 +87,8 @@ import {
   getRemotes,
   addRemote,
   removeRemote,
+  setRemoteUrl,
+  upsertRemote,
   setDefaultBranch,
   cloneRepo,
 } from '../../src/lib/git.js';
@@ -92,6 +100,11 @@ describe('git', () => {
     // Reset the mock git instance before each test
     mockGitInstance = createMockGit();
     vi.clearAllMocks();
+    // promisify(execFile) calls execFile(cmd, args, opts, callback); resolve it.
+    execFileMock.mockImplementation((_cmd, _args, opts, cb) => {
+      const callback = typeof opts === 'function' ? opts : cb;
+      callback?.(null, { stdout: '', stderr: '' });
+    });
   });
 
   afterEach(() => {
@@ -131,9 +144,16 @@ describe('git', () => {
   // ============================================================================
 
   describe('cloneRepo', () => {
-    it('should clone a repository', async () => {
+    it('should clone a repository via execFile', async () => {
       const destDir = join(TEST_HOME, 'cloned-repo');
       await expect(cloneRepo('https://github.com/user/repo.git', destDir)).resolves.not.toThrow();
+
+      expect(execFileMock).toHaveBeenCalledWith(
+        'git',
+        ['clone', 'https://github.com/user/repo.git', destDir],
+        expect.objectContaining({ maxBuffer: expect.any(Number) }),
+        expect.any(Function)
+      );
     });
   });
 
@@ -152,6 +172,49 @@ describe('git', () => {
   describe('removeRemote', () => {
     it('should remove a remote', async () => {
       await expect(removeRemote(TEST_TUCK_DIR, 'origin')).resolves.not.toThrow();
+    });
+  });
+
+  describe('setRemoteUrl', () => {
+    it('should run git remote set-url', async () => {
+      mockGitInstance.remote = vi.fn().mockResolvedValue(undefined);
+      await expect(
+        setRemoteUrl(TEST_TUCK_DIR, 'origin', 'https://github.com/user/new.git')
+      ).resolves.not.toThrow();
+      expect(mockGitInstance.remote).toHaveBeenCalledWith([
+        'set-url',
+        'origin',
+        'https://github.com/user/new.git',
+      ]);
+    });
+  });
+
+  describe('upsertRemote', () => {
+    it('updates an existing origin in place (set-url, never add)', async () => {
+      // Default mock getRemotes returns an existing origin → hasRemote === true.
+      mockGitInstance.remote = vi.fn().mockResolvedValue(undefined);
+      await upsertRemote(TEST_TUCK_DIR, 'origin', 'https://github.com/user/new.git');
+
+      expect(mockGitInstance.remote).toHaveBeenCalledWith([
+        'set-url',
+        'origin',
+        'https://github.com/user/new.git',
+      ]);
+      expect(mockGitInstance.addRemote).not.toHaveBeenCalled();
+    });
+
+    it('adds origin when none exists (no remove+add race)', async () => {
+      // No remotes → hasRemote === false → addRemote path.
+      mockGitInstance.getRemotes = vi.fn().mockResolvedValue([]);
+      mockGitInstance.remote = vi.fn().mockResolvedValue(undefined);
+
+      await upsertRemote(TEST_TUCK_DIR, 'origin', 'https://github.com/user/new.git');
+
+      expect(mockGitInstance.addRemote).toHaveBeenCalledWith(
+        'origin',
+        'https://github.com/user/new.git'
+      );
+      expect(mockGitInstance.remote).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/lib/manifestFile.test.ts
+++ b/tests/lib/manifestFile.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared cloned/remote manifest loader.
+ *
+ * A cloned or remote manifest is UNTRUSTED input: it can be hand-crafted by a
+ * hostile repo to smuggle unsafe entries. `loadManifestFile` is the single
+ * choke point that JSON.parses AND zod-validates a manifest file before any
+ * caller (init's analyzeRepository, apply's clone read) acts on it. A malformed
+ * or schema-violating manifest must be rejected, not silently trusted.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_HOME } from '../setup.js';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+
+const MANIFEST = join(TEST_HOME, 'repo', '.tuckmanifest.json');
+
+describe('loadManifestFile', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(join(TEST_HOME, 'repo'), { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('parses and validates a well-formed manifest', async () => {
+    const manifest = createMockManifest({
+      files: {
+        zsh: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+      },
+    });
+    vol.writeFileSync(MANIFEST, JSON.stringify(manifest, null, 2));
+
+    const { loadManifestFile } = await import('../../src/lib/manifestFile.js');
+    const loaded = await loadManifestFile(MANIFEST);
+
+    expect(loaded.version).toBe('1.0.0');
+    expect(Object.keys(loaded.files)).toContain('zsh');
+    // The schema default fills in the implicit bundle registry.
+    expect(loaded.bundles).toBeTruthy();
+  });
+
+  it('rejects a manifest that is not valid JSON', async () => {
+    vol.writeFileSync(MANIFEST, '{ this is : not json ');
+
+    const { loadManifestFile } = await import('../../src/lib/manifestFile.js');
+    await expect(loadManifestFile(MANIFEST)).rejects.toThrow();
+  });
+
+  it('rejects a manifest whose shape violates the schema', async () => {
+    // Missing required top-level fields (version/created/updated) and a bogus
+    // files map → zod must reject rather than hand back a half-typed object.
+    vol.writeFileSync(
+      MANIFEST,
+      JSON.stringify({ files: { evil: { source: 123 } } })
+    );
+
+    const { loadManifestFile } = await import('../../src/lib/manifestFile.js');
+    await expect(loadManifestFile(MANIFEST)).rejects.toThrow();
+  });
+});

--- a/tests/lib/remoteSetup.test.ts
+++ b/tests/lib/remoteSetup.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for setupRemoteForProvider (src/lib/remoteSetup.ts).
+ *
+ * The init wizard used to funnel GitLab/custom providers through the
+ * GitHub-only setup (setupGitHubRepo / validateGitHubUrl), which hard-coded
+ * github.com and rejected every non-github URL. setupRemoteForProvider drives
+ * the remote-setup step purely through the GitProvider interface so each
+ * provider validates with ITS OWN validateUrl and builds ITS OWN example URL.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  GitProvider,
+  ProviderMode,
+  ProviderRepo,
+} from '../../src/lib/providers/types.js';
+
+// ----------------------------------------------------------------------------
+// Mocks
+// ----------------------------------------------------------------------------
+
+const addRemoteMock = vi.fn();
+const confirmMock = vi.fn();
+const textMock = vi.fn();
+const noteMock = vi.fn();
+
+vi.mock('../../src/lib/git.js', () => ({
+  addRemote: (...args: unknown[]) => addRemoteMock(...args),
+}));
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    confirm: (...args: unknown[]) => confirmMock(...args),
+    text: (...args: unknown[]) => textMock(...args),
+    note: (...args: unknown[]) => noteMock(...args),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+  colors: {
+    brand: (x: string) => x,
+    dim: (x: string) => x,
+    muted: (x: string) => x,
+  },
+}));
+
+// A spy that should NEVER be invoked for non-github providers. If the rerouted
+// code accidentally falls back into GitHub-specific validation, this would be
+// called and the test would catch it.
+const githubValidatorSpy = vi.fn(() => 'Please enter a valid GitHub URL');
+
+/**
+ * Build a minimal fake GitProvider for a given mode. Only the methods used by
+ * setupRemoteForProvider are implemented; everything else throws so an
+ * accidental call is loud.
+ */
+function makeProvider(mode: ProviderMode, overrides: Partial<GitProvider> = {}): GitProvider {
+  const notImplemented = () => {
+    throw new Error(`unexpected provider call for mode=${mode}`);
+  };
+
+  const base: GitProvider = {
+    mode,
+    displayName: mode,
+    cliName: mode === 'local' || mode === 'custom' ? null : mode === 'gitlab' ? 'glab' : 'gh',
+    requiresRemote: mode !== 'local',
+    isCliInstalled: vi.fn(async () => true),
+    isAuthenticated: vi.fn(async () => true),
+    getUser: vi.fn(async () => null),
+    detect: notImplemented as unknown as GitProvider['detect'],
+    repoExists: notImplemented as unknown as GitProvider['repoExists'],
+    createRepo: notImplemented as unknown as GitProvider['createRepo'],
+    getRepoInfo: notImplemented as unknown as GitProvider['getRepoInfo'],
+    cloneRepo: notImplemented as unknown as GitProvider['cloneRepo'],
+    findDotfilesRepo: vi.fn(async () => null),
+    getPreferredRepoUrl: vi.fn(async (r: ProviderRepo) => r.sshUrl),
+    validateUrl: vi.fn(() => true),
+    buildRepoUrl: vi.fn(
+      (username: string, repoName: string, protocol: 'ssh' | 'https') =>
+        protocol === 'ssh'
+          ? `git@gitlab.com:${username}/${repoName}.git`
+          : `https://gitlab.com/${username}/${repoName}.git`
+    ),
+    getSetupInstructions: vi.fn(() => `setup instructions for ${mode}`),
+    getAltAuthInstructions: vi.fn(() => `alt auth for ${mode}`),
+  };
+
+  return { ...base, ...overrides };
+}
+
+describe('setupRemoteForProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    githubValidatorSpy.mockClear();
+  });
+
+  it('returns {remoteUrl:null, pushed:false} for the local provider without prompting', async () => {
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    const local = makeProvider('local', { requiresRemote: false });
+
+    const result = await setupRemoteForProvider(local, '/test-home/.tuck');
+
+    expect(result).toEqual({ remoteUrl: null, pushed: false });
+    // Local mode must not touch git remotes or prompt for a URL.
+    expect(addRemoteMock).not.toHaveBeenCalled();
+    expect(textMock).not.toHaveBeenCalled();
+  });
+
+  it('validates a GitLab URL with the gitlab provider validator (never the github validator)', async () => {
+    const gitlabValidate = vi.fn((url: string) => /^git@gitlab\.com:/.test(url));
+    const gitlab = makeProvider('gitlab', { validateUrl: gitlabValidate });
+
+    confirmMock.mockResolvedValue(true); // "Have you created the repository?"
+    const gitlabUrl = 'git@gitlab.com:user/dotfiles.git';
+    // Capture the validate fn handed to prompts.text and run it ourselves.
+    textMock.mockImplementation(
+      async (_msg: string, opts?: { validate?: (v: string) => string | undefined }) => {
+        // The validator passed to the prompt must accept the gitlab URL...
+        expect(opts?.validate?.(gitlabUrl)).toBeUndefined();
+        // ...and reject a github URL (proving it uses gitlab's validator).
+        expect(opts?.validate?.('https://github.com/u/d.git')).toBeTruthy();
+        return gitlabUrl;
+      }
+    );
+
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    const result = await setupRemoteForProvider(gitlab, '/test-home/.tuck');
+
+    // The gitlab validator was consulted; the github validator never was.
+    expect(gitlabValidate).toHaveBeenCalled();
+    expect(githubValidatorSpy).not.toHaveBeenCalled();
+
+    // Remote was added with the gitlab URL (NOT a github.com URL).
+    expect(addRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', gitlabUrl);
+    expect(addRemoteMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.stringContaining('github.com')
+    );
+
+    expect(result.remoteUrl).toBe(gitlabUrl);
+    expect(result.pushed).toBe(false);
+  });
+
+  it('shows the provider-specific setup instructions, not GitHub instructions', async () => {
+    const gitlab = makeProvider('gitlab');
+    confirmMock.mockResolvedValue(true);
+    textMock.mockResolvedValue('git@gitlab.com:user/dotfiles.git');
+
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    await setupRemoteForProvider(gitlab, '/test-home/.tuck');
+
+    expect(gitlab.getSetupInstructions).toHaveBeenCalled();
+    // The note shown must be the gitlab instructions.
+    expect(noteMock).toHaveBeenCalledWith('setup instructions for gitlab', expect.any(String));
+  });
+
+  it('returns {remoteUrl:null, pushed:false} when the user has not created the repo', async () => {
+    const gitlab = makeProvider('gitlab');
+    confirmMock.mockResolvedValue(false); // "Have you created the repository?" -> No
+
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    const result = await setupRemoteForProvider(gitlab, '/test-home/.tuck');
+
+    expect(result).toEqual({ remoteUrl: null, pushed: false });
+    expect(addRemoteMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts any valid git URL for the custom provider via its own validateUrl', async () => {
+    const customValidate = vi.fn(() => true);
+    const custom = makeProvider('custom', {
+      validateUrl: customValidate,
+      // custom buildRepoUrl throws (matches real CustomProvider); the impl must
+      // tolerate this and still prompt for a URL.
+      buildRepoUrl: vi.fn(() => {
+        throw new Error('Cannot build repository URLs for custom provider');
+      }),
+    });
+
+    confirmMock.mockResolvedValue(true);
+    const customUrl = 'https://git.example.com/u/dots.git';
+    textMock.mockResolvedValue(customUrl);
+
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    const result = await setupRemoteForProvider(custom, '/test-home/.tuck');
+
+    expect(addRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', customUrl);
+    expect(result.remoteUrl).toBe(customUrl);
+  });
+});

--- a/tests/lib/remoteSetup.test.ts
+++ b/tests/lib/remoteSetup.test.ts
@@ -6,6 +6,11 @@
  * github.com and rejected every non-github URL. setupRemoteForProvider drives
  * the remote-setup step purely through the GitProvider interface so each
  * provider validates with ITS OWN validateUrl and builds ITS OWN example URL.
+ *
+ * It also offers a provider-neutral AUTO-CREATE path: when the provider has a
+ * CLI that is installed AND authenticated, it offers to create the repo
+ * automatically (GitHub via gh, GitLab via glab — same code path). When the CLI
+ * is absent/unauthed/declined/failed, it falls back to the manual paste-URL flow.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
@@ -19,12 +24,18 @@ import type {
 // ----------------------------------------------------------------------------
 
 const addRemoteMock = vi.fn();
+const upsertRemoteMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const setRemoteUrlMock = vi.fn();
 const confirmMock = vi.fn();
 const textMock = vi.fn();
 const noteMock = vi.fn();
 
 vi.mock('../../src/lib/git.js', () => ({
   addRemote: (...args: unknown[]) => addRemoteMock(...args),
+  upsertRemote: (...args: unknown[]) => upsertRemoteMock(...args),
+  hasRemote: (...args: unknown[]) => hasRemoteMock(...args),
+  setRemoteUrl: (...args: unknown[]) => setRemoteUrlMock(...args),
 }));
 
 vi.mock('../../src/ui/index.js', () => ({
@@ -55,6 +66,10 @@ const githubValidatorSpy = vi.fn(() => 'Please enter a valid GitHub URL');
  * Build a minimal fake GitProvider for a given mode. Only the methods used by
  * setupRemoteForProvider are implemented; everything else throws so an
  * accidental call is loud.
+ *
+ * NOTE: defaults isCliInstalled/isAuthenticated to TRUE. To exercise the manual
+ * paste-URL flow, pass an override that forces one of them false (otherwise the
+ * auto-create path would be offered).
  */
 function makeProvider(mode: ProviderMode, overrides: Partial<GitProvider> = {}): GitProvider {
   const notImplemented = () => {
@@ -90,10 +105,21 @@ function makeProvider(mode: ProviderMode, overrides: Partial<GitProvider> = {}):
   return { ...base, ...overrides };
 }
 
+/** Force the manual paste-URL flow by making the CLI unavailable. */
+function manualProvider(mode: ProviderMode, overrides: Partial<GitProvider> = {}): GitProvider {
+  return makeProvider(mode, {
+    isCliInstalled: vi.fn(async () => false),
+    ...overrides,
+  });
+}
+
 describe('setupRemoteForProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     githubValidatorSpy.mockClear();
+    upsertRemoteMock.mockResolvedValue(undefined);
+    addRemoteMock.mockResolvedValue(undefined);
+    hasRemoteMock.mockResolvedValue(false);
   });
 
   it('returns {remoteUrl:null, pushed:false} for the local provider without prompting', async () => {
@@ -105,12 +131,14 @@ describe('setupRemoteForProvider', () => {
     expect(result).toEqual({ remoteUrl: null, pushed: false });
     // Local mode must not touch git remotes or prompt for a URL.
     expect(addRemoteMock).not.toHaveBeenCalled();
+    expect(upsertRemoteMock).not.toHaveBeenCalled();
     expect(textMock).not.toHaveBeenCalled();
   });
 
   it('validates a GitLab URL with the gitlab provider validator (never the github validator)', async () => {
     const gitlabValidate = vi.fn((url: string) => /^git@gitlab\.com:/.test(url));
-    const gitlab = makeProvider('gitlab', { validateUrl: gitlabValidate });
+    // Force manual flow (CLI unavailable) so we reach the URL-paste validator.
+    const gitlab = manualProvider('gitlab', { validateUrl: gitlabValidate });
 
     confirmMock.mockResolvedValue(true); // "Have you created the repository?"
     const gitlabUrl = 'git@gitlab.com:user/dotfiles.git';
@@ -132,9 +160,9 @@ describe('setupRemoteForProvider', () => {
     expect(gitlabValidate).toHaveBeenCalled();
     expect(githubValidatorSpy).not.toHaveBeenCalled();
 
-    // Remote was added with the gitlab URL (NOT a github.com URL).
-    expect(addRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', gitlabUrl);
-    expect(addRemoteMock).not.toHaveBeenCalledWith(
+    // Remote was upserted with the gitlab URL (NOT a github.com URL).
+    expect(upsertRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', gitlabUrl);
+    expect(upsertRemoteMock).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       expect.stringContaining('github.com')
@@ -145,7 +173,7 @@ describe('setupRemoteForProvider', () => {
   });
 
   it('shows the provider-specific setup instructions, not GitHub instructions', async () => {
-    const gitlab = makeProvider('gitlab');
+    const gitlab = manualProvider('gitlab');
     confirmMock.mockResolvedValue(true);
     textMock.mockResolvedValue('git@gitlab.com:user/dotfiles.git');
 
@@ -158,7 +186,7 @@ describe('setupRemoteForProvider', () => {
   });
 
   it('returns {remoteUrl:null, pushed:false} when the user has not created the repo', async () => {
-    const gitlab = makeProvider('gitlab');
+    const gitlab = manualProvider('gitlab');
     confirmMock.mockResolvedValue(false); // "Have you created the repository?" -> No
 
     const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
@@ -166,10 +194,12 @@ describe('setupRemoteForProvider', () => {
 
     expect(result).toEqual({ remoteUrl: null, pushed: false });
     expect(addRemoteMock).not.toHaveBeenCalled();
+    expect(upsertRemoteMock).not.toHaveBeenCalled();
   });
 
   it('accepts any valid git URL for the custom provider via its own validateUrl', async () => {
     const customValidate = vi.fn(() => true);
+    // custom.cliName is null so the manual flow is taken automatically.
     const custom = makeProvider('custom', {
       validateUrl: customValidate,
       // custom buildRepoUrl throws (matches real CustomProvider); the impl must
@@ -186,7 +216,105 @@ describe('setupRemoteForProvider', () => {
     const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
     const result = await setupRemoteForProvider(custom, '/test-home/.tuck');
 
-    expect(addRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', customUrl);
+    expect(upsertRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', customUrl);
     expect(result.remoteUrl).toBe(customUrl);
+  });
+
+  it('auto-creates a GitLab repository via the provider CLI (no manual URL prompt)', async () => {
+    const createdRepo: ProviderRepo = {
+      name: 'dotfiles',
+      fullName: 'me/dotfiles',
+      url: 'https://gitlab.com/me/dotfiles',
+      sshUrl: 'git@gitlab.com:me/dotfiles.git',
+      httpsUrl: 'https://gitlab.com/me/dotfiles.git',
+      isPrivate: true,
+    };
+
+    const createRepo = vi.fn(async () => createdRepo);
+    const getPreferredRepoUrl = vi.fn(async (r: ProviderRepo) => r.sshUrl);
+
+    const gitlab = makeProvider('gitlab', {
+      isCliInstalled: vi.fn(async () => true),
+      isAuthenticated: vi.fn(async () => true),
+      createRepo,
+      getPreferredRepoUrl,
+    });
+
+    // confirm() is called for: "Create automatically?" -> yes, "Private?" -> yes
+    confirmMock.mockResolvedValue(true);
+    // text() is the repo-name prompt (NOT a manual URL prompt).
+    textMock.mockResolvedValue('dotfiles');
+
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    const result = await setupRemoteForProvider(gitlab, '/test-home/.tuck');
+
+    // Repo was created through the provider and the remote upserted with its URL.
+    expect(createRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'dotfiles', isPrivate: true })
+    );
+    expect(getPreferredRepoUrl).toHaveBeenCalledWith(createdRepo);
+    expect(upsertRemoteMock).toHaveBeenCalledWith(
+      '/test-home/.tuck',
+      'origin',
+      'git@gitlab.com:me/dotfiles.git'
+    );
+
+    // The manual paste-URL prompt must NOT have been used.
+    const textCalls = textMock.mock.calls;
+    const promptedForUrl = textCalls.some(([msg]) =>
+      String(msg).toLowerCase().includes('url')
+    );
+    expect(promptedForUrl).toBe(false);
+
+    expect(result).toEqual({
+      remoteUrl: 'git@gitlab.com:me/dotfiles.git',
+      pushed: false,
+    });
+  });
+
+  it('falls back to the manual flow when auto-create fails', async () => {
+    const createRepo = vi.fn(async () => {
+      throw new Error('glab boom');
+    });
+
+    const gitlab = makeProvider('gitlab', {
+      isCliInstalled: vi.fn(async () => true),
+      isAuthenticated: vi.fn(async () => true),
+      createRepo,
+    });
+
+    // confirm: auto-create? yes, private? yes, then "created the repo?" yes
+    confirmMock.mockResolvedValue(true);
+    const manualUrl = 'git@gitlab.com:me/dotfiles.git';
+    // First text() = repo name; second text() = manual URL paste.
+    textMock
+      .mockResolvedValueOnce('dotfiles')
+      .mockResolvedValueOnce(manualUrl);
+
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    const result = await setupRemoteForProvider(gitlab, '/test-home/.tuck');
+
+    expect(createRepo).toHaveBeenCalled();
+    // After the failure, the manual flow upserts the pasted URL.
+    expect(upsertRemoteMock).toHaveBeenCalledWith('/test-home/.tuck', 'origin', manualUrl);
+    expect(result.remoteUrl).toBe(manualUrl);
+  });
+
+  it('does not offer auto-create when the CLI is unauthenticated', async () => {
+    const createRepo = vi.fn();
+    const gitlab = makeProvider('gitlab', {
+      isCliInstalled: vi.fn(async () => true),
+      isAuthenticated: vi.fn(async () => false),
+      createRepo,
+    });
+
+    confirmMock.mockResolvedValue(true); // "Have you created the repository?"
+    textMock.mockResolvedValue('git@gitlab.com:me/dotfiles.git');
+
+    const { setupRemoteForProvider } = await import('../../src/lib/remoteSetup.js');
+    await setupRemoteForProvider(gitlab, '/test-home/.tuck');
+
+    // createRepo must never run for an unauthenticated CLI.
+    expect(createRepo).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Wave 3 — reduce GitHub coupling so **GitLab / custom / local are first-class**. TDD throughout; all tests mock git/providers/network and use memfs (no real remote or home touched).

- **Clone safety:** `git.ts cloneRepo` now bounds clones with `timeout` (`GIT_OPERATION_TIMEOUTS.CLONE`) + `maxBuffer` — init/apply can't hang on a huge/wedged remote.
- **Local-mode push gating:** `push` **and** `sync` now call `assertRemoteAvailable(config.remote, 'push')` before every push, so a local-only repo refuses to push even when a stray git `origin` exists (was: pushed whenever an origin existed).
- **`setupRemoteForProvider`** (new `src/lib/remoteSetup.ts`): one provider-agnostic remote-setup flow used by **both** `init` and `config remote`. The init wizard's GitLab/custom branch no longer funnels through GitHub-only setup / `validateGitHubUrl` / hard-coded `github.com` — it uses the chosen provider's `validateUrl`/`buildRepoUrl`. GitHub init's auto-create path is preserved.
- **Provider-neutral `apply <source>`:** routes `custom:` / `file://` / full git URLs through the custom provider's bounded clone, and resolves a bare `owner/repo` via the **configured** provider's `buildRepoUrl` (then detected providers) instead of an unconditional `https://github.com/...` literal.
- **Cloned-manifest validation (security):** new `loadManifestFile()` runs `tuckManifestSchema.parse` on untrusted cloned/remote manifests in both `apply` and `init`, rejecting hostile shapes before use.

**Deferred (noted):** full `lib/github.ts` ↔ `providers/github.ts` dedup and the `runInteractiveInit` state-machine decomposition — both large, low user-value, higher risk.

## Verification
`pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` **1141 passing** (+22).

> Behavior note under review: `config remote` for GitLab/GitHub now uses the unified manual-URL flow (auto-create dropped there; GitHub `init` auto-create retained). Evaluating whether to restore provider-neutral auto-create for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)