### PR TITLE
perf+fix: wave-4 — scan/sync perf, cache invalidation, template engine, files.ts

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -26,6 +26,7 @@ import { smartMerge, isShellFile, generateMergePreview } from '../lib/merge.js';
 import { CATEGORIES } from '../constants.js';
 import { type TuckManifestOutput } from '../schemas/manifest.schema.js';
 import { loadManifestFile } from '../lib/manifestFile.js';
+import { clearManifestCache } from '../lib/manifest.js';
 import { findPlaceholders, restoreContent, restoreFiles as restoreSecrets, getAllSecrets, getSecretCount } from '../lib/secrets/index.js';
 import { createResolver } from '../lib/secretBackends/index.js';
 import { loadConfig } from '../lib/config.js';
@@ -867,6 +868,10 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
     return;
   }
 
+  // cloneSource just rewrote a repo out-of-band. Drop any in-memory manifest
+  // cache so the rest of this run reads fresh state, never a stale manifest.
+  clearManifestCache();
+
   try {
     // Read the manifest
     const manifest = await readClonedManifest(repoDir);
@@ -1059,6 +1064,10 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
   // Clone (or materialize a local source).
   logger.info(local ? 'Reading local source...' : 'Cloning repository...');
   const repoDir = await cloneSource(resolved);
+
+  // cloneSource just rewrote a repo out-of-band. Drop any in-memory manifest
+  // cache so the rest of this run reads fresh state, never a stale manifest.
+  clearManifestCache();
 
   try {
     // Read the manifest

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { spawn } from 'child_process';
 import { prompts, logger, banner, colors as c } from '../ui/index.js';
 import { getTuckDir, getConfigPath, collapsePath } from '../lib/paths.js';
-import { loadConfig, saveConfig, resetConfig } from '../lib/config.js';
+import { loadConfig, saveConfig, resetConfig, clearConfigCache } from '../lib/config.js';
 import { loadManifest } from '../lib/manifest.js';
 import { upsertRemote } from '../lib/git.js';
 import { NotInitializedError, ConfigError } from '../errors.js';
@@ -215,7 +215,7 @@ const runConfigGet = async (key: string, options: ConfigGetOptions = {}): Promis
   }
 };
 
-const runConfigSet = async (
+export const runConfigSet = async (
   key: string,
   value: string,
   options: ConfigSetOptions = {}
@@ -241,6 +241,10 @@ const runConfigSet = async (
   setNestedValue(configObj, key, parsedValue);
 
   await saveConfig(config, tuckDir);
+  // saveConfig leaves the cache populated with the just-written value. Drop it so
+  // a later loadConfig re-reads disk and an out-of-band change isn't masked by a
+  // stale in-memory cache for the rest of this run.
+  clearConfigCache();
 
   if (isJsonMode()) {
     emitJsonOk({ key, value: parsedValue, updated: true });
@@ -581,6 +585,9 @@ export const runConfigRemote = async (): Promise<void> => {
   };
 
   await saveConfig(updatedConfig, tuckDir);
+  // Drop the post-write cache so any subsequent load re-reads disk (avoids a
+  // stale in-memory config masking an out-of-band change during this run).
+  clearConfigCache();
 
   // Track whether a remote URL was ACTUALLY configured so the final message
   // reflects reality (and never prints a false "Remote configured" success).
@@ -624,6 +631,7 @@ export const runConfigRemote = async (): Promise<void> => {
         ...updatedConfig.remote,
       };
       await saveConfig(updatedConfig, tuckDir);
+      clearConfigCache();
     }
   }
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -438,6 +438,8 @@ const runConfigWizard = async (config: TuckConfigOutput, tuckDir: string): Promi
   };
 
   await saveConfig(updatedConfig, tuckDir);
+  // Drop the now-stale cache so a later read in the same run sees the write.
+  clearConfigCache();
 
   console.log();
   prompts.log.success('Configuration updated!');
@@ -493,6 +495,8 @@ const editConfigInteractive = async (config: TuckConfigOutput, tuckDir: string):
 
   setNestedValue(configObj, selectedKey, newValue);
   await saveConfig(config, tuckDir);
+  // Drop the now-stale cache so a later read in the same run sees the write.
+  clearConfigCache();
 
   prompts.log.success(`Updated ${selectedKey} = ${formatConfigValue(newValue)}`);
 };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,7 +13,7 @@ import {
   collapsePath,
 } from '../lib/paths.js';
 import { saveConfig } from '../lib/config.js';
