### PR TITLE
fix: tracked-directory handling (apply/restore/verify) + bare-init .gitignore

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -17,7 +17,7 @@ import {
   getTuckDir,
 } from '../lib/paths.js';
 import { resolveWriteTarget, setKnownRepoRoots, type RepoWriteTarget } from '../lib/writeContext.js';
-import { setFilePermissions } from '../lib/files.js';
+import { setFilePermissions, copyFileOrDir } from '../lib/files.js';
 import { resolveLiveTarget, resolveRepoRoot, bindRepo } from '../lib/repoScope.js';
 import { cloneRepo } from '../lib/git.js';
 import { isGhInstalled, ghCloneRepo, repoExists } from '../lib/github.js';
@@ -91,6 +91,28 @@ const applyRecordedPermissions = async (
   } catch {
     // Never fail an apply over a chmod that the filesystem rejects.
   }
+};
+
+/**
+ * Apply a tracked DIRECTORY entry by copying the whole tree into place.
+ *
+ * The per-file apply loops read `repoPath` as text (for secret resolution /
+ * smart-merge), which throws EISDIR on a directory. Directory entries (e.g.
+ * `~/.config/nvim`, `~/.ssh`) are copied verbatim instead; secret/merge handling
+ * is per-file and does not apply to a directory tree.
+ */
+const applyDirectoryEntry = async (file: ApplyFile, dryRun: boolean): Promise<void> => {
+  const exists = await pathExists(file.destination);
+  if (dryRun) {
+    logger.file(exists ? 'modify' : 'add', `${collapsePath(file.destination)} (directory)`);
+    return;
+  }
+  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+  await ensureDir(dirname(writeTarget));
+  await copyFileOrDir(file.repoPath, writeTarget, { overwrite: true });
+  await applyRecordedPermissions(writeTarget, file.permissions);
+  await fixSecurePermissions(writeTarget);
+  logger.file(exists ? 'modify' : 'add', `${collapsePath(file.destination)} (directory)`);
 };
 
 export interface ApplyOptions {
@@ -590,6 +612,13 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
   const tuckDir = getTuckDir();
 
   for (const file of files) {
+    // Directory entries are copied as a tree; readFile / secret-resolution /
+    // smart-merge are text-file operations that throw EISDIR on a directory.
+    if ((await stat(file.repoPath)).isDirectory()) {
+      await applyDirectoryEntry(file, dryRun);
+      result.appliedCount++;
+      continue;
+    }
     let fileContent = await readFile(file.repoPath, 'utf-8');
 
     // Resolve placeholders using configured backend (1Password, Bitwarden, pass, or local)
@@ -664,6 +693,13 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
   const tuckDir = getTuckDir();
 
   for (const file of files) {
+    // Directory entries are copied as a tree; readFile / secret-resolution /
+    // smart-merge are text-file operations that throw EISDIR on a directory.
+    if ((await stat(file.repoPath)).isDirectory()) {
+      await applyDirectoryEntry(file, dryRun);
+      result.appliedCount++;
+      continue;
+    }
     let fileContent = await readFile(file.repoPath, 'utf-8');
 
     // Resolve placeholders using configured backend (1Password, Bitwarden, pass, or local)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -67,7 +67,7 @@ import type { InitOptions } from '../types.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
 import { preparePathsForTracking } from '../lib/trackPipeline.js';
 import { errorToMessage } from '../lib/validation.js';
-import { REPO_RUNTIME_GITIGNORE_PATTERNS } from '../lib/state.js';
+import { REPO_RUNTIME_GITIGNORE_PATTERNS, ensureRuntimeArtifactsGitignored } from '../lib/state.js';
 
 const GITIGNORE_TEMPLATE = `# OS generated files
 .DS_Store
@@ -329,6 +329,12 @@ const initFromScratch = async (
       await createDefaultFiles(tuckDir, hostname);
     });
   }
+
+  // Always exclude runtime secrets / keystore / backups from commits. This is a
+  // SECURITY control, not a "default file", so it must exist even for --bare
+  // (which only skips the README and sample files). For non-bare the full
+  // template above already contains these patterns, so this is a no-op.
+  await ensureRuntimeArtifactsGitignored(tuckDir);
 
   // Add remote if provided
   if (options.remote) {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -13,7 +13,7 @@
  */
 import { Command } from 'commander';
 import { resolve, dirname } from 'path';
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile, stat } from 'fs/promises';
 import { ensureDir } from 'fs-extra';
 import { logger, colors as c } from '../ui/index.js';
 import {
@@ -32,6 +32,8 @@ import {
   snapshotWriteContext,
   restoreWriteContext,
   resolveWriteTarget,
+  isSandbox,
+  getWriteRoot,
 } from '../lib/writeContext.js';
 import { smartMerge, isShellFile, type MergeConflict } from '../lib/merge.js';
 import { prepareFilesToApply } from './apply.js';
@@ -159,6 +161,38 @@ const dryApplyIntoSandbox = async (
     // Read side uses the REAL live target (real home), never the sandbox.
     const liveExists = await pathExists(file.destination);
 
+    // Resolve + confine the write target up front. An escape (traversal /
+    // out-of-sandbox absolute) throws → report it and write NOTHING.
+    let writeTarget: string;
+    try {
+      writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+    } catch {
+      wouldEscapeRoot.push(file.source);
+      continue;
+    }
+
+    // A tracked DIRECTORY entry: copy the whole tree into the sandbox (smartMerge
+    // applies to shell TEXT files only) and diff by directory checksum. Reading a
+    // directory as a file below would throw EISDIR.
+    if ((await stat(file.repoPath)).isDirectory()) {
+      await ensureDir(dirname(writeTarget));
+      await copyFileOrDir(file.repoPath, writeTarget, { overwrite: true });
+      let dirStatus: DryApplyChange['status'];
+      if (!liveExists) {
+        dirStatus = 'created';
+      } else {
+        const [liveSum, sandboxSum] = await Promise.all([
+          getFileChecksum(file.destination),
+          getFileChecksum(writeTarget),
+        ]);
+        dirStatus = liveSum === sandboxSum ? 'unchanged' : 'modified';
+      }
+      // Byte counts are per-file; for a directory the status is the signal.
+      changes.push({ target: writeTarget, status: dirStatus, bytesBefore: 0, bytesAfter: 0 });
+      continue;
+    }
+
+    // ── single file ──
     // Determine the content apply WOULD write: smart-merged for shell files with
     // an existing live copy (and surface the conflicts apply discards), else the
     // verbatim repo copy.
@@ -169,16 +203,6 @@ const dryApplyIntoSandbox = async (
       for (const conflict of merge.conflicts) {
         conflicts.push({ ...conflict, target: collapsePath(file.destination) });
       }
-    }
-
-    // Resolve + confine the write target. An escape (traversal / out-of-sandbox
-    // absolute) throws → report it and write NOTHING.
-    let writeTarget: string;
-    try {
-      writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
-    } catch {
-      wouldEscapeRoot.push(file.source);
-      continue;
     }
 
     await ensureDir(dirname(writeTarget));
@@ -223,11 +247,18 @@ const runVerifyApply = async (options: VerifyOptions): Promise<void> => {
     throw new NotInitializedError();
   }
 
-  // The sandbox root: an explicit --root (resolved) or an internal scratch dir.
-  const sandboxRoot = options.root
+  // The sandbox root: an explicit --root, else an internal scratch dir.
+  // `--root` is a GLOBAL option the preAction hook resolves into the WriteContext,
+  // so when the subcommand didn't receive its own `options.root` (the common CLI
+  // case) honor the global sandbox via getWriteRoot() — otherwise `--apply` would
+  // silently ignore the user's `--root` and write into a throwaway temp dir.
+  const explicitRoot = options.root
     ? resolve(expandPath(options.root))
-    : resolve(tuckDir, '.verify-sandbox', `dry-${Date.now()}`);
-  const usingTempSandbox = !options.root;
+    : isSandbox()
+      ? getWriteRoot()
+      : undefined;
+  const sandboxRoot = explicitRoot ?? resolve(tuckDir, '.verify-sandbox', `dry-${Date.now()}`);
+  const usingTempSandbox = !explicitRoot;
 
   // Confine ALL writes under the sandbox for the duration of the dry-apply.
   // Snapshot first so the finally restores any PRIOR boundary (e.g. a global

--- a/src/lib/secrets/redactor.ts
+++ b/src/lib/secrets/redactor.ts
@@ -315,6 +315,12 @@ export const restoreFiles = async (
       continue;
     }
 
+    // Secret placeholders are per-file; a tracked DIRECTORY has no content to
+    // restore at the directory level (and readFile on a dir throws EISDIR).
+    if ((await stat(expandedPath)).isDirectory()) {
+      continue;
+    }
+
     const content = await readFile(expandedPath, 'utf-8');
     const result = restoreContent(content, secrets);
 
@@ -442,6 +448,12 @@ export const restoreFilesWithResolver = async (
     const expandedPath = expandPath(filepath);
 
     if (!(await pathExists(expandedPath))) {
+      continue;
+    }
+
+    // Secret placeholders are per-file; a tracked DIRECTORY has no content to
+    // restore at the directory level (and readFile on a dir throws EISDIR).
+    if ((await stat(expandedPath)).isDirectory()) {
       continue;
     }
 

--- a/tests/commands/apply-permissions.test.ts
+++ b/tests/commands/apply-permissions.test.ts
@@ -159,4 +159,33 @@ describe('apply honors manifest permissions for non-ssh/gpg files', () => {
       expect(mode.toString(8)).toBe('600');
     }
   );
+
+  it('applies a tracked DIRECTORY entry as a tree (EISDIR regression)', async () => {
+    // apply's per-file loops read repoPath as text (for secret resolution / merge)
+    // which throws EISDIR on a directory — directories must be copied as a tree.
+    // Caught by live sandbox testing of `tuck apply` with a tracked ~/.config dir.
+    const localSrc = join(TEST_HOME, 'dotfiles-src');
+    const manifest = createMockManifest({
+      files: {
+        cfg: createMockTrackedFile({
+          source: '~/.config/app',
+          destination: 'files/config/app',
+          category: 'misc',
+        }),
+      },
+    });
+    vol.mkdirSync(join(localSrc, 'files', 'config', 'app'), { recursive: true });
+    vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+    vol.writeFileSync(join(localSrc, 'files', 'config', 'app', 'settings.conf'), 'theme=dark\n');
+    vol.writeFileSync(join(localSrc, 'files', 'config', 'app', 'nested.conf'), 'x=1\n');
+
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply(localSrc, { replace: true }); // must NOT throw EISDIR
+
+    expect(vol.existsSync(join(TEST_HOME, '.config', 'app', 'settings.conf'))).toBe(true);
+    expect(vol.readFileSync(join(TEST_HOME, '.config', 'app', 'nested.conf'), 'utf-8')).toBe('x=1\n');
+  });
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -146,6 +146,22 @@ describe('init command behavior', () => {
     saveConfigMock.mockResolvedValue(undefined);
   });
 
+  it('--bare still creates the security .gitignore (runtime exclusions)', async () => {
+    const { vol } = await import('memfs');
+    pathExistsMock.mockResolvedValue(false); // not already initialized
+    const { runInit } = await import('../../src/commands/init.js');
+
+    await runInit({ bare: true, yes: true });
+
+    // The runtime .gitignore is a SECURITY control (excludes secrets/keystore/
+    // backups) and must exist even for --bare, which only skips README/samples.
+    // Regression caught by live sandbox testing of `tuck init --bare`.
+    expect(vol.existsSync('/test-home/.tuck/.gitignore')).toBe(true);
+    expect(vol.readFileSync('/test-home/.tuck/.gitignore', 'utf-8')).toContain(
+      'secrets.local.json'
+    );
+  });
+
   it('clones from remote and backfills missing manifest/config', async () => {
     pathExistsMock.mockResolvedValue(false);
     const { runInit } = await import('../../src/commands/init.js');

--- a/tests/commands/verify-sandbox.test.ts
+++ b/tests/commands/verify-sandbox.test.ts
@@ -201,6 +201,64 @@ describe('verify --root / --apply', () => {
     expect(byTarget('.modrc').bytesBefore).toBe('LIVE VERSION\n'.length);
   });
 
+  it('--apply honors a GLOBAL --root (WriteContext) when options.root is unset', async () => {
+    // `--root` is a global program option resolved into the WriteContext by the
+    // preAction hook, so the verify subcommand's options.root is empty on a real
+    // CLI run. --apply must then use the global sandbox root (for inspection),
+    // not a throwaway internal temp dir. (Regression from live sandbox testing.)
+    const globalRoot = '/test-home/global-dry';
+    setWriteContext({ root: globalRoot, isSandbox: true });
+
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'export A=1\n');
+    writeManifestFiles({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        checksum: await checksum(`${TUCK}/files/shell/zshrc`),
+      },
+    });
+
+    // No options.root passed → must fall back to the global sandbox root.
+    await runVerify({ json: true, apply: true });
+
+    const env = envelope();
+    expect(env.ok).toBe(true);
+    expect(resolve(env.data.root)).toBe(resolve(globalRoot));
+    // The preview materialized under the GLOBAL root, never an internal temp dir.
+    expect(env.data.changes.every((c: { target: string }) => resolve(c.target).startsWith(resolve(globalRoot)))).toBe(true);
+  });
+
+  it('handles a tracked DIRECTORY entry without crashing (EISDIR regression)', async () => {
+    // A tracked directory: repo copy + an identical live tree (unchanged).
+    vol.mkdirSync(`${TUCK}/files/config/app`, { recursive: true });
+    vol.writeFileSync(`${TUCK}/files/config/app/settings.conf`, 'theme=dark\n');
+    vol.mkdirSync('/test-home/.config/app', { recursive: true });
+    vol.writeFileSync('/test-home/.config/app/settings.conf', 'theme=dark\n');
+
+    writeManifestFiles({
+      app: {
+        source: '~/.config/app',
+        destination: 'files/config/app',
+        category: 'misc',
+        checksum: await checksum(`${TUCK}/files/config/app`),
+      },
+    });
+
+    // Must NOT throw EISDIR (reading a directory as a file) — the live repro that
+    // mocked unit tests missed but a real sandbox run surfaced.
+    await runVerify({ json: true, apply: true, root: SANDBOX });
+
+    const env = envelope();
+    expect(env.ok).toBe(true);
+    const dirChange = env.data.changes.find((ch: { target: string }) =>
+      ch.target.replace(/\\/g, '/').includes('/.config/app')
+    );
+    expect(dirChange).toBeTruthy();
+    expect(dirChange.status).toBe('unchanged');
+    // The directory tree was materialized under the SANDBOX, never the live home.
+    expect(vol.existsSync(`${dirChange.target}/settings.conf`)).toBe(true);
+  });
+
   it('reports a traversal/escaping manifest entry in wouldEscapeRoot and writes NOTHING', async () => {
     // A safe entry alongside an escaping one.
     vol.writeFileSync(`${TUCK}/files/shell/okrc`, 'OK\n');

--- a/tests/lib/redactor-roundtrip.test.ts
+++ b/tests/lib/redactor-roundtrip.test.ts
@@ -9,7 +9,8 @@
  * ordering guarantee cannot silently regress.
  */
 import { describe, it, expect } from 'vitest';
-import { redactContent, restoreContent } from '../../src/lib/secrets/redactor.js';
+import { vol } from 'memfs';
+import { redactContent, restoreContent, restoreFiles } from '../../src/lib/secrets/redactor.js';
 import type { SecretMatch } from '../../src/lib/secrets/scanner.js';
 
 const makeMatch = (value: string, placeholder: string): SecretMatch => ({
@@ -58,5 +59,23 @@ describe('redactor round-trip with overlapping (short ⊂ long) secrets', () => 
 
     expect(restored).toBe(1);
     expect(restoredContent).toBe(original);
+  });
+});
+
+describe('restoreFiles with a tracked directory path', () => {
+  it('skips a directory entry without throwing EISDIR', async () => {
+    // restore (and apply) pass restored target paths to restoreFiles to swap
+    // placeholders back. A tracked DIRECTORY path would readFile→EISDIR; it must
+    // be skipped. Caught by live sandbox testing of `tuck restore --all`.
+    vol.reset();
+    vol.mkdirSync('/test-home/.config/app', { recursive: true });
+    vol.writeFileSync('/test-home/.config/app/settings.conf', 'theme=dark\n');
+    vol.mkdirSync('/test-home/.tuck', { recursive: true }); // tuckDir, no secrets store
+
+    const res = await restoreFiles(['~/.config/app'], '/test-home/.tuck');
+
+    expect(res.filesModified).toBe(0);
+    // The directory's contents are untouched (no spurious rewrite).
+    expect(vol.readFileSync('/test-home/.config/app/settings.conf', 'utf-8')).toBe('theme=dark\n');
   });
 });


### PR DESCRIPTION
## Summary
Bugs found by **live sandbox testing** — building the CLI and running real `tuck` commands against throwaway fake homes (`HOME=$(mktemp -d)`), which the 1200+ mocked unit tests missed because they only ever used **single files**. Each fix is verified by a real end-to-end run **and** a regression test that now exercises directory entries.

### Tracked directories crashed with EISDIR (`~/.config/*`, `~/.ssh` are common)
- **`apply`**: both materialization loops read `repoPath` as text (secret-resolution / smart-merge) → `EISDIR` on a directory, leaving a **partial apply** (the file applied, the directory didn't, then it errored). New `applyDirectoryEntry()` copies the tree + applies recorded perms.
- **`restore`**: `restoreFiles`/`restoreFilesWithResolver` (placeholder restoration) `readFile`'d every restored path; now skip directory paths.
- **`verify --apply`**: the dry-apply read `repoPath` as a file; now copies dir trees and diffs by directory checksum.

### `verify --apply --root <dir>` ignored the user's `--root`
`--root` is a **global** option (resolved into the WriteContext by the preAction hook), so the verify subcommand's `options.root` is empty on a real CLI run — `--apply` was silently writing into a throwaway temp dir. Now it honors the global sandbox root for inspection.

### `init --bare` shipped no security `.gitignore`
The `.gitignore` (excludes `secrets.local.json` / keystore / backups) was only written by `createDefaultFiles`, which `--bare` skips — so secrets could be committed/pushed. Now always written via `ensureRuntimeArtifactsGitignored` (doctor `security.runtime-gitignore`: **fail → pass**, `18/1/1 → 20/0/0`).

## Verification
Live sandbox runs (init/add/status/list/verify/sync/restore/apply/secrets/doctor + cross-machine `file://` apply + `verify --apply --root`), real `~` never touched. `pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` **1205 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)