-import { createManifest } from '../lib/manifest.js';
+import { createManifest, clearManifestCache } from '../lib/manifest.js';
 import { loadManifestFile } from '../lib/manifestFile.js';
 import type { TuckManifest, RemoteConfig } from '../types.js';
 import {
@@ -1198,6 +1198,11 @@ const initFromRemote = async (tuckDir: string, remoteUrl: string): Promise<void>
   await withSpinner(`Cloning from ${remoteUrl}...`, async () => {
     await cloneRepo(remoteUrl, tuckDir);
   });
+
+  // The clone just wrote the manifest out-of-band. Drop any in-memory manifest
+  // cache so a later loadManifest in this same run (e.g. the restore step) reads
+  // the freshly-cloned manifest, never a stale cached one.
+  clearManifestCache();
 
   // Verify manifest exists
   if (!(await pathExists(getManifestPath(tuckDir)))) {

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,13 +1,13 @@
 import { Command } from 'commander';
 import { prompts, logger, banner, colors as c } from '../ui/index.js';
 import { getTuckDir, collapsePath, expandPath } from '../lib/paths.js';
-import { loadManifest, getTrackedFileBySource } from '../lib/manifest.js';
+import { loadManifest, buildSourceIndex } from '../lib/manifest.js';
 import { detectDotfiles, DETECTION_CATEGORIES, DetectedFile } from '../lib/detect.js';
 import { NotInitializedError } from '../errors.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
 import { preparePathsForTracking } from '../lib/trackPipeline.js';
 import { shouldExcludeFromBin } from '../lib/binary.js';
-import { isIgnored } from '../lib/tuckignore.js';
+import { loadTuckignore, isIgnoredInSet } from '../lib/tuckignore.js';
 import { setJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 
 export interface ScanOptions {
@@ -266,14 +266,20 @@ export const runScan = async (options: ScanOptions): Promise<void> => {
     return;
   }
 
+  // Build the "already tracked?" lookup ONCE (O(tracked)) instead of calling the
+  // O(N) getTrackedFileBySource per detected file, and load .tuckignore ONCE up
+  // front instead of re-reading it per detected file inside isIgnored().
+  const sourceIndex = await buildSourceIndex(tuckDir);
+  const ignoredPaths = await loadTuckignore(tuckDir);
+
   // Check which files are already tracked
   const selectableFiles: SelectableFile[] = [];
 
   for (const file of detected) {
-    const tracked = await getTrackedFileBySource(tuckDir, file.path);
+    const tracked = sourceIndex.get(file.path) ?? null;
 
-    // Skip if in .tuckignore
-    if (await isIgnored(tuckDir, file.path)) {
+    // Skip if in .tuckignore (same normalization as isIgnored, no per-file disk read).
+    if (isIgnoredInSet(ignoredPaths, file.path)) {
       continue;
     }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -16,7 +16,7 @@ import {
   getAllTrackedFiles,
   updateFileInManifest,
   removeFileFromManifest,
-  getTrackedFileBySource,
+  buildSourceIndex,
   clearManifestCache,
 } from '../lib/manifest.js';
 import { stageAll, commit, getStatus, push, hasRemote, fetch, pull } from '../lib/git.js';
@@ -39,7 +39,7 @@ import {
   formatFileSize,
   SIZE_BLOCK_THRESHOLD,
 } from '../lib/files.js';
-import { addToTuckignore, loadTuckignore, isIgnored } from '../lib/tuckignore.js';
+import { addToTuckignore, loadTuckignore, isIgnoredInSet } from '../lib/tuckignore.js';
 import { checkLocalMode } from '../lib/remoteChecks.js';
 import { loadConfig } from '../lib/config.js';
 import { assertRemoteAvailable } from '../lib/providers/index.js';
@@ -62,6 +62,19 @@ interface SyncResult {
   // The sync command only handles changes to already-tracked files.
 }
 
+/**
+ * A {@link FileChange} that also carries the manifest `id` it was derived from.
+ *
+ * detectChanges already knows each change's manifest id while iterating the
+ * tracked-files map, so it stamps it here. syncFiles can then update/remove the
+ * right manifest entry in O(1) instead of re-loading the whole map and doing a
+ * linear `Object.values(...).find(f => f.source === change.source)` per change
+ * (which was O(changes × tracked)). `id` is optional so changes constructed
+ * elsewhere remain assignable; syncFiles falls back to the old lookup when it's
+ * absent.
+ */
+type TrackedFileChange = FileChange & { id?: string };
+
 const pathsResolveToSameLocation = async (sourcePath: string, destinationPath: string): Promise<boolean> => {
   try {
     const [resolvedSource, resolvedDestination] = await Promise.all([
@@ -74,12 +87,12 @@ const pathsResolveToSameLocation = async (sourcePath: string, destinationPath: s
   }
 };
 
-const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
+const detectChanges = async (tuckDir: string): Promise<TrackedFileChange[]> => {
   const files = await getAllTrackedFiles(tuckDir);
   const ignoredPaths = await loadTuckignore(tuckDir);
-  const changes: FileChange[] = [];
+  const changes: TrackedFileChange[] = [];
 
-  for (const [, file] of Object.entries(files)) {
+  for (const [id, file] of Object.entries(files)) {
     // Home-scoped sources are confined to $HOME; repo-scoped sources live under a
     // (possibly out-of-home) repo root, so they are validated by their repoRelative
     // safety in the manifest schema, not by validateSafeSourcePath.
@@ -113,6 +126,7 @@ const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
         status: 'deleted',
         source: file.source,
         destination: file.destination,
+        id,
       });
       continue;
     }
@@ -126,6 +140,7 @@ const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
           status: 'modified',
           source: file.source,
           destination: file.destination,
+          id,
         });
       }
     } catch {
@@ -134,6 +149,7 @@ const detectChanges = async (tuckDir: string): Promise<FileChange[]> => {
         status: 'modified',
         source: file.source,
         destination: file.destination,
+        id,
       });
     }
   }
@@ -324,16 +340,21 @@ const detectNewDotfiles = async (tuckDir: string): Promise<DetectedFile[]> => {
   // Get all detected dotfiles on the system
   const detected = await detectDotfiles();
 
+  // Build the "already tracked?" lookup ONCE (O(tracked)) instead of calling the
+  // O(N) getTrackedFileBySource per detected file (which was O(detected × tracked)),
+  // and load .tuckignore ONCE up front instead of re-reading it per detected file.
+  const sourceIndex = await buildSourceIndex(tuckDir);
+  const ignoredPaths = await loadTuckignore(tuckDir);
+
   // Filter out already-tracked files, ignored files, and excluded patterns
   const newFiles: DetectedFile[] = [];
 
   for (const file of detected) {
-    // Skip if already tracked
-    const tracked = await getTrackedFileBySource(tuckDir, file.path);
-    if (tracked) continue;
+    // Skip if already tracked (O(1) map lookup, same answer as getTrackedFileBySource).
+    if (sourceIndex.has(file.path)) continue;
 
-    // Skip if in .tuckignore
-    if (await isIgnored(tuckDir, file.path)) continue;
+    // Skip if in .tuckignore (same normalization as isIgnored, no per-file disk read).
+    if (isIgnoredInSet(ignoredPaths, file.path)) continue;
 
     newFiles.push(file);
   }
@@ -393,7 +414,7 @@ const generateCommitMessage = (result: SyncResult): string => {
 
 const syncFiles = async (
   tuckDir: string,
-  changes: FileChange[],
+  changes: TrackedFileChange[],
   options: SyncOptions
 ): Promise<SyncResult> => {
   const result: SyncResult = {
@@ -410,6 +431,17 @@ const syncFiles = async (
   // Run pre-sync hook
   await runPreSyncHook(tuckDir, hookOptions);
 
+  // Load the tracked-files map ONCE up front. The old loop re-read it per change
+  // (twice each: once to home-confine the source, once inside the modified/
+  // deleted branch to recover the file id), turning id recovery into an
+  // O(changes × tracked) linear scan. We index by source for O(1) lookups and
+  // prefer the id already stamped on the change by detectChanges.
+  const trackedFiles = await getAllTrackedFiles(tuckDir);
+  const bySource = new Map<string, { id: string; file: (typeof trackedFiles)[string] }>();
+  for (const [id, file] of Object.entries(trackedFiles)) {
+    bySource.set(file.source, { id, file });
+  }
+
   // Process each change
   for (const change of changes) {
     if (!change.destination) {
@@ -417,10 +449,13 @@ const syncFiles = async (
     }
     validateSafeManifestDestination(change.destination);
 
-    // Look up the tracked entry so we can resolve a repo-scoped live path and
-    // only home-confine genuine home-scoped sources.
-    const trackedFiles = await getAllTrackedFiles(tuckDir);
-    const trackedEntry = Object.values(trackedFiles).find((f) => f.source === change.source);
+    // Resolve the tracked entry + its id via the prebuilt index. Prefer the id
+    // carried on the change (set by detectChanges); fall back to the source
+    // lookup for changes constructed elsewhere.
+    const indexed = bySource.get(change.source);
+    const trackedEntry = indexed?.file;
+    const fileId = change.id ?? indexed?.id;
+
     if (trackedEntry?.scope !== 'repo') {
       validateSafeSourcePath(change.source);
     }
@@ -449,10 +484,8 @@ const syncFiles = async (
           await copyFileOrDir(sourcePath, destPath, { overwrite: true });
         }
 
-        // Update checksum in manifest
+        // Update checksum in manifest using the id resolved above.
         const newChecksum = await getFileChecksum(destPath);
-        const files = await getAllTrackedFiles(tuckDir);
-        const fileId = Object.entries(files).find(([, f]) => f.source === change.source)?.[0];
 
         if (fileId) {
           await updateFileInManifest(tuckDir, fileId, {
@@ -467,10 +500,7 @@ const syncFiles = async (
         // Delete the file from the tuck repository
         await deleteFileOrDir(destPath);
 
-        // Remove from manifest
-        const files = await getAllTrackedFiles(tuckDir);
-        const fileId = Object.entries(files).find(([, f]) => f.source === change.source)?.[0];
-
+        // Remove from manifest using the id resolved above.
         if (fileId) {
           await removeFileFromManifest(tuckDir, fileId);
         }

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -1,5 +1,6 @@
 import { join, basename, isAbsolute } from 'path';
 import { readdir, stat } from 'fs/promises';
+import type { Stats } from 'fs';
 import { pathExists, expandPath, collapsePath } from './paths.js';
 import { IS_WINDOWS, IS_MACOS, IS_LINUX } from './platform.js';
 import { loadPatterns, type DotfilePattern } from './patternsRegistry.js';
@@ -859,26 +860,23 @@ const shouldIncludeForPlatform = (item: { platform?: string }): boolean => {
 };
 
 /**
- * Get file/directory size
+ * Stat a path once, following symlinks (mirrors the historical behavior of the
+ * old getSize()/isDirectory() helpers which both used stat(), not lstat()).
+ *
+ * Returns null when the path does not exist or cannot be stat'd. A successful
+ * stat doubles as the existence check that the loop previously made with a
+ * separate pathExists()/access() call — so existing files now cost ONE syscall
+ * instead of three (access + stat + stat) while producing identical results:
+ *   - isDirectory  ← stats.isDirectory()
+ *   - size         ← stats.size
+ *   - "exists"     ← stat succeeded (a broken symlink fails stat just like it
+ *                     failed the old access(F_OK) check)
  */
-const getSize = async (path: string): Promise<number | undefined> => {
+const statPath = async (path: string): Promise<Stats | null> => {
   try {
-    const stats = await stat(path);
-    return stats.size;
+    return await stat(path);
   } catch {
-    return undefined;
-  }
-};
-
-/**
- * Check if path is a directory
- */
-const isDirectory = async (path: string): Promise<boolean> => {
-  try {
-    const stats = await stat(path);
-    return stats.isDirectory();
-  } catch {
-    return false;
+    return null;
   }
 };
 
@@ -904,30 +902,39 @@ export const detectDotfiles = async (options?: {
     patterns = DOTFILE_PATTERNS;
   }
 
-  for (const pattern of patterns) {
-    // Skip if not for current platform
-    if (!shouldIncludeForPlatform(pattern)) continue;
+  // Pre-filter to the patterns we actually need to probe (platform + exclusion
+  // rules are pure/synchronous), then run the single-stat probes concurrently.
+  // The candidate array preserves the original pattern order so the resulting
+  // `detected` list is byte-identical to the old serial loop.
+  const candidates = patterns.filter((pattern) => {
+    if (!shouldIncludeForPlatform(pattern)) return false;
+    if (!includeExcluded && shouldExcludeFile(pattern.path)) return false;
+    return true;
+  });
 
-    // Skip if matches exclusion patterns (unless explicitly including)
-    if (!includeExcluded && shouldExcludeFile(pattern.path)) continue;
+  const probes = await Promise.all(
+    candidates.map(async (pattern) => {
+      const fullPath = expandPath(pattern.path);
+      const stats = await statPath(fullPath);
+      return { pattern, stats };
+    })
+  );
 
-    const fullPath = expandPath(pattern.path);
+  for (const { pattern, stats } of probes) {
+    // A null stat means the path didn't exist (or couldn't be stat'd) — the
+    // same condition the old `pathExists` guard skipped on.
+    if (stats === null) continue;
 
-    if (await pathExists(fullPath)) {
-      const isDir = await isDirectory(fullPath);
-      const size = await getSize(fullPath);
-
-      detected.push({
-        path: pattern.path,
-        name: basename(pattern.path),
-        category: pattern.category,
-        description: pattern.description,
-        isDirectory: isDir,
-        size,
-        sensitive: pattern.sensitive,
-        exclude: pattern.exclude,
-      });
-    }
+    detected.push({
+      path: pattern.path,
+      name: basename(pattern.path),
+      category: pattern.category,
+      description: pattern.description,
+      isDirectory: stats.isDirectory(),
+      size: stats.size,
+      sensitive: pattern.sensitive,
+      exclude: pattern.exclude,
+    });
   }
 
   return detected;

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -14,7 +14,7 @@ import {
 import { copy, ensureDir } from 'fs-extra';
 import { join, dirname, basename, relative } from 'path';
 import { constants } from 'fs';
-import { FileNotFoundError, PermissionError } from '../errors.js';
+import { FileNotFoundError, PermissionError, TuckError } from '../errors.js';
 import { expandPath, pathExists, isDirectory, validateSafeDestinationPath } from './paths.js';
 import { allowedRoots } from './writeContext.js';
 import { IS_WINDOWS } from './platform.js';
@@ -153,28 +153,66 @@ export const getFileInfo = async (filepath: string): Promise<FileInfo> => {
   }
 };
 
-export const getDirectoryFiles = async (dirpath: string): Promise<string[]> => {
-  const expandedPath = expandPath(dirpath);
-  const files: string[] = [];
+/**
+ * Result of a single recursive directory walk.
+ *
+ * `files` is the deterministically sorted list of tracked regular files (the
+ * exact same list `getDirectoryFiles` returns). `totalSize` is the summed byte
+ * size of those files, collected during the SAME walk so callers that need the
+ * size never have to traverse the tree a second time.
+ */
+export interface DirectoryTreeStats {
+  files: string[];
+  totalSize: number;
+}
 
-  // Skip common temporary/cache files and git repos that change frequently
-  const skipPatterns = [
-    '.DS_Store',
-    'Thumbs.db',
-    '.git', // Skip git directories to prevent nested repos
-    '.gitignore',
-    'node_modules',
-    '.cache',
-    '__pycache__',
-    '*.pyc',
-    '*.swp',
-    '*.tmp',
-    '.npmrc',
-    'package-lock.json',
-    'yarn.lock',
-    'pnpm-lock.yaml',
-  ];
+// Names that are always skipped when walking a tracked directory. Kept in a
+// single place so getDirectoryFiles and getDirectoryTreeStats can never drift.
+const DIRECTORY_SKIP_PATTERNS = [
+  '.DS_Store',
+  'Thumbs.db',
+  '.git', // Skip git directories to prevent nested repos
+  '.gitignore',
+  'node_modules',
+  '.cache',
+  '__pycache__',
+  '*.pyc',
+  '*.swp',
+  '*.tmp',
+  '.npmrc',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+];
 
+const shouldSkipEntry = (name: string): boolean =>
+  DIRECTORY_SKIP_PATTERNS.some((pattern) => {
+    if (pattern.includes('*')) {
+      // Escape special regex characters (especially .) before replacing * with .*
+      const escapedPattern = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+      const regex = new RegExp('^' + escapedPattern + '$');
+      return regex.test(name);
+    }
+    return name === pattern;
+  });
+
+/**
+ * Single recursive walk shared by `getDirectoryFiles` and
+ * `getDirectoryTreeStats`. Pushes regular-file paths into `accFiles` and, when
+ * `collectSize` is true, adds each file's byte size to the returned running
+ * total. Sizes come from the same `lstat` used for symlink detection — since
+ * symlinks are skipped, every collected entry is a regular file whose `lstat`
+ * size equals its `stat` size, so the total is identical to the previous
+ * stat()-per-file approach.
+ *
+ * The file list is NOT sorted here; callers sort the fully-collected list so
+ * ordering matches the historical (sort-after-recurse) behavior exactly.
+ */
+const walkDirectory = async (
+  expandedPath: string,
+  accFiles: string[],
+  collectSize: boolean
+): Promise<number> => {
   let entries;
   try {
     entries = await readdir(expandedPath, { withFileTypes: true });
@@ -183,23 +221,15 @@ export const getDirectoryFiles = async (dirpath: string): Promise<string[]> => {
     if (process.env.DEBUG) {
       console.warn(`[tuck] Warning: Could not read directory ${expandedPath}:`, error);
     }
-    return files;
+    return 0;
   }
+
+  let totalSize = 0;
 
   for (const entry of entries) {
     const entryPath = join(expandedPath, entry.name);
-    
-    const shouldSkip = skipPatterns.some(pattern => {
-      if (pattern.includes('*')) {
-        // Escape special regex characters (especially .) before replacing * with .*
-        const escapedPattern = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
-        const regex = new RegExp('^' + escapedPattern + '$');
-        return regex.test(entry.name);
-      }
-      return entry.name === pattern;
-    });
-    
-    if (shouldSkip) {
+
+    if (shouldSkipEntry(entry.name)) {
       continue;
     }
 
@@ -213,10 +243,13 @@ export const getDirectoryFiles = async (dirpath: string): Promise<string[]> => {
       }
 
       if (entry.isDirectory()) {
-        const subFiles = await getDirectoryFiles(entryPath);
-        files.push(...subFiles);
+        totalSize += await walkDirectory(entryPath, accFiles, collectSize);
       } else if (entry.isFile()) {
-        files.push(entryPath);
+        accFiles.push(entryPath);
+        if (collectSize) {
+          // Same size stat() would report for a regular (non-symlink) file.
+          totalSize += lstats.size;
+        }
       }
     } catch (error) {
       // Skip entries we can't access (permission errors, etc.)
@@ -227,7 +260,30 @@ export const getDirectoryFiles = async (dirpath: string): Promise<string[]> => {
     }
   }
 
+  return totalSize;
+};
+
+export const getDirectoryFiles = async (dirpath: string): Promise<string[]> => {
+  const expandedPath = expandPath(dirpath);
+  const files: string[] = [];
+  await walkDirectory(expandedPath, files, false);
   return files.sort();
+};
+
+/**
+ * Walk a directory tree ONCE, returning both the (sorted) file list and the
+ * total byte size of those files. Use this instead of calling
+ * `getDirectoryFiles`/`getDirectoryFileCount` and then re-walking to stat each
+ * file when you need the size — it produces an identical file list and size
+ * while traversing the tree a single time.
+ */
+export const getDirectoryTreeStats = async (
+  dirpath: string
+): Promise<DirectoryTreeStats> => {
+  const expandedPath = expandPath(dirpath);
+  const files: string[] = [];
+  const totalSize = await walkDirectory(expandedPath, files, true);
+  return { files: files.sort(), totalSize };
 };
 
 export const getDirectoryFileCount = async (dirpath: string): Promise<number> => {
@@ -256,14 +312,30 @@ export const copyFileOrDir = async (
   await ensureDir(dirname(expandedDest));
 
   const sourceIsDir = await isDirectory(expandedSource);
+  const shouldOverwrite = options?.overwrite ?? true;
+
+  // When overwrite is disabled, never silently MERGE a source directory into an
+  // already-populated target directory: fs-extra's copy would happily union the
+  // two trees, leaving the caller unaware its config landed on top of someone
+  // else's. Fail clearly instead, mirroring the EEXIST guard COPYFILE_EXCL gives
+  // single files below. (We check before any directory is created or copied.)
+  if (sourceIsDir && !shouldOverwrite && (await pathExists(expandedDest))) {
+    throw new TuckError(
+      `Destination already exists: ${expandedDest}`,
+      'DESTINATION_EXISTS',
+      [
+        'Remove or rename the existing destination first',
+        'Pass overwrite to replace it (only if you intend to)',
+      ]
+    );
+  }
 
   try {
-    const shouldOverwrite = options?.overwrite ?? true;
-
     if (sourceIsDir) {
       // Copy directory but skip .git and other problematic files
-      await copy(expandedSource, expandedDest, { 
+      await copy(expandedSource, expandedDest, {
         overwrite: shouldOverwrite,
+        errorOnExist: !shouldOverwrite,
         filter: (src: string) => {
           const name = basename(src);
           // Skip .git directories, node_modules, and cache directories
@@ -271,14 +343,16 @@ export const copyFileOrDir = async (
           return !skipDirs.includes(name);
         }
       });
-      const fileCount = await getDirectoryFileCount(expandedDest);
-      const files = await getDirectoryFiles(expandedDest);
-      let totalSize = 0;
-      for (const file of files) {
-        const stats = await stat(file);
-        totalSize += stats.size;
-      }
-      return { source: expandedSource, destination: expandedDest, fileCount, totalSize };
+      // Single walk: collect the file list AND its total size in one traversal
+      // (was previously a getDirectoryFileCount + getDirectoryFiles + per-file
+      // stat — three passes over the same tree).
+      const { files, totalSize } = await getDirectoryTreeStats(expandedDest);
+      return {
+        source: expandedSource,
+        destination: expandedDest,
+        fileCount: files.length,
+        totalSize,
+      };
     } else {
       // Use COPYFILE_EXCL flag to prevent overwriting when overwrite is false
       // If overwrite is true (default), use mode 0 which allows overwriting
@@ -288,7 +362,19 @@ export const copyFileOrDir = async (
       return { source: expandedSource, destination: expandedDest, fileCount: 1, totalSize: stats.size };
     }
   } catch (error) {
-    throw new PermissionError(destination, 'write');
+    // Preserve the REAL failure cause. A blanket PermissionError hid whether the
+    // copy ran out of disk (ENOSPC), hit a missing path (ENOENT), or collided
+    // with an existing target (EEXIST) — all of which need different handling
+    // upstream. Only translate genuine permission failures into PermissionError;
+    // rethrow everything else with its original .code/.errno intact.
+    if (error instanceof TuckError) {
+      throw error;
+    }
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === 'EACCES' || code === 'EPERM' || code === undefined) {
+      throw new PermissionError(destination, 'write');
+    }
+    throw error;
   }
 };
 

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -189,6 +189,34 @@ export const getTrackedFileBySource = async (
   return null;
 };
 
+/**
+ * Build a single source→{id,file} lookup map for the manifest.
+ *
+ * `getTrackedFileBySource` is O(N) per call, so callers that probe many sources
+ * against the manifest (e.g. new-file detection in `scan`/`sync`, which checks
+ * every detected dotfile) were O(detected × tracked). Building this map ONCE
+ * before such a loop turns each "already tracked?" check into an O(1) lookup
+ * with identical semantics: a source is "tracked" iff it appears as a key here,
+ * exactly as `getTrackedFileBySource` returning non-null.
+ *
+ * Note: if two entries somehow share the same `source`, the LAST one in
+ * iteration order wins here. `getTrackedFileBySource` returns the FIRST match,
+ * but a duplicate-source manifest is malformed and never produced by tuck, so
+ * the only observable answer ("is this source tracked?") is unchanged.
+ */
+export const buildSourceIndex = async (
+  tuckDir: string
+): Promise<Map<string, { id: string; file: TrackedFileOutput }>> => {
+  const manifest = await loadManifest(tuckDir);
+  const index = new Map<string, { id: string; file: TrackedFileOutput }>();
+
+  for (const [id, file] of Object.entries(manifest.files)) {
+    index.set(file.source, { id, file });
+  }
+
+  return index;
+};
+
 export const getAllTrackedFiles = async (
   tuckDir: string
 ): Promise<Record<string, TrackedFileOutput>> => {

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -54,14 +54,92 @@ const evalCondition = (ctx: TemplateContext, expr: string): boolean => {
   return Boolean(v) && v !== 'false' && v !== '0';
 };
 
-const renderInline = (text: string, ctx: TemplateContext): string => {
-  // Handle {{#if …}}…{{else}}…{{/if}} blocks first (non-nested for safety).
-  text = text.replace(
-    /\{\{#if\s+([^}]+)\}\}([\s\S]*?)(?:\{\{else\}\}([\s\S]*?))?\{\{\/if\}\}/g,
-    (_, expr: string, ifBranch: string, elseBranch?: string) => {
-      return evalCondition(ctx, expr) ? ifBranch : elseBranch ?? '';
+/**
+ * Resolve {{#if …}}…{{else}}…{{/if}} blocks with correct nesting.
+ *
+ * The old single-pass regex was non-greedy and matched the FIRST {{/if}}, so a
+ * nested block (`{{#if a}}A{{#if b}}B{{/if}}C{{/if}}`) closed the OUTER block on
+ * the INNER {{/if}} — leaking `C{{/if}}` and dropping the inner condition. We
+ * stack-parse instead: each {{#if}} pushes a frame, the matching {{/if}} pops it
+ * and substitutes the chosen branch (with nested children already resolved). The
+ * matching is depth-balanced, so the correct {{/if}} closes each block.
+ */
+const renderInlineConditionals = (text: string, ctx: TemplateContext): string => {
+  const tokenRe = /\{\{#if\s+([^}]+)\}\}|\{\{else\}\}|\{\{\/if\}\}/g;
+
+  type Frame = {
+    expr: string;
+    /** Literal output accumulated so far for the active branch. */
+    out: string;
+    /** True once {{else}} has been seen for this frame. */
+    sawElse: boolean;
+    /** Captured if-branch text, set when {{else}} is reached. */
+    ifBranch: string;
+  };
+
+  const stack: Frame[] = [];
+  const newFrame = (expr: string): Frame => ({ expr, out: '', sawElse: false, ifBranch: '' });
+
+  // Root accumulator (text outside any conditional).
+  let root = '';
+  const append = (s: string): void => {
+    if (stack.length === 0) root += s;
+    else stack[stack.length - 1].out += s;
+  };
+
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = tokenRe.exec(text)) !== null) {
+    // Emit the literal text between the previous token and this one.
+    append(text.slice(lastIndex, m.index));
+    lastIndex = tokenRe.lastIndex;
+
+    const [matched, ifExpr] = m;
+    if (ifExpr !== undefined) {
+      stack.push(newFrame(ifExpr));
+    } else if (matched === '{{else}}') {
+      if (stack.length === 0) {
+        // Stray {{else}} with no open if — preserve verbatim.
+        append(matched);
+      } else {
+        const top = stack[stack.length - 1];
+        top.sawElse = true;
+        top.ifBranch = top.out;
+        top.out = '';
+      }
+    } else {
+      // {{/if}}
+      if (stack.length === 0) {
+        // Stray {{/if}} — preserve verbatim.
+        append(matched);
+      } else {
+        const frame = stack.pop()!;
+        const ifBranch = frame.sawElse ? frame.ifBranch : frame.out;
+        const elseBranch = frame.sawElse ? frame.out : '';
+        append(evalCondition(ctx, frame.expr) ? ifBranch : elseBranch);
+      }
     }
-  );
+  }
+
+  // Trailing literal text after the final token.
+  append(text.slice(lastIndex));
+
+  // Unbalanced {{#if}} with no closing {{/if}}: flush remaining frames as-is so
+  // we never silently drop content (preserve prior best-effort behavior).
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    const flushed = frame.sawElse
+      ? `{{#if ${frame.expr}}}${frame.ifBranch}{{else}}${frame.out}`
+      : `{{#if ${frame.expr}}}${frame.out}`;
+    append(flushed);
+  }
+
+  return root;
+};
+
+const renderInline = (text: string, ctx: TemplateContext): string => {
+  // Handle {{#if …}}…{{else}}…{{/if}} blocks first, with correct nesting.
+  text = renderInlineConditionals(text, ctx);
 
   // Then substitutions: {{var}} and {{var | default "x"}}
   text = text.replace(/\{\{\s*([^}|]+?)\s*(?:\|\s*default\s+"([^"]*)")?\s*\}\}/g, (_, key: string, def?: string) => {
@@ -77,7 +155,11 @@ const renderCommentMarkers = (text: string, ctx: TemplateContext): string => {
   // Comment char is anything before "tuck:" on the line.
   const lines = text.split('\n');
   const out: string[] = [];
-  type Frame = { keep: boolean; sawElse: boolean };
+  // `ifTaken` records whether THIS block's own condition (the `if` branch) was
+  // true, independent of the parent. On `else` we recompute keep from the
+  // parent's keep AND the negation of `ifTaken` — so a child branch can never
+  // resurrect output the parent suppressed.
+  type Frame = { keep: boolean; sawElse: boolean; ifTaken: boolean };
   const stack: Frame[] = [];
 
   const ifRe = /^\s*([#;/*]+)\s*tuck:if\s+(.+?)\s*$/;
@@ -89,14 +171,17 @@ const renderCommentMarkers = (text: string, ctx: TemplateContext): string => {
     if (ifM) {
       const cond = evalCondition(ctx, ifM[2]);
       const parentKeep = stack.length === 0 || stack[stack.length - 1].keep;
-      stack.push({ keep: parentKeep && cond, sawElse: false });
+      stack.push({ keep: parentKeep && cond, sawElse: false, ifTaken: cond });
       continue;
     }
     if (elseRe.test(line)) {
       if (stack.length > 0) {
         const top = stack[stack.length - 1];
         top.sawElse = true;
-        top.keep = !top.keep;
+        // A child's else-body must stay gated by the parent: keep the else body
+        // only when the parent kept this block AND the if branch was not taken.
+        const parentKeep = stack.length === 1 || stack[stack.length - 2].keep;
+        top.keep = parentKeep && !top.ifTaken;
       }
       continue;
     }

--- a/src/lib/tuckignore.ts
+++ b/src/lib/tuckignore.ts
@@ -100,16 +100,28 @@ export const addToTuckignore = async (tuckDir: string, path: string): Promise<vo
 };
 
 /**
+ * Check if a path is in a PRE-LOADED ignore set.
+ *
+ * This is the synchronous core of {@link isIgnored}: it performs the exact same
+ * path normalization (expand → collapse) and membership test, but against a Set
+ * the caller already loaded with {@link loadTuckignore}. Detection loops that
+ * probe many paths should `loadTuckignore` once and call this per path instead
+ * of calling {@link isIgnored} (which re-reads .tuckignore from disk every time).
+ */
+export const isIgnoredInSet = (ignoredPaths: Set<string>, path: string): boolean => {
+  // Normalize path for comparison
+  const expanded = expandPath(path);
+  const collapsed = collapsePath(expanded);
+
+  return ignoredPaths.has(collapsed);
+};
+
+/**
  * Check if a path is in .tuckignore
  */
 export const isIgnored = async (tuckDir: string, path: string): Promise<boolean> => {
   const ignoredPaths = await loadTuckignore(tuckDir);
-  
-  // Normalize path for comparison
-  const expanded = expandPath(path);
-  const collapsed = collapsePath(expanded);
-  
-  return ignoredPaths.has(collapsed);
+  return isIgnoredInSet(ignoredPaths, path);
 };
 
 /**

--- a/tests/commands/apply-cache-invalidation.test.ts
+++ b/tests/commands/apply-cache-invalidation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Apply manifest-cache-invalidation regression — BATCH W4-D.
+ *
+ * `tuck apply` clones/materializes a source repo into a temp dir. The local tuck
+ * manifest cache (used elsewhere in the same run, e.g. secret resolution and any
+ * later loadManifest) must NOT survive that out-of-band materialization stale.
+ * apply.ts now calls clearManifestCache() right after cloneSource populates the
+ * temp repo. This test pins that the cache-clear happens during an apply.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+
+const clearManifestCacheSpy = vi.fn();
+
+// Wrap the real manifest module so loadManifest etc. behave normally, but the
+// cache-clear is observable.
+vi.mock('../../src/lib/manifest.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/lib/manifest.js')>();
+  return {
+    ...original,
+    clearManifestCache: (...args: unknown[]) => {
+      clearManifestCacheSpy(...args);
+      return (original.clearManifestCache as (...a: unknown[]) => void)(...args);
+    },
+  };
+});
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('merge'),
+    multiselect: vi.fn().mockResolvedValue([]),
+    cancel: vi.fn(),
+  },
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: vi.fn(),
+    dim: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: new Proxy({}, { get: () => (x: string) => x }),
+}));
+
+const cloneRepoMock = vi.fn();
+vi.mock('../../src/lib/git.js', () => ({ cloneRepo: cloneRepoMock }));
+
+const findPlaceholdersMock = vi.fn(() => [] as string[]);
+const restoreContentMock = vi.fn((content: string) => ({ restoredContent: content, unresolved: [] }));
+
+vi.mock('../../src/lib/github.js', () => ({
+  isGhInstalled: vi.fn().mockResolvedValue(false),
+  findDotfilesRepo: vi.fn().mockResolvedValue(null),
+  ghCloneRepo: vi.fn(),
+  repoExists: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../../src/lib/timemachine.js', () => ({
+  createPreApplySnapshot: vi.fn().mockResolvedValue({ id: 'snapshot-test' }),
+}));
+
+vi.mock('../../src/lib/merge.js', () => ({
+  smartMerge: vi.fn(async (_d: string, content: string) => ({ content, preservedBlocks: 0 })),
+  isShellFile: vi.fn().mockReturnValue(false),
+  generateMergePreview: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  findPlaceholders: (...a: unknown[]) => findPlaceholdersMock(...(a as [])),
+  restoreContent: (...a: [string]) => restoreContentMock(...a),
+  restoreFiles: vi.fn().mockResolvedValue({ totalRestored: 0, allUnresolved: [] }),
+  getAllSecrets: vi.fn().mockResolvedValue({}),
+  getSecretCount: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('../../src/lib/secretBackends/index.js', () => ({ createResolver: vi.fn() }));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: vi.fn().mockResolvedValue({ security: { secretBackend: 'local' }, remote: { mode: 'local' } }),
+}));
+
+vi.mock('../../src/lib/platform.js', () => ({ IS_WINDOWS: false }));
+
+describe('apply clears the manifest cache after clone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findPlaceholdersMock.mockReturnValue([]);
+    restoreContentMock.mockImplementation((content: string) => ({
+      restoredContent: content,
+      unresolved: [],
+    }));
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+
+    cloneRepoMock.mockImplementation(async (_url: string, dir: string) => {
+      vol.mkdirSync(dir, { recursive: true });
+      const manifest = createMockManifest({
+        files: {
+          safe: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+        },
+      });
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), 'export NEW=1');
+    });
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('calls clearManifestCache during a remote apply', async () => {
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true });
+
+    expect(clearManifestCacheSpy).toHaveBeenCalled();
+  });
+
+  it('calls clearManifestCache for a local-directory source too', async () => {
+    const localSrc = join(TEST_HOME, 'dotfiles-src');
+    const manifest = createMockManifest({
+      files: {
+        safe: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+      },
+    });
+    vol.mkdirSync(join(localSrc, 'files', 'shell'), { recursive: true });
+    vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+    vol.writeFileSync(join(localSrc, 'files', 'shell', 'zshrc'), 'export NEW=1');
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply(localSrc, { replace: true });
+
+    expect(clearManifestCacheSpy).toHaveBeenCalled();
+    // No remote clone happened for a local source.
+    expect(cloneRepoMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/config-cache-invalidation.test.ts
+++ b/tests/commands/config-cache-invalidation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Config write-path cache-invalidation regression — BATCH W4-D.
+ *
+ * `saveConfig` updates the in-memory config cache to the value it just wrote.
+ * That is correct for the value tuck itself wrote, but it means a config write
+ * via the `config set` command leaves a populated cache; if the on-disk config
+ * is then changed out-of-band (or another code path expects a fresh read), the
+ * stale cache masks the new state for the rest of the run.
+ *
+ * The fix wires clearConfigCache() into the config write paths so a fresh
+ * loadConfig() re-reads disk. This test pins that property: after `config set`,
+ * an out-of-band edit to the config file must be observed by loadConfig().
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_TUCK_DIR } from '../setup.js';
+import { initTestTuck } from '../utils/testHelpers.js';
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn(),
+    select: vi.fn(),
+    text: vi.fn(),
+    log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+  },
+  logger: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  banner: vi.fn(),
+  colors: new Proxy({}, { get: () => (x: string) => x }),
+}));
+
+const CONFIG_PATH = join(TEST_TUCK_DIR, '.tuckrc.json');
+
+describe('config set cache invalidation', () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    vol.reset();
+    const { clearConfigCache } = await import('../../src/lib/config.js');
+    clearConfigCache();
+  });
+
+  it('clears the config cache after `config set` so an out-of-band edit is observed', async () => {
+    await initTestTuck();
+
+    const { loadConfig, clearConfigCache } = await import('../../src/lib/config.js');
+    // Start from a clean cache so we know the cache state is owned by this test.
+    clearConfigCache();
+
+    // Warm the cache to the pre-set value.
+    const before = await loadConfig(TEST_TUCK_DIR);
+    expect(before.repository.autoCommit).not.toBe(false);
+
+    // Run `config set` — this used to leave a populated cache.
+    const { runConfigSet } = await import('../../src/commands/config.js');
+    await runConfigSet('repository.autoCommit', 'false', {});
+
+    // Simulate an out-of-band rewrite of the config file (e.g. a clone/pull or a
+    // concurrent editor) that flips the value to true again.
+    const onDisk = JSON.parse(vol.readFileSync(CONFIG_PATH, 'utf-8') as string);
+    onDisk.repository.autoCommit = true;
+    vol.writeFileSync(CONFIG_PATH, JSON.stringify(onDisk, null, 2));
+
+    // A fresh load MUST reflect the on-disk value, not the cached post-set value.
+    const after = await loadConfig(TEST_TUCK_DIR);
+    expect(after.repository.autoCommit).toBe(true);
+  });
+});

--- a/tests/commands/config-remote-provider.test.ts
+++ b/tests/commands/config-remote-provider.test.ts
@@ -53,6 +53,9 @@ vi.mock('../../src/lib/config.js', () => ({
   loadConfig: (...args: unknown[]) => loadConfigMock(...args),
   saveConfig: (...args: unknown[]) => saveConfigMock(...args),
   resetConfig: vi.fn(),
+  // config.ts now clears the config cache after each write; the command imports
+  // this binding, so the mock must provide it (a no-op here).
+  clearConfigCache: vi.fn(),
 }));
 
 vi.mock('../../src/lib/paths.js', () => ({

--- a/tests/commands/init-cache-invalidation.test.ts
+++ b/tests/commands/init-cache-invalidation.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Init manifest-cache-invalidation regression — BATCH W4-D.
+ *
+ * `tuck init --from <url>` clones a repo into the tuck dir, rewriting the
+ * manifest out-of-band. The in-memory manifest cache must be dropped after the
+ * clone so a later loadManifest in the SAME run (e.g. the restore step) reads the
+ * freshly-cloned manifest rather than stale cached state. init.ts now calls
+ * clearManifestCache() after the clone path populates the repo.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const cloneRepoMock = vi.fn();
+const createManifestMock = vi.fn();
+const saveConfigMock = vi.fn();
+const pathExistsMock = vi.fn();
+const clearManifestCacheMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  nextSteps: vi.fn(),
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    text: vi.fn(),
+    confirm: vi.fn(),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn(), step: vi.fn(), message: vi.fn() },
+  },
+  logger: { success: vi.fn(), info: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  colors: { brand: (x: string) => x, dim: (x: string) => x, bold: (x: string) => x },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  getManifestPath: vi.fn((tuckDir: string) => `${tuckDir}/.tuckmanifest.json`),
+  getConfigPath: vi.fn((tuckDir: string) => `${tuckDir}/.tuckrc.json`),
+  getFilesDir: vi.fn((tuckDir: string) => `${tuckDir}/files`),
+  getCategoryDir: vi.fn((tuckDir: string, category: string) => `${tuckDir}/files/${category}`),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  pathExists: pathExistsMock,
+  collapsePath: vi.fn((path: string) => path.replace('/test-home', '~')),
+}));
+
+vi.mock('../../src/lib/config.js', () => ({ saveConfig: saveConfigMock }));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  createManifest: createManifestMock,
+  clearManifestCache: clearManifestCacheMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  initRepo: vi.fn(),
+  addRemote: vi.fn(),
+  cloneRepo: cloneRepoMock,
+  setDefaultBranch: vi.fn(),
+  stageAll: vi.fn(),
+  commit: vi.fn(),
+  push: vi.fn(),
+}));
+
+vi.mock('../../src/lib/providerSetup.js', () => ({
+  setupProvider: vi.fn(),
+  detectProviderFromUrl: vi.fn(() => 'local'),
+}));
+
+vi.mock('../../src/lib/providers/index.js', () => ({
+  getProvider: vi.fn(),
+  describeProviderConfig: vi.fn(() => 'local'),
+  buildRemoteConfig: vi.fn(() => ({ mode: 'local' })),
+}));
+
+vi.mock('../../src/lib/github.js', () => ({
+  isGhInstalled: vi.fn(),
+  isGhAuthenticated: vi.fn(),
+  getAuthenticatedUser: vi.fn(),
+  getPreferredRemoteProtocol: vi.fn(),
+  findDotfilesRepo: vi.fn(),
+  ghCloneRepo: vi.fn(),
+}));
+
+vi.mock('../../src/lib/detect.js', () => ({
+  detectDotfiles: vi.fn().mockResolvedValue([]),
+  DETECTION_CATEGORIES: {},
+}));
+
+vi.mock('../../src/lib/validation.js', () => ({
+  errorToMessage: vi.fn((error: unknown) => String(error)),
+}));
+
+describe('init clears the manifest cache after a clone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cloneRepoMock.mockResolvedValue(undefined);
+    createManifestMock.mockResolvedValue(undefined);
+    saveConfigMock.mockResolvedValue(undefined);
+  });
+
+  it('calls clearManifestCache after `init --from` clones the repo', async () => {
+    // Cloned repo already has both manifest and config present.
+    pathExistsMock.mockResolvedValue(true);
+    const { runInit } = await import('../../src/commands/init.js');
+
+    await runInit({ from: 'https://github.com/acme/dotfiles.git' });
+
+    expect(cloneRepoMock).toHaveBeenCalledWith(
+      'https://github.com/acme/dotfiles.git',
+      '/test-home/.tuck'
+    );
+    expect(clearManifestCacheMock).toHaveBeenCalled();
+  });
+});

--- a/tests/commands/init-windows.test.ts
+++ b/tests/commands/init-windows.test.ts
@@ -49,6 +49,8 @@ vi.mock('../../src/lib/config.js', () => ({
 
 vi.mock('../../src/lib/manifest.js', () => ({
   createManifest: createManifestMock,
+  // init.ts drops the manifest cache after a clone; provide the binding (no-op).
+  clearManifestCache: vi.fn(),
 }));
 
 vi.mock('../../src/lib/git.js', () => ({

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -69,6 +69,9 @@ vi.mock('../../src/lib/config.js', () => ({
 
 vi.mock('../../src/lib/manifest.js', () => ({
   createManifest: createManifestMock,
+  // init.ts now drops the manifest cache after a clone; the command imports this
+  // binding, so the mock must provide it (a no-op here).
+  clearManifestCache: vi.fn(),
 }));
 
 vi.mock('../../src/lib/git.js', () => ({

--- a/tests/commands/scan-perf.test.ts
+++ b/tests/commands/scan-perf.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression tests for the W4-B scan perf refactor (src/commands/scan.ts).
+ *
+ * The old scan loop called getTrackedFileBySource (O(N)) AND isIgnored (which
+ * re-reads .tuckignore from disk) once PER detected file, i.e.
+ * O(detected × tracked) tracked-lookups and ~detected redundant .tuckignore
+ * reads. The refactor builds the source→{id,file} index ONCE and loads
+ * .tuckignore ONCE before the loop, then does O(1) checks per file — with
+ * identical "already tracked" / "ignored" results.
+ *
+ * This file uses its own complete mock topology (including the new
+ * buildSourceIndex / loadTuckignore / isIgnoredInSet seams) so it exercises the
+ * refactored code path directly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadManifestMock = vi.fn();
+const buildSourceIndexMock = vi.fn();
+const detectDotfilesMock = vi.fn();
+const loadTuckignoreMock = vi.fn();
+const shouldExcludeFromBinMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  colors: {
+    bold: Object.assign((x: string) => x, { cyan: (x: string) => x }),
+    dim: (x: string) => x,
+    green: (x: string) => x,
+    yellow: (x: string) => x,
+    cyan: (x: string) => x,
+    white: (x: string) => x,
+  },
+  logger: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    dim: vi.fn(),
+  },
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(false),
+    select: vi.fn().mockResolvedValue('preview'),
+    multiselect: vi.fn(),
+    text: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      step: vi.fn(),
+      message: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  collapsePath: vi.fn((p: string) => p),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  buildSourceIndex: buildSourceIndexMock,
+}));
+
+vi.mock('../../src/lib/detect.js', () => ({
+  detectDotfiles: detectDotfilesMock,
+  DETECTION_CATEGORIES: {
+    shell: { icon: '$', name: 'Shell', description: 'Shell configuration' },
+    git: { icon: '*', name: 'Git', description: 'Git configuration' },
+  },
+}));
+
+vi.mock('../../src/lib/tuckignore.js', () => ({
+  loadTuckignore: loadTuckignoreMock,
+  isIgnoredInSet: (set: Set<string>, path: string) => set.has(path),
+}));
+
+vi.mock('../../src/lib/binary.js', () => ({
+  shouldExcludeFromBin: shouldExcludeFromBinMock,
+}));
+
+vi.mock('../../src/lib/fileTracking.js', () => ({
+  trackFilesWithProgress: vi.fn().mockResolvedValue({
+    succeeded: 0,
+    failed: 0,
+    errors: [],
+    sensitiveFiles: [],
+  }),
+}));
+
+vi.mock('../../src/lib/trackPipeline.js', () => ({
+  preparePathsForTracking: vi.fn().mockResolvedValue([]),
+}));
+
+describe('scan command perf (W4-B)', () => {
+  const DETECTED = [
+    { path: '~/.zshrc', category: 'shell', description: 'Shell config', sensitive: false, isDirectory: false },
+    { path: '~/.gitconfig', category: 'git', description: 'Git config', sensitive: false, isDirectory: false },
+    { path: '~/.vimrc', category: 'shell', description: 'Vim config', sensitive: false, isDirectory: false },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadManifestMock.mockResolvedValue({ files: {} });
+    detectDotfilesMock.mockResolvedValue(DETECTED);
+    loadTuckignoreMock.mockResolvedValue(new Set<string>());
+    shouldExcludeFromBinMock.mockResolvedValue(false);
+    // .zshrc is already tracked; the rest are new.
+    buildSourceIndexMock.mockResolvedValue(
+      new Map([['~/.zshrc', { id: 'zshrc', file: { source: '~/.zshrc' } }]])
+    );
+  });
+
+  it('builds the source index ONCE and loads .tuckignore ONCE regardless of detected count', async () => {
+    const { runScan } = await import('../../src/commands/scan.js');
+    await runScan({ quick: true });
+
+    // 3 detected files, but each "is tracked?" / "is ignored?" lookup uses the
+    // single prebuilt index / preloaded set — not a per-file disk read.
+    expect(buildSourceIndexMock).toHaveBeenCalledTimes(1);
+    expect(loadTuckignoreMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks already-tracked files via the index (same answer as getTrackedFileBySource)', async () => {
+    const captured: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      captured.push(args.map(String).join(' '));
+    };
+    try {
+      const { runScan } = await import('../../src/commands/scan.js');
+      await runScan({ quick: true, all: true });
+    } finally {
+      console.log = origLog;
+    }
+
+    const out = captured.join('\n');
+    // .zshrc is in the index → classified as already tracked (1 tracked), and
+    // the remaining two (.gitconfig, .vimrc) are new — exactly what the old
+    // per-file getTrackedFileBySource path would have reported.
+    expect(out).toContain('2 new, 1 already tracked');
+  });
+
+  it('skips ignored files using the preloaded ignore set', async () => {
+    // Ignore .gitconfig: it must not appear among the new/selectable files.
+    loadTuckignoreMock.mockResolvedValue(new Set<string>(['~/.gitconfig']));
+
+    const captured: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      captured.push(args.map(String).join(' '));
+    };
+    try {
+      const { runScan } = await import('../../src/commands/scan.js');
+      await runScan({ quick: true });
+    } finally {
+      console.log = origLog;
+    }
+
+    const out = captured.join('\n');
+    expect(out).not.toContain('~/.gitconfig');
+    expect(out).toContain('~/.vimrc');
+  });
+});

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -5,6 +5,8 @@ const loadManifestMock = vi.fn();
 const getTrackedFileBySourceMock = vi.fn();
 const detectDotfilesMock = vi.fn();
 const isIgnoredMock = vi.fn();
+const buildSourceIndexMock = vi.fn();
+const loadTuckignoreMock = vi.fn();
 const shouldExcludeFromBinMock = vi.fn();
 const trackFilesWithProgressMock = vi.fn();
 const preparePathsForTrackingMock = vi.fn();
@@ -64,6 +66,7 @@ vi.mock('../../src/lib/paths.js', () => ({
 vi.mock('../../src/lib/manifest.js', () => ({
   loadManifest: loadManifestMock,
   getTrackedFileBySource: getTrackedFileBySourceMock,
+  buildSourceIndex: buildSourceIndexMock,
 }));
 
 vi.mock('../../src/lib/detect.js', () => ({
@@ -76,6 +79,8 @@ vi.mock('../../src/lib/detect.js', () => ({
 
 vi.mock('../../src/lib/tuckignore.js', () => ({
   isIgnored: isIgnoredMock,
+  loadTuckignore: loadTuckignoreMock,
+  isIgnoredInSet: (set: Set<string>, path: string) => set.has(path),
 }));
 
 vi.mock('../../src/lib/binary.js', () => ({
@@ -106,6 +111,8 @@ describe('scan command behavior', () => {
       },
     ]);
     isIgnoredMock.mockResolvedValue(false);
+    buildSourceIndexMock.mockResolvedValue(new Map());
+    loadTuckignoreMock.mockResolvedValue(new Set<string>());
     shouldExcludeFromBinMock.mockResolvedValue(false);
     trackFilesWithProgressMock.mockResolvedValue({
       succeeded: 1,

--- a/tests/commands/sync-perf.test.ts
+++ b/tests/commands/sync-perf.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression tests for the W4-B sync change-detection perf refactor.
+ *
+ * The old syncFiles() re-read the whole tracked-files map repeatedly and did a
+ * linear Object.values(...).find() per change to recover each file id:
+ *   - getAllTrackedFiles() once in detectChanges,
+ *   - getAllTrackedFiles() once per change to home-confine the source,
+ *   - getAllTrackedFiles() AGAIN inside the modified/deleted branch, then a
+ *     `.find(f => f.source === change.source)` to recover the id.
+ * That made id recovery O(changes × tracked) and the map reloads O(changes).
+ *
+ * The refactor carries the file `id` on each change (resolved once via the
+ * source index) and loads the tracked-files map a small CONSTANT number of
+ * times, independent of the change count. Observable outputs (copies, manifest
+ * updates, commit) are unchanged — this only removes redundant work.
+ *
+ * Mirrors tests/commands/sync.test.ts' mock topology so the seams are identical.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+const updateFileInManifestMock = vi.fn();
+const removeFileFromManifestMock = vi.fn();
+const getTrackedFileBySourceMock = vi.fn();
+const buildSourceIndexMock = vi.fn();
+const pathExistsMock = vi.fn();
+const copyFileOrDirMock = vi.fn();
+const getFileChecksumMock = vi.fn();
+const deleteFileOrDirMock = vi.fn();
+const loadTuckignoreMock = vi.fn();
+const isIgnoredMock = vi.fn();
+const resolveLiveTargetMock = vi.fn();
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(false),
+    confirmDangerous: vi.fn().mockResolvedValue(true),
+    select: vi.fn().mockResolvedValue('abort'),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      step: vi.fn(),
+      message: vi.fn(),
+    },
+  },
+  logger: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    file: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    dim: vi.fn(),
+  },
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  colors: { dim: (x: string) => x },
+}));
+
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => '/test-home/.tuck'),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  pathExists: pathExistsMock,
+  collapsePath: vi.fn((p: string) => p),
+  validateSafeSourcePath: vi.fn(),
+  validateSafeManifestDestination: vi.fn(),
+  validatePathWithinRoot: vi.fn(),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  getAllTrackedFiles: getAllTrackedFilesMock,
+  updateFileInManifest: updateFileInManifestMock,
+  removeFileFromManifest: removeFileFromManifestMock,
+  getTrackedFileBySource: getTrackedFileBySourceMock,
+  buildSourceIndex: buildSourceIndexMock,
+}));
+
+vi.mock('../../src/lib/repoScope.js', () => ({
+  resolveLiveTarget: resolveLiveTargetMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  stageAll: vi.fn(),
+  commit: vi.fn().mockResolvedValue('abc123def456'),
+  getStatus: vi.fn().mockResolvedValue({ behind: 0 }),
+  push: vi.fn(),
+  hasRemote: vi.fn().mockResolvedValue(false),
+  fetch: vi.fn(),
+  pull: vi.fn(),
+}));
+
+vi.mock('../../src/lib/files.js', () => ({
+  copyFileOrDir: copyFileOrDirMock,
+  getFileChecksum: getFileChecksumMock,
+  deleteFileOrDir: deleteFileOrDirMock,
+  checkFileSizeThreshold: vi.fn().mockResolvedValue({ warn: false, block: false, size: 10 }),
+  formatFileSize: vi.fn((n: number) => `${n} B`),
+  SIZE_BLOCK_THRESHOLD: 100 * 1024 * 1024,
+}));
+
+vi.mock('../../src/lib/tuckignore.js', () => ({
+  addToTuckignore: vi.fn(),
+  loadTuckignore: loadTuckignoreMock,
+  isIgnored: isIgnoredMock,
+}));
+
+vi.mock('../../src/lib/hooks.js', () => ({
+  runPreSyncHook: vi.fn(),
+  runPostSyncHook: vi.fn(),
+}));
+
+vi.mock('../../src/lib/detect.js', () => ({
+  detectDotfiles: vi.fn().mockResolvedValue([]),
+  DETECTION_CATEGORIES: {},
+}));
+
+vi.mock('../../src/lib/fileTracking.js', () => ({
+  trackFilesWithProgress: vi.fn().mockResolvedValue({
+    succeeded: 0,
+    failed: 0,
+    errors: [],
+    sensitiveFiles: [],
+  }),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  scanForSecrets: vi.fn().mockResolvedValue({ totalSecrets: 0, results: [] }),
+  isSecretScanningEnabled: vi.fn().mockResolvedValue(false),
+  shouldBlockOnSecrets: vi.fn().mockResolvedValue(true),
+  processSecretsForRedaction: vi.fn(),
+  redactFile: vi.fn(),
+}));
+
+vi.mock('../../src/commands/secrets.js', () => ({ displayScanResults: vi.fn() }));
+vi.mock('../../src/lib/audit.js', () => ({ logForceSecretBypass: vi.fn() }));
+vi.mock('../../src/lib/remoteChecks.js', () => ({ checkLocalMode: vi.fn().mockResolvedValue(false) }));
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: vi.fn().mockResolvedValue({ remote: { mode: 'github' } }),
+}));
+vi.mock('../../src/lib/providers/index.js', () => ({ assertRemoteAvailable: vi.fn() }));
+
+describe('sync change-detection perf (W4-B)', () => {
+  const TRACKED = {
+    zshrc: { source: '~/.zshrc', destination: 'files/shell/zshrc', checksum: 'old' },
+    gitconfig: { source: '~/.gitconfig', destination: 'files/git/gitconfig', checksum: 'old' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadManifestMock.mockResolvedValue({ files: {} });
+    loadTuckignoreMock.mockResolvedValue(new Set());
+    getAllTrackedFilesMock.mockResolvedValue(TRACKED);
+    buildSourceIndexMock.mockImplementation(async () => {
+      const m = new Map<string, { id: string; file: unknown }>();
+      for (const [id, file] of Object.entries(TRACKED)) m.set(file.source, { id, file });
+      return m;
+    });
+    pathExistsMock.mockResolvedValue(true);
+    isIgnoredMock.mockResolvedValue(false);
+    // Every tracked file is modified (checksum 'old' -> 'new').
+    getFileChecksumMock.mockResolvedValue('new');
+    resolveLiveTargetMock.mockImplementation(async (file: { source: string }) =>
+      file.source.replace(/^~\//, '/test-home/')
+    );
+  });
+
+  it('updates the manifest once per modified file (id carried, no linear find drift)', async () => {
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand('sync: multi', {
+      noCommit: true,
+      noHooks: true,
+      scan: false,
+      pull: false,
+    } as never);
+
+    // Two modified files → two copies, two manifest updates with the CORRECT ids.
+    expect(copyFileOrDirMock).toHaveBeenCalledTimes(2);
+    expect(updateFileInManifestMock).toHaveBeenCalledTimes(2);
+
+    const updatedIds = updateFileInManifestMock.mock.calls.map((c) => c[1]).sort();
+    expect(updatedIds).toEqual(['gitconfig', 'zshrc']);
+  });
+
+  it('does not reload the tracked-files map O(changes) times', async () => {
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand('sync: multi', {
+      noCommit: true,
+      noHooks: true,
+      scan: false,
+      pull: false,
+    } as never);
+
+    // With the old code this grew with the number of changes (one reload per
+    // change in syncFiles, plus another inside each branch). After the refactor
+    // the map is loaded a small constant number of times, independent of the
+    // 2 changes processed.
+    expect(getAllTrackedFilesMock.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests/lib/detect-perf.test.ts
+++ b/tests/lib/detect-perf.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for the W4-B scan/sync performance refactor of detect.ts.
+ *
+ * The probe per pattern was 3 serial filesystem calls (pathExists/access +
+ * stat for isDirectory + stat for size). The refactor collapses these to ONE
+ * stat per existing path (still following symlinks, so detection results are
+ * byte-identical) and runs the per-pattern probes concurrently.
+ *
+ * These tests pin the OBSERVABLE behavior that must not change:
+ *   - which patterns are detected,
+ *   - the shape of each DetectedFile (path/name/category/description/
+ *     isDirectory/size/sensitive/exclude),
+ *   - symlink-following semantics (a symlink to a directory reports
+ *     isDirectory: true, just like the old stat()-based code).
+ * Plus the perf property: at most one stat per existing path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import * as fsp from 'fs/promises';
+import { detectDotfiles } from '../../src/lib/detect.js';
+import { resetPatternsCache } from '../../src/lib/patternsRegistry.js';
+import { TEST_HOME } from '../setup.js';
+
+describe('detect.ts perf refactor (W4-B)', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    resetPatternsCache();
+  });
+
+  afterEach(() => {
+    vol.reset();
+    resetPatternsCache();
+    vi.restoreAllMocks();
+  });
+
+  it('detects a plain file with the same DetectedFile shape', async () => {
+    vol.writeFileSync('/test-home/.zshrc', 'export FOO=1\n');
+
+    const detected = await detectDotfiles();
+    const zshrc = detected.find((f) => f.path === '~/.zshrc');
+
+    expect(zshrc).toBeDefined();
+    expect(zshrc!.name).toBe('.zshrc');
+    expect(zshrc!.category).toBe('shell');
+    expect(zshrc!.isDirectory).toBe(false);
+    // size must be populated from a real stat, not undefined
+    expect(typeof zshrc!.size).toBe('number');
+    expect(zshrc!.size).toBe('export FOO=1\n'.length);
+  });
+
+  it('detects a directory pattern as isDirectory: true', async () => {
+    vol.mkdirSync('/test-home/.config/nvim', { recursive: true });
+
+    const detected = await detectDotfiles();
+    const nvim = detected.find((f) => f.path === '~/.config/nvim');
+
+    expect(nvim).toBeDefined();
+    expect(nvim!.isDirectory).toBe(true);
+  });
+
+  it('follows symlinks like the old stat()-based probe (symlink to dir => isDirectory true)', async () => {
+    // Real target directory, then a tracked dotfile path symlinked to it.
+    vol.mkdirSync('/test-home/real-nvim', { recursive: true });
+    vol.mkdirSync('/test-home/.config', { recursive: true });
+    vol.symlinkSync('/test-home/real-nvim', '/test-home/.config/nvim');
+
+    const detected = await detectDotfiles();
+    const nvim = detected.find((f) => f.path === '~/.config/nvim');
+
+    expect(nvim).toBeDefined();
+    // stat() follows the link → directory. lstat() would wrongly report false.
+    expect(nvim!.isDirectory).toBe(true);
+  });
+
+  it('does not stat an existing path more than once (no redundant syscalls)', async () => {
+    vol.writeFileSync('/test-home/.zshrc', 'x\n');
+    vol.writeFileSync('/test-home/.gitconfig', '[user]\n');
+
+    const statSpy = vi.spyOn(fsp, 'stat');
+
+    await detectDotfiles();
+
+    const perPath = new Map<string, number>();
+    for (const call of statSpy.mock.calls) {
+      const p = String(call[0]);
+      perPath.set(p, (perPath.get(p) ?? 0) + 1);
+    }
+
+    // The old code stat()'d each existing path twice (isDirectory + getSize),
+    // plus an access() existence check. After the refactor each path is
+    // stat()'d at most once.
+    for (const [p, count] of perPath) {
+      expect(count, `stat called ${count}x for ${p}`).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/tests/lib/files-tree-stats.test.ts
+++ b/tests/lib/files-tree-stats.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression tests for BATCH W4-E (files.ts polish):
+ *
+ *  1. directory-tree-stats — getDirectoryTreeStats walks the tree ONCE and
+ *     returns both the (identical) file list and a correct totalSize, so callers
+ *     that need size do not pay for a second walk. The file list and ordering
+ *     must be byte-for-byte identical to getDirectoryFiles, and copyFileOrDir's
+ *     reported fileCount/totalSize must be unchanged.
+ *
+ *  2. files-dir-copy-enospc — a no-overwrite copy onto an existing target dir
+ *     must NOT silently merge, and a low-level error (ENOSPC) must surface its
+ *     real error code instead of being masked by a generic PermissionError.
+ *
+ * fs/promises and fs-extra are mocked globally against memfs in setup.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import {
+  getDirectoryFiles,
+  getDirectoryTreeStats,
+  copyFileOrDir,
+} from '../../src/lib/files.js';
+import { TEST_HOME } from '../setup.js';
+
+describe('files tree-stats + dir-copy (W4-E)', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+    vi.restoreAllMocks();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1) directory-tree-stats: single-walk helper, identical file list
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('getDirectoryTreeStats', () => {
+    it('returns a file list identical to getDirectoryFiles', async () => {
+      const dir = join(TEST_HOME, 'tree');
+      const sub = join(dir, 'sub');
+      vol.mkdirSync(sub, { recursive: true });
+      vol.writeFileSync(join(dir, 'c.txt'), 'ccc');
+      vol.writeFileSync(join(dir, 'a.txt'), 'a');
+      vol.writeFileSync(join(sub, 'nested.txt'), 'nested-content');
+
+      const listOnly = await getDirectoryFiles(dir);
+      const stats = await getDirectoryTreeStats(dir);
+
+      // Exact same array (same entries, same sorted order).
+      expect(stats.files).toEqual(listOnly);
+    });
+
+    it('skips the same ignored patterns as getDirectoryFiles', async () => {
+      const dir = join(TEST_HOME, 'tree');
+      vol.mkdirSync(dir, { recursive: true });
+      vol.writeFileSync(join(dir, 'keep.txt'), 'keep');
+      vol.writeFileSync(join(dir, '.DS_Store'), 'system');
+      vol.mkdirSync(join(dir, 'node_modules'), { recursive: true });
+      vol.writeFileSync(join(dir, 'node_modules', 'x.js'), 'dep');
+
+      const stats = await getDirectoryTreeStats(dir);
+
+      expect(stats.files).toEqual(await getDirectoryFiles(dir));
+      expect(stats.files.some((f) => f.includes('.DS_Store'))).toBe(false);
+      expect(stats.files.some((f) => f.includes('node_modules'))).toBe(false);
+    });
+
+    it('totalSize equals the sum of stat() sizes over the file list', async () => {
+      const dir = join(TEST_HOME, 'tree');
+      const sub = join(dir, 'sub');
+      vol.mkdirSync(sub, { recursive: true });
+      vol.writeFileSync(join(dir, 'a.txt'), 'aaaa'); // 4 bytes
+      vol.writeFileSync(join(sub, 'b.txt'), 'bbbbbbb'); // 7 bytes
+
+      const stats = await getDirectoryTreeStats(dir);
+
+      // Independent reference: sum stat() sizes the old (double-walk) way.
+      const { stat } = await import('fs/promises');
+      const files = await getDirectoryFiles(dir);
+      let reference = 0;
+      for (const f of files) reference += (await stat(f)).size;
+
+      expect(stats.totalSize).toBe(reference);
+      expect(stats.totalSize).toBe(11);
+    });
+
+    it('returns empty list and zero size for an empty directory', async () => {
+      const dir = join(TEST_HOME, 'empty');
+      vol.mkdirSync(dir, { recursive: true });
+
+      const stats = await getDirectoryTreeStats(dir);
+
+      expect(stats.files).toEqual([]);
+      expect(stats.totalSize).toBe(0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1b) copyFileOrDir must report unchanged fileCount + totalSize for dirs
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('copyFileOrDir directory stats are unchanged', () => {
+    it('reports correct fileCount and totalSize after copying a dir', async () => {
+      const src = join(TEST_HOME, 'src');
+      const sub = join(src, 'nested');
+      vol.mkdirSync(sub, { recursive: true });
+      vol.writeFileSync(join(src, 'a.txt'), 'aaaa'); // 4
+      vol.writeFileSync(join(sub, 'b.txt'), 'bbbbbbb'); // 7
+      const dest = join(TEST_HOME, 'dest');
+
+      const result = await copyFileOrDir(src, dest);
+
+      expect(result.fileCount).toBe(2);
+      expect(result.totalSize).toBe(11);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 2) files-dir-copy-enospc
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('no-overwrite directory copy onto an existing dir', () => {
+    it('does NOT silently merge into an existing target dir', async () => {
+      const src = join(TEST_HOME, 'src');
+      vol.mkdirSync(src, { recursive: true });
+      vol.writeFileSync(join(src, 'new.txt'), 'fresh');
+
+      // Target dir already exists with a pre-existing, unrelated file.
+      const dest = join(TEST_HOME, 'dest');
+      vol.mkdirSync(dest, { recursive: true });
+      vol.writeFileSync(join(dest, 'existing.txt'), 'original');
+
+      // With overwrite:false this must fail clearly rather than merging src
+      // into dest.
+      await expect(copyFileOrDir(src, dest, { overwrite: false })).rejects.toThrow();
+
+      // And it must NOT have planted src/new.txt into the existing dir.
+      expect(vol.existsSync(join(dest, 'new.txt'))).toBe(false);
+      // The pre-existing file must be untouched.
+      expect(vol.readFileSync(join(dest, 'existing.txt'), 'utf-8')).toBe('original');
+    });
+  });
+
+  describe('low-level copy errors surface their real code', () => {
+    it('preserves an ENOSPC code instead of masking it as a generic error', async () => {
+      const src = join(TEST_HOME, 'source.txt');
+      const dest = join(TEST_HOME, 'dest.txt');
+      vol.writeFileSync(src, 'data');
+
+      const fsPromises = await import('fs/promises');
+      const enospc = Object.assign(new Error('no space left on device'), {
+        code: 'ENOSPC',
+        errno: -28,
+      });
+      vi.spyOn(fsPromises, 'copyFile').mockRejectedValueOnce(enospc as never);
+
+      await expect(copyFileOrDir(src, dest)).rejects.toMatchObject({ code: 'ENOSPC' });
+    });
+  });
+});

--- a/tests/lib/manifest-source-index.test.ts
+++ b/tests/lib/manifest-source-index.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression tests for buildSourceIndex (W4-B).
+ *
+ * `getTrackedFileBySource` is O(N) per call; callers that looked up many
+ * sources against the manifest (new-file detection in scan/sync) were O(N×M).
+ * `buildSourceIndex` builds the source→{id,file} map ONCE so callers can do
+ * O(1) lookups. This must return EXACTLY the same answer as the old per-call
+ * `getTrackedFileBySource` path for every source.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import {
+  buildSourceIndex,
+  getTrackedFileBySource,
+  clearManifestCache,
+} from '../../src/lib/manifest.js';
+import { TEST_TUCK_DIR } from '../setup.js';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+
+describe('buildSourceIndex (W4-B)', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+    clearManifestCache();
+  });
+
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+  });
+
+  const writeManifestWith = (entries: Array<{ id: string; source: string }>): void => {
+    const manifest = createMockManifest();
+    for (const e of entries) {
+      manifest.files[e.id] = createMockTrackedFile({ source: e.source });
+    }
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+  };
+
+  it('maps each tracked source to its {id, file}', async () => {
+    writeManifestWith([
+      { id: 'zshrc', source: '~/.zshrc' },
+      { id: 'gitconfig', source: '~/.gitconfig' },
+    ]);
+
+    const index = await buildSourceIndex(TEST_TUCK_DIR);
+
+    expect(index.size).toBe(2);
+    expect(index.get('~/.zshrc')?.id).toBe('zshrc');
+    expect(index.get('~/.gitconfig')?.id).toBe('gitconfig');
+    expect(index.get('~/.zshrc')?.file.source).toBe('~/.zshrc');
+  });
+
+  it('returns the SAME answers as the old per-call getTrackedFileBySource path', async () => {
+    const sources = ['~/.zshrc', '~/.gitconfig', '~/.vimrc', '~/.tmux.conf'];
+    writeManifestWith(sources.map((s, i) => ({ id: `id${i}`, source: s })));
+
+    const index = await buildSourceIndex(TEST_TUCK_DIR);
+
+    // Tracked sources resolve identically.
+    for (const source of sources) {
+      const viaIndex = index.get(source) ?? null;
+      const viaQuery = await getTrackedFileBySource(TEST_TUCK_DIR, source);
+      expect(viaIndex?.id).toBe(viaQuery?.id);
+      expect(viaIndex?.file).toEqual(viaQuery?.file);
+    }
+
+    // Untracked sources resolve to "not found" in both paths.
+    for (const missing of ['~/.unknown', '~/.config/nvim']) {
+      const viaIndex = index.get(missing) ?? null;
+      const viaQuery = await getTrackedFileBySource(TEST_TUCK_DIR, missing);
+      expect(viaIndex).toBeNull();
+      expect(viaQuery).toBeNull();
+    }
+  });
+
+  it('returns an empty map for a manifest with no files', async () => {
+    vol.writeFileSync(
+      join(TEST_TUCK_DIR, '.tuckmanifest.json'),
+      JSON.stringify(createMockManifest())
+    );
+
+    const index = await buildSourceIndex(TEST_TUCK_DIR);
+    expect(index.size).toBe(0);
+  });
+});

--- a/tests/lib/template-nesting.test.ts
+++ b/tests/lib/template-nesting.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Template engine nesting-correctness regression tests — BATCH W4-D.
+ *
+ * Two latent bugs in src/lib/template.ts are pinned here:
+ *
+ *   (a) A nested comment-marker {{tuck:else}} under a FALSE parent block wrongly
+ *       emitted its body. The fix ANDs a child's keep with the parent's keep so a
+ *       child branch can never resurrect output that the parent suppressed.
+ *
+ *   (b) An inline nested {{#if a}}A{{#if b}}B{{/if}}C{{/if}} with a=false wrongly
+ *       rendered C and consumed only the FIRST {{/if}} (greedy-first match). The
+ *       fix stack-parses nested inline conditionals so the correct {{/if}} closes
+ *       each block.
+ *
+ * These are correctness fixes only — all previously-passing single-level behavior
+ * must be preserved unchanged.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderTemplate } from '../../src/lib/template.js';
+
+describe('template engine nesting (comment markers)', () => {
+  it('(a) a nested tuck:else under a FALSE parent emits nothing', () => {
+    const text = [
+      '# tuck:if keepit == "yes"', // FALSE: keepit is "no"
+      'PARENT_BODY',
+      '# tuck:if inner == "yes"', // child, also FALSE
+      'CHILD_IF',
+      '# tuck:else',
+      'CHILD_ELSE', // must NOT appear: parent is false
+      '# tuck:endif',
+      '# tuck:endif',
+      'AFTER',
+    ].join('\n');
+
+    const out = renderTemplate(text, { keepit: 'no', inner: 'no' });
+
+    expect(out).not.toContain('PARENT_BODY');
+    expect(out).not.toContain('CHILD_IF');
+    expect(out).not.toContain('CHILD_ELSE');
+    expect(out).toContain('AFTER');
+  });
+
+  it('(a) a nested tuck:else under a TRUE parent still toggles normally', () => {
+    const text = [
+      '# tuck:if keepit == "yes"', // TRUE
+      'PARENT_BODY',
+      '# tuck:if inner == "yes"', // child FALSE
+      'CHILD_IF',
+      '# tuck:else',
+      'CHILD_ELSE', // SHOULD appear: parent true, child if false
+      '# tuck:endif',
+      '# tuck:endif',
+    ].join('\n');
+
+    const out = renderTemplate(text, { keepit: 'yes', inner: 'no' });
+
+    expect(out).toContain('PARENT_BODY');
+    expect(out).not.toContain('CHILD_IF');
+    expect(out).toContain('CHILD_ELSE');
+  });
+
+  it('preserves single-level else behavior (false branch -> else body)', () => {
+    const text = ['# tuck:if x == "yes"', 'IF_BODY', '# tuck:else', 'ELSE_BODY', '# tuck:endif'].join(
+      '\n'
+    );
+    const out = renderTemplate(text, { x: 'no' });
+    expect(out).not.toContain('IF_BODY');
+    expect(out).toContain('ELSE_BODY');
+  });
+});
+
+describe('template engine nesting (inline {{#if}})', () => {
+  it('(b) inline nested-if under a FALSE parent renders nothing and consumes the correct {{/if}}', () => {
+    const text = '{{#if a}}A{{#if b}}B{{/if}}C{{/if}}';
+    const out = renderTemplate(text, { a: 'false', b: 'true' });
+    // Whole outer block is false -> empty. No stray "C" and no leftover "{{/if}}".
+    expect(out).toBe('');
+  });
+
+  it('(b) inline nested-if under a TRUE parent renders the inner result and consumes both {{/if}}', () => {
+    const text = 'X{{#if a}}A{{#if b}}B{{/if}}C{{/if}}Y';
+    expect(renderTemplate(text, { a: 'true', b: 'true' })).toBe('XABCY');
+    expect(renderTemplate(text, { a: 'true', b: 'false' })).toBe('XACY');
+  });
+
+  it('preserves single-level inline if/else behavior', () => {
+    expect(renderTemplate('{{#if a}}YES{{else}}NO{{/if}}', { a: 'true' })).toBe('YES');
+    expect(renderTemplate('{{#if a}}YES{{else}}NO{{/if}}', { a: 'false' })).toBe('NO');
+  });
+
+  it('preserves plain substitution alongside conditionals', () => {
+    const out = renderTemplate('{{#if a}}hi {{name}}{{/if}}', { a: 'true', name: 'sam' });
+    expect(out).toBe('hi sam');
+  });
+});

--- a/tests/lib/tuckignore-preloaded.test.ts
+++ b/tests/lib/tuckignore-preloaded.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression tests for isIgnoredInSet (W4-B).
+ *
+ * `isIgnored` re-reads .tuckignore from disk on EVERY call. Detection loops that
+ * checked ~150 detected files therefore re-read the same file ~150 times. The
+ * new `isIgnoredInSet` performs the identical normalization + membership test
+ * against a SET that the caller loads once via `loadTuckignore`, so the answer
+ * is byte-identical but the file is read once.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { loadTuckignore, isIgnored, isIgnoredInSet } from '../../src/lib/tuckignore.js';
+import { TEST_TUCK_DIR } from '../setup.js';
+
+describe('isIgnoredInSet (W4-B)', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('gives the same answer as isIgnored for every probed path', async () => {
+    const ignorePath = join(TEST_TUCK_DIR, '.tuckignore');
+    vol.writeFileSync(ignorePath, '~/.docker/config.json\n~/.netrc\n');
+
+    const ignored = await loadTuckignore(TEST_TUCK_DIR);
+
+    const probes = [
+      '~/.docker/config.json', // ignored
+      '~/.netrc', // ignored
+      '~/.zshrc', // not ignored
+      '~/.gitconfig', // not ignored
+    ];
+
+    for (const probe of probes) {
+      const viaSet = isIgnoredInSet(ignored, probe);
+      const viaDisk = await isIgnored(TEST_TUCK_DIR, probe);
+      expect(viaSet).toBe(viaDisk);
+    }
+  });
+
+  it('normalizes absolute home paths just like isIgnored', async () => {
+    const ignorePath = join(TEST_TUCK_DIR, '.tuckignore');
+    vol.writeFileSync(ignorePath, '~/.netrc\n');
+
+    const ignored = await loadTuckignore(TEST_TUCK_DIR);
+
+    // Absolute path within $HOME should collapse to ~/.netrc and match.
+    const abs = '/test-home/.netrc';
+    expect(isIgnoredInSet(ignored, abs)).toBe(await isIgnored(TEST_TUCK_DIR, abs));
+    expect(isIgnoredInSet(ignored, abs)).toBe(true);
+  });
+
+  it('returns false for an empty ignore set', () => {
+    expect(isIgnoredInSet(new Set(), '~/.zshrc')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Wave 4 — efficiency + correctness. All perf changes are **behavior-preserving** (regression tests assert identical results); TDD throughout; memfs/temp only.

### Performance
- **scan/sync new-file detection** was O(detected × tracked) (a `getTrackedFileBySource` scan per detected file). New `manifest.buildSourceIndex()` builds a `source→{id,file}` Map once → O(1) lookups.
- **detect.ts** collapsed 3 serial syscalls/pattern (×~150 patterns) to one `stat` per path, probes run concurrently (`Promise.all`), order + symlink-follow preserved.
- **`loadTuckignore`** was re-read per detected file (~150×) → hoisted above the loop via `isIgnoredInSet(preloadedSet, path)` (`isIgnored` now delegates to it).
- **sync change-application** carries the manifest id on each change + indexes tracked files once → removes per-change reload and linear `.find()` (O(changes × tracked)).
- **files.ts** `copyFileOrDir` directory branch walked the tree **3×** → one shared single-pass walker (`getDirectoryTreeStats`, size opt-in).

### Correctness
- **Cache invalidation:** `clearManifestCache()` after a clone in `init --from` and `apply`, `clearConfigCache()` after config writes — no run operates on a stale in-memory manifest/config.
- **Template engine:** a nested `{{tuck:else}}` under a **false** parent no longer leaks its body; inline nested `{{#if}}` uses a depth-balanced parser instead of greedy-matching the first `{{/if}}`.
- **files.ts** no-overwrite directory copy no longer silently **merges** into an existing target (throws `DESTINATION_EXISTS`) and preserves real error codes (`ENOSPC`/`ENOENT`) instead of masking them as permission errors.

**Deferred (noted):** file-hash mtime/size short-circuit (cross-cutting — its own focused PR) and lazy command imports (Commander-registration risk).

## Verification
`pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` **1182 passing** (+33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)