### PR TITLE
feat(P0): templating/decrypt-on-apply, MCP widening, e2e harness + chezmoi-parity audit

### DIFF
--- a/docs/CHEZMOI-PARITY-AUDIT-2026-06.md
+++ b/docs/CHEZMOI-PARITY-AUDIT-2026-06.md
@@ -1,0 +1,244 @@
+# tuck vs chezmoi & peers — Feature-Parity, Best-Practices & Implementation Audit (2026-06)
+
+> Produced by a 27-agent parallel audit workflow (`chezmoi-parity-audit`): 15 reference deep-dives across **chezmoi** (×8 slices) + **yadm / stow / dotbot / dotter / rcm / vcsh** — reading the actual cloned source — plus 5 tuck-subsystem inventories, fanned into **6 dimension gap-analyses** (each agent re-verified every "tuck is missing/partial" claim against `src/` before asserting it), then synthesized. Reference sources were cloned to `/tmp/dotfiles-refs`; chezmoi's own `comparison-table.md` seeded the matrix. This is the **outward-facing** companion to `docs/AUDIT-2026-05.md` (which is inward-facing code-safety). The headline P0 claims (templating/decrypt not wired into `apply`, no `import`/`edit`/`completion` commands) were independently re-verified against tuck source after the run.
+
+## 1. Executive Summary
+
+tuck is a TypeScript dotfiles manager whose **lifecycle surface is already at near-chezmoi parity** (init, add, remove, sync, push, pull, apply, restore, status, list, diff, verify, undo, scan — all wired and functional per the verified inventory) and whose **safety architecture exceeds chezmoi in three places**: a process-wide write-confinement sandbox (`src/lib/writeContext.ts`, `--root`), secret-scanning-by-default on every sync (`src/commands/sync.ts`), and an atomic snapshot/undo time-machine (`src/lib/timemachine.ts`) taken before every apply and pre-pull sync. It also owns a genuine **category of one**: a native MCP server (`src/commands/mcp.ts`, 6 tools, `TUCK_MCP_ALLOW_WRITE` gate), AI-agent-config sync (`src/commands/context.ts`), and repo-scoped tracking by stable `(repoKey, repoRelative)` identity (`src/lib/repoScope.ts`). None of the seven reference tools (chezmoi, yadm, stow, dotbot, dotter, rcm, vcsh) have any of these.
+
+**Where tuck genuinely stands.** On the *transactional* axis (drift detection, rollback, secret hygiene, agent automation) tuck is at or ahead of chezmoi. On the *declarative-config* axis (per-machine templating, externals, migration on-ramps) tuck has **built the engines but not connected them**. The single most damaging finding, verified directly in source: `renderTemplate` appears only in `src/lib/template.ts` and `src/commands/preset.ts` — **`apply.ts` never calls it**. A complete, tested template engine exists, but the `template: boolean` manifest field is hardcoded `false` and never read at apply time, so tuck's flagship use case ("one repo, many machines") silently does not work for tracked dotfiles. A parallel verified bug: `apply.ts` contains zero `TCKE1`/`decrypt` references, so encrypted repo files are copied to disk as **raw ciphertext** — the keystore-encryption subsystem is dead weight until this is fixed.
+
+**Real strengths to lean on:** (1) the 3-way live/repo/manifest state model (`stateModel.ts`) already distinguishes drift-local from drift-repo — chezmoi's core insight, already built; (2) the `--root` write sandbox is type-stronger than chezmoi's no-op `DryRunSystem`; (3) secret scanning with ReDoS guards + gitleaks is on by default, which chezmoi leaves to user discipline; (4) comprehensive JSON envelopes across all commands enable end-to-end agent control; (5) repo-scoped tracking lets tuck manage configs *inside* other git checkouts, which no peer models.
+
+**The 5 highest-leverage moves:**
+
+1. **Wire the existing template engine into `tuck apply`** (P0, M) — integration of already-tested code, not net-new; closes the largest competitive gap in one stroke.
+2. **Add transparent decrypt-on-apply for `TCKE1` files** (P0, M) — a correctness bug, not a feature: encryption currently ships ciphertext to disk.
+3. **Widen the MCP server** to expose diff/verify/scan_untracked/apply-plan (P0, M) — turns "has MCP" into "the agent-native dotfiles manager," tuck's only uncontested moat.
+4. **Ship `tuck import --from chezmoi|stow`** and stop shipping pseudocode-only migration docs (P1, L) — the primary adoption on-ramp; `docs/migrations/*.md` (5,618 lines) currently *imply* working importers that do not exist.
+5. **Quick-win bundle**: `tuck completion <shell>` + doctor env checks (git-version/$EDITOR/umask/symlink/latest-version + homedir redaction) + fix the dead `--keep-original` stub on `remove` (P1, S).
+
+---
+
+## 2. Master Feature Matrix
+
+Legend: ✅ full · ◐ partial/stubbed · ❌ absent · 🏆 tuck better than all peers. tuck statuses reflect only what the gap findings verified.
+
+| Feature | tuck | chezmoi | yadm | stow | dotbot | dotter | rcm | vcsh |
+|---|---|---|---|---|---|---|---|---|
+| **— chezmoi's own comparison rows —** | | | | | | | | |
+| Manage shell/git/editor config | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Single binary / one-line bootstrap | ◐ (npm/brew + `apply <user>`) | ✅ | ✅ | ❌ | ◐ | ✅ | ✅ | ❌ |
+| Per-machine differences (templating) | ❌ (engine unwired in apply) | ✅ | ◐ (alt-files) | ❌ | ◐ (`if`) | ✅ | ◐ (host-/tag-) | ❌ |
+| Use any tool to edit config | ✅ (direct files) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Manage machine-to-machine secrets | ◐ (scan+redact+PM resolve; no decrypt-on-apply) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Apply / dry-run | ✅ (`--dry-run`/`--plan`) | ✅ | ❌ | ◐ (`--simulate`) | ✅ | ✅ | ❌ | ❌ |
+| Diff before apply | ✅ (live-vs-repo) | ✅ | ◐ (`git diff`) | ❌ | ❌ | ✅ | ❌ | ◐ |
+| Status (drift) | ◐ (2-way; repo-scoped path bug) | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Verify (CI exit-code gate) | 🏆 (3-way + sandbox dry-apply) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Import from git repo on init | ◐ (GitHub-only; tuck or plain-dotfiles) | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Update (pull + apply) | ✅ (sync) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **— advanced rows (extending chezmoi's table) —** | | | | | | | | |
+| Templates wired into deploy | ❌ | ✅ | ◐ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Three-tier template data (built-ins+file+local) | ◐ (built-ins only; config vars inert) | ✅ | ◐ | ❌ | ❌ | ◐ | ❌ | ❌ |
+| Whole-file encryption | ◐ (TCKE1/scrypt formats exist) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Transparent decrypt-on-apply | ❌ (verified: none in apply.ts) | ✅ | ✅ | ❌ | ❌ | ◐ (trans_r) | ❌ | ❌ |
+| age/GPG interop | ❌ (tuck-only formats) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ (transcrypt) |
+| Password-manager integration | ◐ (4: 1Password/Bitwarden/pass/local) | ✅ (14) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Secret scanning (built-in) | 🏆 (ReDoS-guarded + gitleaks, default) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| OS-keystore-managed passphrase | ◐ (macOS/Linux/fallback; Win stub) | ◐ (keyring for secrets) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Agent / MCP server | 🏆 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| AI-agent-config tracking (CLAUDE.md etc.) | 🏆 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Repo-scope (track files in other checkouts) | 🏆 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Write-sandbox (`--root` confinement) | 🏆 | ◐ (DryRunSystem) | ❌ | ❌ | ❌ | ◐ (dry-run FS) | ❌ | ❌ |
+| Migration importers (chezmoi/stow/yadm) | ❌ (docs-only pseudocode) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Golden / txtar integration tests | ❌ | ✅ (292) | ◐ (pytest) | ✅ (Perl .t) | ◐ (pytest) | ◐ | ✅ (Cram) | ✅ (Perl) |
+| Snapshot/undo time-machine | 🏆 (atomic, recursive) | ◐ (via git) | ◐ (via git) | ❌ | ◐ (backup) | ◐ (backup) | ❌ | ◐ (via git) |
+| Structured JSON output (all commands) | 🏆 | ◐ (dump/managed) | ❌ | ❌ | ❌ | ❌ | ❌ | ◐ |
+| edit → apply loop | ❌ (no `edit` cmd) | ✅ | ✅ | ✅ (live=link) | ✅ (live=link) | ✅ (live=link) | ✅ | ✅ |
+| 3-way merge command | ❌ (merge.ts is shell-append) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| re-add / mass-sync | ❌ | ✅ | ✅ (bare git) | n/a | ❌ | n/a | ❌ | ✅ (bare git) |
+| chattr (toggle attrs in place) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Externals (remote files/archives/repos) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Archive import/export | ◐ (tar only for clone bootstrap) | ✅ | ❌ | ❌ | ❌ | ❌ | ◐ (`rcup -g`) | ❌ |
+| Shell completions | ❌ | ✅ | ✅ | ◐ | ❌ | ✅ | ◐ | ✅ |
+| cd / enter / shell subshell | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| exact-dir / managed removal of untracked | ❌ | ✅ | ❌ | ◐ (unstow) | ✅ (clean) | ✅ (set-diff) | ❌ | ❌ |
+| Pre/post hooks | ◐ (sync/restore only; preset postApply dead) | ✅ | ✅ | ❌ | ◐ (shell) | ✅ | ✅ | ✅ |
+| Watch mode (re-apply on change) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Profiles / personas | ❌ (bundles filter apply only) | ◐ (.chezmoiignore) | ◐ (class) | ❌ | ❌ | ✅ (packages) | ◐ (tag) | ❌ |
+| App-settings catalog (mackup-style) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Declarative package bootstrap | ❌ | ◐ (run_once scripts) | ◐ (bootstrap) | ❌ | ◐ (shell) | ❌ | ❌ | ❌ |
+| Symlink-farm deploy mode | ◐ (inverted: live becomes link) | ✅ (symlink mode) | ◐ (alt) | 🏆 | ✅ | ✅ | ✅ | ❌ (bare git) |
+| Cache-diff safe redeploy (warn on edit) | ❌ (clobbers w/ snapshot) | ✅ (3-state) | ❌ | ◐ (conflict) | ◐ | 🏆 | ❌ | ❌ |
+| Persistent run-once/onchange state | ❌ | ✅ (boltdb) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| destroy / purge (clean uninstall) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (delete) |
+| Single System abstraction (one code path) | ◐ (verify reuses apply prep; restore/diff separate) | ✅ | ❌ | ✅ (plan/execute) | ✅ (plugin dispatch) | 🏆 (Filesystem trait) | ❌ | ❌ |
+
+---
+
+## 3. Parity Gaps (Prioritized, Deduplicated)
+
+The six gap analyses produced overlapping items; the following list **deduplicates** them into a single prioritized backlog. Effort: S (≤1 day), M (2–5 days), L (>1 week).
+
+### P0 — correctness bugs and the headline competitive gap
+
+| # | Gap | Effort | Recommendation |
+|---|---|---|---|
+| P0-1 | **Templating not wired into apply** (verified: `renderTemplate` absent from `apply.ts`; `template:true` never read) | M | Call `renderTemplate` in `apply.ts` for `template:true` entries; add `tuck add --template`; pass `config.templates.variables` into `defaultTemplateContext`. Engine + tests already exist. |
+| P0-2 | **No decrypt-on-apply** (verified: no `TCKE1`/`decrypt` in `apply.ts`) — encrypted repo files land as ciphertext | M | Detect the `TCKE1` header in apply's read pipeline, pull passphrase from the keystore, decrypt before write. Mirror the secret-resolution path already wired at `apply.ts` (`resolveFileSecrets`). |
+| P0-3 | **MCP surface too thin** (verified: 6 tools, read-only inspection limited to status/scan) | M | Add `diff`, `verify(--exit-code)`, `scan_untracked`, secrets-status, and a sandboxed apply-plan tool behind `TUCK_MCP_ALLOW_WRITE`. |
+
+### P1 — daily-workflow and adoption blockers
+
+| # | Gap | Effort | Recommendation |
+|---|---|---|---|
+| P1-1 | **No `tuck edit`** (verified: no `edit.ts`; only `config edit`) | M | `tuck edit <file>` opens the repo copy in `$EDITOR`; `--apply` on save; decrypt-to-0700-tempdir for encrypted files. |
+| P1-2 | **No re-add / mass-sync** (verified: `add` is one-file, idempotent-by-error) | M | `tuck re-add` iterates tracked non-template files, compares live-vs-repo via `stateModel`, updates changed files in one pass. |
+| P1-3 | **No migration importers** (verified: no `import.ts`, no `src/lib/migrations/`; docs are pseudocode) | L | Ship `tuck import --from chezmoi|stow` first (largest switcher pools); map `dot_`/`private_`/`.tmpl`/`encrypted_` and stow packages into the manifest pipeline with `--dry-run` + write-only-missing. |
+| P1-4 | **Migration docs over-state capability** (5,618 lines of `ChezmoiMigrator` pseudocode with no src) | S | Either implement, or banner each doc as "design — not yet implemented." |
+| P1-5 | **No shell completions** (verified: none in `index.ts`) | S | `tuck completion <bash|zsh|fish>` — Commander lacks built-in; generate static scripts. Every major peer ships this. |
+| P1-6 | **No 3-way merge command** (verified: `merge.ts` is shell-append, not external merge tool) | M | `tuck merge <file>` invoking configurable `merge.command` (default vimdiff) with live/repo/computed-target. |
+| P1-7 | **Doctor missing env checks** (verified: no umask/EDITOR/latest/gitVersion/symlink/redact) | S | Add git-version (semver-min), `$VISUAL`/`$EDITOR`, umask, symlink-probe, npm/GitHub latest-version (`--no-network`), and redact `homedir()`→`~` in all messages. |
+| P1-8 | **`--keep-original` is a dead stub** on `remove` (verified: flag declared, value never read) | S | On removing a symlink-tracked file, materialize repo content back to the original path as a regular file before untracking. |
+| P1-9 | **No machine-specific file selection** (profiles/alt-files) | L | `tuck apply --profile <name>` built on the existing bundle concept (profiles = bundle subsets + variable overrides). Covers all-or-nothing per-machine inclusion that templates don't. |
+| P1-10 | **No `.tuckdata` machine-data file** (verified: `config.templates.variables` never read) | M | Add `.tuckdata.{yaml,toml,json}` + deep-merge with built-ins and local config. Depends on P0-1. |
+
+### P2 — declarative-management completeness and polish
+
+| # | Gap | Effort | Recommendation |
+|---|---|---|---|
+| P2-1 | **No cache-diff safety** — apply `--replace` clobbers manually-edited live files (recoverable via snapshot, but silent) | M | Before overwrite, consult `stateModel` drift-local; if user-edited and no `--force`, warn-and-skip (dotter's core guarantee). |
+| P2-2 | **No System abstraction** — apply/restore/diff keep separate write paths that can diverge | L | Introduce `System` interface (writeFile/mkdir/remove/chmod/symlink) with Real/DryRun/ReadOnly impls; route all four commands through it. Keystone that makes P2-1 cheap. |
+| P2-3 | **No persistent EntryState** — hooks re-run every time; apply has no no-op short-circuit | M | State file under `getStateDir()` keyed by content SHA-256 (run-once) and target path (run-onchange); add apply already-up-to-date short-circuit. |
+| P2-4 | **No externals** (verified: no `.tuckexternal` subsystem) | L | `.tuckexternal.toml` declaring remote files/archives/git-repos, cached by SHA-256(url), `refreshPeriod`, required checksum before write. |
+| P2-5 | **No exact-dir / managed removal** (verified: no prune/deleteUntracked in apply) | M | Exact/managed directory flag so apply deletes untracked destination entries for strict declarative sync. |
+| P2-6 | **No `tuck export`/`archive`** (verified: `preset publish` is a no-tar stub) | M | `tuck export` (self-contained installer à la `rcup -g`) and/or `tuck archive` (tar/zip of rendered target). |
+| P2-7 | **No `tuck shell`/`cd`** (verified: no GIT_DIR subshell) | S | Spawn `$SHELL` with cwd at the repo (and GIT_DIR if bare) for raw-git debugging. ~10 lines. |
+| P2-8 | **age/GPG interop absent** | L | `Encryption` interface with `AgeEncryption` (bundle `age-encryption` npm) + `GpgEncryption`. |
+| P2-9 | **No watch mode** (verified: no chokidar in commands) | S | `tuck watch` re-runs apply on repo change, excluding `.tuck/` and `.git/`. Only valuable after P0-1. |
+| P2-10 | **No app-settings catalog / package bootstrap** | M–L | `src/lib/apps/*.toml` for ~50 dev apps + `tuck add --app`; `[packages]` block + `tuck bootstrap` (Brewfile-first). |
+| P2-11 | **No destroy/purge** (verified: only `remove` untracks, `undo` restores) | M | `tuck purge` (config/state/snapshots) + optional `tuck destroy <file>` behind a typed-phrase confirm (vcsh pattern). |
+| P2-12 | **`status` repo-scoped path bug + no porcelain** | S | Fix `expandPath` misuse for repo-scoped sources (use `resolveLiveTarget` as verify does); add `--porcelain` A/M/D codes. |
+| P2-13 | **diff doesn't compare vs manifest checksum** — repo-drift shows "no difference" | S | Extend diff to the 3-way model `verify` already uses. |
+| P2-14 | **gitignore re-assertion only at init** (verified: `ensureRuntimeArtifactsGitignored` called only in `init.ts`) | S | Call it at the top of the sync commit path (and apply/import) so pre-existing repos can't leak `secrets.local.json`/state. |
+
+---
+
+## 4. Best Practices to Adopt From the Source Code
+
+Each item cites the specific reference technique and the verified tuck gap.
+
+1. **chezmoi's `System` abstraction — one code path for dry-run/diff/apply/verify.** chezmoi implements target-state traversal once (`applyArgs → SourceState.Apply`) and injects a different `System` (RealSystem, DryRunSystem, ErrorOnWriteSystem, GitDiffSystem) per command; dotter does the same with a 10-method `Filesystem` trait. tuck verified state: `verify` reuses `prepareFilesToApply`, but `restore` has its own `prepareFilesToRestore` and `apply` has inline `applyWithMerge`/`applyWithReplace`. **Adopt:** a single injected `System` so `--dry-run` is structural (a no-op sink) rather than scattered `if (dryRun)` branches, halving the surface where apply and diff can disagree. (P2-2)
+
+2. **chezmoi's three-state reconciliation (target/last-written/actual) for idempotency and conflict detection.** chezmoi stores the last-applied `EntryState{type, mode, SHA256}` in boltdb and compares all three to distinguish "repo changed" from "user edited" from "conflict." tuck verified state: `stateModel.ts` already computes the 3-way comparison and powers `verify` — but `apply`/`sync` use 2-way and never gate on drift-local. **Adopt:** persist `EntryState` keyed by content SHA-256 and consult it in apply.
+
+3. **dotter's cache-diff safe redeploy.** dotter writes the last-deployed output to `.dotter/cache/<path>` and refuses to overwrite a live file whose content no longer matches the cache without `--force` — its central safety guarantee. tuck verified state: `applyWithReplace` checks `pathExists` only to label add/modify, then writes unconditionally (a pre-apply snapshot makes it recoverable, but the edit is clobbered silently). **Adopt:** warn-and-skip on drift-local before destructive write. (P2-1)
+
+4. **chezmoi/boltdb persistent state for run-once/run-onchange scripts.** Idempotency is proven by the script's own content hash (`ScriptStateBucket` keyed on `hex(sha256(body))`) for run-once, and by target path (`EntryStateBucket`) for run-onchange — so renaming re-runs but identical content does not. tuck verified state: no persistent script state; hooks run on every sync/restore. **Adopt:** the two-keyspace model (content-hash for once, path for onchange), recorded only after success so failures retry. (P2-3)
+
+5. **chezmoi's transparent encryption (decrypt-on-apply + edit-encrypted).** The `encrypted_` filename attribute drives a strategy-pattern `Encryption` interface; apply decrypts on read, and `edit-encrypted` decrypts to a 0700 tempdir, edits, re-encrypts. tuck verified state: per-file `encrypt-file`/`decrypt-file` exist but `apply.ts` never decrypts. **Adopt:** decrypt-on-apply (P0-2) and an `Encryption` interface to enable age/GPG (P2-8).
+
+6. **chezmoi's password-manager call memoization + `op`/`pass` `--` argv hardening.** Each PM CLI call is memoized per-run on the joined arg list, and user-controlled paths follow `--`. tuck verified state: `execFile` + `--` is implemented for backends, and `bitwarden-argv.test.ts` asserts it for Bitwarden — but `op`/`pass` lack recorded-argv tests. **Adopt:** the memoization pattern (a `.zshrc.tmpl` may reference one item 10×) and bitwarden-style argv assertions for the other backends.
+
+7. **chezmoi's `doctor` as a composable check framework with PII redaction.** Each check is `Name() + Run() → (result, message)`; output redacts `homedir()→~` because it's pasted into public issues. tuck verified state: ~15–20 checks exist, but none for git-version/$EDITOR/umask/symlink/latest-version and no redaction pass. **Adopt:** the missing actionable env checks and a single `replaceAll(homedir(), '~')` pass. (P1-7)
+
+8. **chezmoi's atomic write via temp-file + same-filesystem rename, with chmod-before-write.** `renameio` guarantees a file is old-or-new, never truncated; `f.Chmod(perm)` runs *before* `f.Write` so a new `.ssh/config` is never briefly world-readable. tuck verified state: `atomicWriteFile` (`files.ts:54`) does same-dir temp+rename (good) and honors mode, but the apply/restore `writeFile` calls chmod *after* writing. **Adopt:** pass `{mode}` to the initial write for sensitive destinations (or route through `atomicWriteFile`).
+
+9. **rcm's hook contract: cwd = hook's own dir, propagate exit code, support file-or-sorted-dir.** A failing pre-hook aborts with the hook's *own* exit code (e.g. 7, not 1); cwd is the hook directory so hooks reference siblings; `find … | sort` handles both a single file and a numbered directory. tuck verified state: hooks cover sync/restore only, `preset.json` postApply hooks are never executed, no per-command pre/post for add/apply/edit. **Adopt:** generalize hooks to all commands, execute preset postApply, set cwd + propagate exit code. (Gap: hooks, P1)
+
+10. **stow's / dotbot's two-phase plan-then-execute conflict collection.** Stow runs a pure planning pass collecting *all* conflicts before any write, then executes; dotbot's Link detects "already correct" and skips. tuck verified state: apply conflict detection is implicit (copy overwrites). **Adopt:** collect would-be conflicts, print together, abort before writing — preventing partial-apply states.
+
+11. **chezmoi/stow/dotbot/yadm golden integration tests (txtar / Cram / `.t`).** Each declares an inline filesystem + commands + expected stdout in one self-contained file; chezmoi has 292 txtar scripts, 107 named `issueNNNN.txtar`. tuck verified state: ~1,175 it() cases but ~95% memfs-mocked, **zero tests spawn `dist/index.js`** (CI only smoke-tests `--version`/`--help`), no golden corpus. **Adopt:** a txtar-equivalent harness (see §5).
+
+12. **XDG config/state separation (chezmoi, yadm, dotter).** chezmoi keeps `~/.config/chezmoi/chezmoi.toml` *out* of the repo (`~/.local/share/chezmoi`); machine-specific values live in a never-tracked local file. tuck verified state: `getConfigPath` resolves `config.json` *inside* the repo dir, risking commit/overwrite-on-pull. **Adopt:** move config to `$XDG_CONFIG_HOME/tuck/config.json`; split per-machine template vars into a never-tracked local override. (UX gap)
+
+---
+
+## 5. Testing Upgrades
+
+tuck's CI matrix (3 OS × 3 Node, `fail-fast: false`) already beats every peer, and its security suite (path traversal, ReDoS payloads, redaction, sandbox confinement) and `bitwarden-argv` test are genuinely strong. The gaps are concentrated and concrete:
+
+1. **Build an end-to-end binary harness (P0, M).** Build `dist/index.js` once, set `HOME` to a throwaway temp dir, run `init → add → sync → apply` round-trips, assert on-disk files + stdout. Verified: nothing spawns the binary today; the `parseAsync()` entry point is untested. This is the single biggest testing hole — bugs in flag parsing/command wiring ship behind memfs-mocked unit tests.
+
+2. **Adopt a txtar/testscript-equivalent golden harness (P0, L).** One self-contained script per command (`add`/`apply`/`sync`/`restore`/`status`) with embedded fixtures + golden stdout, plus one named script per fixed bug (chezmoi's `issueNNNN.txtar` convention). This makes human-readable output regressions catchable and enables the harness in (1).
+
+3. **De-mock the flagship workflow against real git (P1, M).** `full-workflow.test.ts` mocks `simple-git`, so it asserts mock call counts, not real commit/push/pull/rebase staging. Two suites (`mergeConflicts`, `provider-e2e`) already prove the `hasGit()`-gated real-git pattern; extend it to the main path.
+
+4. **Add an idempotency assertion (P1, S).** Run apply twice on every integration test; assert the second run reports zero changes. The strongest guarantee a dotfiles manager makes — currently unverified for the main restore path (and apply has no no-op short-circuit, so this test would also surface P2-3).
+
+5. **Recorded-argv tests for `op`/`pass`/GitLab (P1, S).** Mirror `bitwarden-argv.test.ts`: assert `--` precedes the user-controlled path for `op`/`pass`, and add a `GitLabProvider` argv test (only GitHub's `buildCreateRepoArgs()` is covered). A flag/injection regression is currently undetectable.
+
+6. **Run Linux CI twice under umask 022 and 002 (P1, S).** tuck chmods-after-write in apply/restore — a classic umask-order bug class that 022-only CI hides. chezmoi injects umask via ldflags; tuck can set `process.umask()` in setup or via a matrix env.
+
+7. **Tests for the newly-wired pipelines (gated on P0 work).** Once P0-1/P0-2 land: assert `{{os}}` substitution in an applied `template:true` file; assert a `TCKE1` repo file is decrypted on apply; add the end-to-end `apply → resolveFileSecrets → op/bw/pass → restoreContent` test using a mockcommand-style fake binary (yadm's `pinentry-mock` pattern).
+
+8. **Property/fuzz tests with fast-check (P2, M).** `expandPath`/`collapsePath` round-trips, repo-scoped pseudo-path parsing, and template render invariants. The two template nesting bugs already found by hand are exactly what fuzzing catches systematically.
+
+9. **Complete or remove the hand-rolled `fs-extra` mock (P2, S).** `tests/setup.ts` mocks only `copy`/`ensureDir`/`pathExists`; `ensureFile`/`move`/`outputFile`/`readJson` fall through to real `fs-extra`, so tests can silently hit real disk.
+
+10. **Ratchet coverage thresholds (P2, S).** 40% statements / 34% functions is too low to enforce subsystem coverage; raise gradually as the e2e harness lands. Optionally wire `pnpm bench` into a non-blocking CI job for perf-trend tracking.
+
+---
+
+## 6. "tuck Should Be MORE" — Differentiation Roadmap
+
+tuck's defensible wedge is **the agent-native, safety-first dotfiles manager**, not chezmoi-templating-parity. The play is to deepen the three moats that no reference tool can quickly copy, while fixing the two verified bugs that currently neuter them.
+
+**Wedge 1 — The AI-agent dotfiles manager (already built, under-marketed).** `context.ts` tracks CLAUDE.md/.cursorrules/AGENTS.md/GEMINI.md across repos with a 10-type classifier and Zod-validated remote manifests; `repoScope.ts` tracks configs *inside any git checkout* by stable key. Combined with the MCP server, this is a category of one.
+- Promote to headline positioning: "tracks configs anywhere, not just dotfiles in `~`."
+- Add `tuck context diff` and a shared-template registry so teams sync one canonical `AGENTS.md`/`CLAUDE.md` across all their repos.
+
+**Wedge 2 — The richest agent surface (MCP).** Today's 6 read tools can list/status/scan but cannot let an agent preview a diff, check drift, see untracked dotfiles, or dry-run an apply into the `--root` sandbox.
+- Surface diff/verify/scan_untracked/secrets-status/apply-plan (P0-3).
+- Expose the `--root` sandbox through the apply-plan tool so an agent can preview real changes with **zero risk to live HOME** — a concrete, demoable "agents physically cannot touch your home dir" claim.
+
+**Wedge 3 — Safety as a marketed guarantee.** Secret-scanning-by-default (`sync.ts`), the `--root` write-jail (`writeContext.ts`), and the atomic snapshot/undo (`timemachine.ts`) all exceed chezmoi and are verified — but under-advertised.
+- Market "cannot accidentally commit a secret" and "every apply is a transaction you can roll back."
+- Expose the secret scan as an MCP read tool so agents never propose committing a key.
+
+**Ambitious, none-of-the-seven-have-it features (after the moats are solid):**
+- **AI-assisted migration** (`tuck import --from <tool>`, LLM-guided): parse a chezmoi/stow/yadm source-state and *propose* the tuck manifest plus which files to encrypt/redact. Uses tuck's own MCP/AI DNA; turns the adoption blocker (P1-3) into a differentiator.
+- **App-settings catalog** (`tuck add --app vscode`): mackup is decaying on macOS 14+ and none of the seven cloned tools fill this. ~50 dev-app TOML mappings.
+- **`tuck watch`**: only dotter has it; cheap delight once templating-in-apply lands.
+- **Profiles** built on the existing bundle concept: dotdrop's top differentiator, mostly a layer over code tuck already has.
+
+**Explicitly do NOT chase first:** full Go-template/sprig parity, externals, declarative package bootstrap, a full-screen TUI — these are lower-leverage than deepening the agent + safety moats, and several (externals, bootstrap) are low-frequency needs.
+
+---
+
+## 7. Concrete Next Actions (Engineer Checklist)
+
+### P0 — start immediately (correctness + headline gap)
+- [ ] **Wire templating into apply.** In `src/commands/apply.ts`, for each manifest entry with `template === true`, run `renderTemplate(content, defaultTemplateContext(...))` before writing. Stop hardcoding `template:false` in `src/lib/fileTracking.ts`; add `--template` to `tuck add`. Pass `config.templates.variables` into the context.
+- [ ] **Decrypt-on-apply.** In apply's read path, detect the `TCKE1` header; fetch the passphrase from the keystore (`src/lib/crypto/keystore/*`); decrypt before write. Reuse the structure of the existing `resolveFileSecrets` hook.
+- [ ] **Add tests for both pipelines:** `{{os}}` substitution appears in the written file; a `TCKE1` repo file is decrypted on disk after apply.
+- [ ] **Widen MCP** (`src/commands/mcp.ts`): add `diff`, `verify(--exit-code)`, `scan_untracked`, secrets-status, and a sandboxed apply-plan tool; keep all writes behind `TUCK_MCP_ALLOW_WRITE`.
+- [ ] **Build the e2e binary harness:** spawn `dist/index.js` against a temp `HOME`, run `init→add→sync→apply`, assert files + stdout.
+
+### P1 — next (daily workflow + adoption + quick wins)
+- [ ] `tuck edit <file>` (open repo copy in `$EDITOR`, `--apply` on save, decrypt-to-0700-tempdir for encrypted).
+- [ ] `tuck re-add` (mass-sync edited live files via `stateModel` comparison).
+- [ ] `tuck merge <file>` (configurable `merge.command`, default vimdiff, with live/repo/computed-target).
+- [ ] `tuck import --from chezmoi` and `--from stow` with a shared `Migrator` interface, `--dry-run`, and write-only-missing semantics; route clone through the provider-neutral `remoteSetup` so non-GitHub sources work.
+- [ ] Banner `docs/migrations/*.md` as "design — not yet implemented" until the importer ships.
+- [ ] `tuck completion <bash|zsh|fish>` (generate static scripts).
+- [ ] Doctor env checks: git-version (semver-min), `$VISUAL`/`$EDITOR`, umask, symlink-probe, npm/GitHub latest-version (`--no-network`); add `replaceAll(homedir(), '~')` redaction over all messages.
+- [ ] Implement the dead `--keep-original` flag on `remove` (materialize repo content back to a regular file).
+- [ ] `tuck apply --profile <name>` built on bundles (subset + variable overrides); foreign-manager auto-detect hints in `scan`/`init`.
+- [ ] De-mock `full-workflow.test.ts` against real git (gated by `hasGit()`); add an apply-twice idempotency assertion; add `op`/`pass`/GitLab recorded-argv tests; run Linux CI under umask 022 *and* 002.
+- [ ] Move `config.json` to `$XDG_CONFIG_HOME/tuck/`; split per-machine vars into a never-tracked local file.
+- [ ] Call `ensureRuntimeArtifactsGitignored(tuckDir)` at the top of the sync commit path (and apply/import), not only at init.
+
+### P2 — declarative completeness + architecture
+- [ ] **Introduce the `System` interface** (Real/DryRun/ReadOnly) and route apply/restore/diff/verify through it (keystone for the next two items).
+- [ ] **Cache-diff safety:** in apply `--replace`, consult `stateModel` drift-local and warn-and-skip without `--force`.
+- [ ] **Persistent EntryState** under `getStateDir()` (content-hash keyspace for run-once, path keyspace for run-onchange); add apply already-up-to-date no-op.
+- [ ] Adopt a txtar/testscript golden harness; add property/fuzz tests (fast-check) for path resolution and templating; complete the `fs-extra` mock; ratchet coverage thresholds.
+- [ ] `.tuckexternal.toml` (remote files/archives/repos, SHA-256(url) cache, `refreshPeriod`, required checksum); exact-dir managed removal of untracked entries.
+- [ ] `tuck export`/`archive`; `tuck shell`/`cd` subshell; `tuck watch` (chokidar, exclude `.tuck/`+`.git/`).
+- [ ] `tuck purge` + optional `tuck destroy <file>` (typed-phrase confirm); fix `status` repo-scoped path resolution (use `resolveLiveTarget`) and add `--porcelain`; extend `diff` to the 3-way model.
+- [ ] Generalize hooks to all commands; execute preset `postApply`; set hook cwd to the hook's own dir and propagate its exit code.
+- [ ] `Encryption` interface with `AgeEncryption` + `GpgEncryption` for ecosystem interop; broaden PM backends (rbw/keepassxc/vault) opportunistically.
+- [ ] App-settings catalog (`src/lib/apps/*.toml` + `tuck add --app`); `[packages]` block + `tuck bootstrap` (Brewfile-first).
+- [ ] Publish a GitHub Action wrapping `tuck verify --exit-code --json` to advertise native CI drift detection.

--- a/docs/TEMPLATES-AND-ENCRYPTION.md
+++ b/docs/TEMPLATES-AND-ENCRYPTION.md
@@ -1,0 +1,77 @@
+# Templates & Encryption
+
+tuck can store a file as a **template** (rendered per-machine on apply) or **encrypted**
+(ciphertext at rest in the repo, decrypted on apply). Both are wired through one shared
+`materialize` step — see `docs/superpowers/specs/2026-06-03-templating-and-decrypt-on-apply-design.md`.
+
+## The mental model (important)
+
+For a normal tracked file, the repo copy and the live file are kept **in sync both ways**
+(`tuck sync` copies live → repo; `tuck apply`/`tuck restore` copy repo → live).
+
+For a **template or encrypted** file this is different and **one-directional**:
+
+- the **repo** holds the *source* — the `{{ }}` template text, or the ciphertext;
+- the **live** file is a *derived artifact* — the rendered text, or the decrypted plaintext.
+
+Because the two intentionally differ, **`tuck sync` never captures a template/encrypted file
+back into the repo** (doing so would overwrite your template with machine-specific output, or
+write your plaintext secret into the repo). To change one of these files, **edit the repo
+source and run `tuck apply`** (a `tuck edit` helper is planned). `tuck status`/`tuck verify`
+still report real drift for them — a stale live file shows up, with the remedy being `tuck apply`.
+
+## Templates
+
+```bash
+tuck add --template ~/.gitconfig    # store the {{ }} source; render on apply
+tuck apply                          # writes the rendered file to ~/.gitconfig
+```
+
+### Syntax
+
+```
+{{os}}                              # variable substitution
+{{email | default "me@example.com"}}# fallback when missing/empty
+{{#if os == "darwin"}}...{{else}}...{{/if}}   # inline conditional (nests correctly)
+
+# tuck:if os == "linux"             # whole-line / comment-marker style for files
+alias open=xdg-open                 #   that can't carry {{ }} inline
+# tuck:endif
+```
+
+### Variables
+
+Built-ins are always available: `os`, `arch`, `hostname`, `user`, `home`, `ci`, and any
+`env.NAME` (read from the environment at render time). Add your own machine-specific values
+under `templates.variables` in `.tuckrc.json`:
+
+```json
+{ "templates": { "variables": { "email": "me@work.com", "profile": "work" } } }
+```
+
+A dedicated `.tuckdata` file for richer per-machine data is planned.
+
+## Encryption
+
+Whole-file encryption uses **AES-256-GCM** (PBKDF2, the `TCKE1` format) with a single
+encryption password stored in your OS keystore (Keychain / libsecret / encrypted fallback):
+
+```bash
+tuck encryption setup               # set the encryption password (once per machine)
+tuck add --encrypt ~/.netrc         # store TCKE1 ciphertext in the repo
+tuck apply                          # decrypts ~/.netrc back into place
+```
+
+If no password is configured, `tuck add --encrypt` fails with a clear message rather than
+committing plaintext. A file can be **both** encrypted and a template — apply decrypts first,
+then renders.
+
+## Limitations
+
+- Template/encrypted files are **copy-only** — they cannot use the symlink strategy (a symlink
+  would expose the raw source/ciphertext at the live path). `--encrypt`/`--template` with the
+  symlink strategy is rejected.
+- The transform is **text-oriented** (dotfiles are text). Track binary files without
+  `--encrypt`/`--template`.
+- If a decryption fails (wrong/absent password, corrupt ciphertext), that one file is **skipped
+  loudly** during apply/restore — tuck never writes ciphertext or partial output to your system.

--- a/docs/superpowers/plans/2026-06-03-p0-3-widen-mcp.md
+++ b/docs/superpowers/plans/2026-06-03-p0-3-widen-mcp.md
@@ -1,0 +1,505 @@
+# P0-3 — Widen & Harden the tuck MCP Server: TDD Implementation Plan
+
+## 0. Pre-flight findings (what already exists vs. what the audit claims)
+
+I read `src/commands/mcp.ts` and `tests/commands/mcp.test.ts` in full. **The current branch has already landed almost every protocol-correctness item the audit lists.** Verify before you "fix" — re-deriving these from the audit text would duplicate work and risk regressions. Concretely, in `src/commands/mcp.ts` today:
+
+| Audit "MCP protocol gap" | Status on this branch | Anchor |
+|---|---|---|
+| `serverInfo.version` hardcoded `1.0.0` | **DONE** — sourced from `VERSION` | `mcp.ts:26`, `mcp.ts:220` |
+| gate `tools/call` on `initialize` | **DONE** | `mcp.ts:245`; also `tools/list` gated `mcp.ts:231` |
+| handler throw → MCP `{isError:true}` not `-32603` | **DONE** | `toolError` `mcp.ts:181-185`, `mcp.ts:269-271` |
+| validate `params.arguments` vs `inputSchema` | **DONE (shallow)** | `validateArgs` `mcp.ts:188-199`, `mcp.ts:253` |
+| serialize/await request handling, in-order responses | **DONE** | `chain` promise `mcp.ts:284`, `mcp.ts:287-303` |
+| stdin max-line guard | **DONE** | `MAX_LINE_BYTES` `mcp.ts:30`, `mcp.ts:290-293` |
+| writes gated behind `TUCK_MCP_ALLOW_WRITE` | **DONE** | `WRITE_TOOLS` `mcp.ts:33`, `writesAllowed` `mcp.ts:35-36`, `mcp.ts:255-260` |
+
+`tests/commands/mcp.test.ts` already asserts every one of these (version `:40`, gate-before-init `:46`/`:116`, isError-on-throw `:160`, arg validation `:64`, write-gate `:90`/`:181`/`:205`, ping `:106`, notification `:111`, id-preservation `:154`). **All 16 tests are green on this branch.**
+
+**Therefore P0-3 splits into two streams:**
+
+- **Stream A (the real work): WIDEN.** Add 5 tools — `diff`, `verify`, `scan_untracked`, `secrets_status`, `apply_plan` (the dry-run). This is where the audit value (`row 90`, `192-198`, `216`) actually lands.
+- **Stream B (HARDEN — close the *residual* gaps the current code still has, not the ones already fixed).** I found four genuine residual gaps below. Do not re-fix the seven items in the table.
+
+### The single load-bearing design constraint (governs every new tool)
+
+The existing tools (`mcp.ts:68`, `:86`, `:106`) call **library functions** (`getAllTrackedFiles`, `getStatus`, `detectDotfiles`) and return plain objects. They deliberately **never** call the `runVerify`/`runDiff`/`runScan`/`runSecretsList` command wrappers. That is mandatory, because those wrappers:
+
+- call `setJsonMode(true,...)` + `emitJsonOk(...)`, which does `process.stdout.write(JSON.stringify(env)+'\n')` (`jsonOutput.ts:87`) — this would inject a second JSON document into the **same stdout stream** the JSON-RPC framer (`respond`, `mcp.ts:165`) owns, corrupting every host parser; and
+- call `process.exit(1)` / set `process.exitCode` on drift (`verify.ts:399`, `diff.ts:367`), killing the long-running server.
+
+So each new tool MUST reuse the **pure/extractable core**, never the `run*`. Inventory of what is reusable today:
+
+- `computeStateModel(tuckDir)` → `FileStateEntry[]`, `summarizeStateModel(entries)` → `StateSummary`, `hasDrift(summary)` — all **exported** (`stateModel.ts:170`, `:192`; `verify.ts:91`). The branch comment confirms these are materialize-aware (`stateModel.ts:139-163`), so a verify tool reports **real** template/encrypt drift. ✅ directly usable.
+- `dryApplyIntoSandbox(tuckDir, bundle)` → `DryApplyResult` — **module-private** in `verify.ts:136`. Must be **exported** to back `apply_plan`. The sandbox plumbing (`snapshotWriteContext`/`setWriteContext({root,isSandbox:true})`/`restoreWriteContext`, `verify.ts:266-267`,`:313`) must be replicated in the tool, not the CLI's temp-dir cleanup logic.
+- `scanForSecrets(filepaths, tuckDir)` → `ScanSummary` (`secrets/index.ts:110`), `FileScanResult`/`SecretMatch` carry `redactedValue` (`scanner.ts:38`,`:48`). The raw `value` field (`scanner.ts:37`) MUST be stripped before returning.
+- `detectDotfiles()` (`detect.ts:888`) + `buildSourceIndex(tuckDir)` (used in `scan.ts:272`) → the "untracked" set is `detected − tracked`, mirroring `scan.ts:278-296`. This logic is **inline in `runScan`** and must be extracted to a pure helper.
+- `getFileDiff(tuckDir, source)` → `FileDiff` — **module-private** in `diff.ts:48`. Reuse it; do not reach for git or `runDiff`.
+
+---
+
+## Stream B — HARDEN (residual gaps only)
+
+### B1. `tools/list` must not advertise write tools the host can never call, and write tools should be discoverable as such
+
+**Gap:** `tools/list` (`mcp.ts:230-242`) advertises `context_add` unconditionally, but a host with no `TUCK_MCP_ALLOW_WRITE` will always get an `isError` from `tools/call` (`mcp.ts:255`). A well-behaved agent that lists-then-calls gets a confusing failure. Two acceptable designs — pick **annotate**, not hide (hiding breaks the existing `:122` test that asserts `context_add` is listed, and chezmoi-parity wants the agent to *know* the tool exists but is gated).
+
+**Files touched:** `src/commands/mcp.ts`, `tests/commands/mcp.test.ts`.
+
+**Failing test first** (`tests/commands/mcp.test.ts`, append to the `mcp dispatch` describe):
+```ts
+it('annotates write tools in tools/list with a writeGated flag and readOnlyHint', async () => {
+  await init();
+  const resp = await dispatch({ jsonrpc: '2.0', id: 20, method: 'tools/list' }, state);
+  const tools = (resp as { result: { tools: Array<{ name: string; annotations?: { readOnlyHint?: boolean }; writeGated?: boolean }> } }).result.tools;
+  const ctxAdd = tools.find((t) => t.name === 'context_add')!;
+  const verify = tools.find((t) => t.name === 'verify')!;
+  expect(ctxAdd.writeGated).toBe(true);
+  expect(ctxAdd.annotations?.readOnlyHint).toBe(false);
+  expect(verify.writeGated).toBeFalsy();
+  expect(verify.annotations?.readOnlyHint).toBe(true);
+});
+```
+
+**Minimal implementation** (`mcp.ts:236-242`): in the `tools/list` `.map`, add `writeGated: WRITE_TOOLS.has(t.name)` and `annotations: { readOnlyHint: !WRITE_TOOLS.has(t.name) }`. `readOnlyHint` is a real MCP tool-annotation field, so SDK-driven hosts honor it.
+
+**Assert:** `pnpm vitest run tests/commands/mcp.test.ts`
+
+**Commit:** `feat(mcp): annotate write-gated tools with readOnlyHint in tools/list`
+
+---
+
+### B2. `validateArgs` is too shallow — it ignores **unknown / extra** args and never type-checks **non-required** typed properties
+
+**Gap:** `validateArgs` (`mcp.ts:188-199`) only iterates `required`. For the new tools, `apply_plan`/`diff`/`verify` take **optional** typed params (`bundle: string`, `exitCode: boolean`, `paths: string[]`). A host sending `bundle: 42` or `exitCode: "yes"` would pass validation and reach the handler with a wrong-typed value. The audit row says "validate params.arguments against each tool inputSchema" — current code validates only the required subset. This is a genuine residual gap once optional-typed tools exist.
+
+**Files touched:** `src/commands/mcp.ts`, `tests/commands/mcp.test.ts`.
+
+**Failing test first:**
+```ts
+it('rejects a wrong-typed OPTIONAL argument as an isError tool result', async () => {
+  await init();
+  const resp = await dispatch(
+    { jsonrpc: '2.0', id: 21, method: 'tools/call',
+      params: { name: 'apply_plan', arguments: { bundle: 42 } } },
+    state
+  );
+  const r = (resp as { result: { isError: boolean; content: { text: string }[] } }).result;
+  expect(r.isError).toBe(true);
+  expect(r.content[0].text).toMatch(/bundle.*string/i);
+});
+```
+(`apply_plan` is read-only/dry-run, see A5, so it is callable without the write gate — making this assertion clean.)
+
+**Minimal implementation** (`mcp.ts:188-199`): extend `validateArgs` to also walk every key present in `args`: if the key has a declared property with a `type`, enforce it (`string`/`boolean`/`number`/`array` via `typeof`/`Array.isArray`); keep rejecting missing-required. Do **not** reject unknown keys (forward-compat — hosts may send extra metadata); the audit asks for validation against the schema's declared types, not strict-mode rejection. Add `'boolean'` and `'array'` branches alongside the existing `'string'` branch.
+
+**Assert:** `pnpm vitest run tests/commands/mcp.test.ts`
+
+**Commit:** `fix(mcp): type-check optional tool arguments, not just required ones`
+
+---
+
+### B3. `initialize` should echo the client's `protocolVersion` and reject a double-initialize cleanly
+
+**Gap:** `initialize` (`mcp.ts:212-222`) hardcodes `protocolVersion: '2024-11-05'` and ignores `params.protocolVersion` the client sends. Per spec the server should respond with a version it supports (ideally the client's if compatible). Also, a second `initialize` silently re-sets `state.initialized = true` — harmless but a host sending duplicate inits gets no signal. **Low priority; include only if cheap.** Keep conservative: continue to advertise our supported version, but if the client's requested version string is present and equal, echo it; otherwise return ours. Do NOT attempt version negotiation logic beyond an exact-match echo — that needs the real SDK (flagged in §3).
+
+**Failing test:**
+```ts
+it('echoes a recognised client protocolVersion on initialize', async () => {
+  const resp = await dispatch(
+    { jsonrpc: '2.0', id: 22, method: 'initialize', params: { protocolVersion: '2024-11-05' } },
+    state
+  );
+  expect((resp as { result: { protocolVersion: string } }).result.protocolVersion).toBe('2024-11-05');
+});
+```
+
+**Implementation** (`mcp.ts:212-222`): read `(req.params as {protocolVersion?:string})?.protocolVersion`; set the response field to the client's value iff it is in a `SUPPORTED_PROTOCOL_VERSIONS` set (currently just `'2024-11-05'`), else our default. This is the only safe behavior without the SDK's negotiation.
+
+**Commit:** `fix(mcp): echo supported client protocolVersion on initialize`
+
+---
+
+### B4. Backpressure / `respond` write-result is ignored under the serialized chain
+
+**Gap:** `respond` (`mcp.ts:164-166`) ignores the boolean `process.stdout.write` returns. Because handling is serialized via `chain` (`mcp.ts:287`), a slow consumer can let the kernel buffer grow unbounded; combined with the MAX_LINE *input* guard there is no symmetric *output* guard. This is a robustness nit, not a correctness bug. **Recommendation: document-and-defer, or add a tiny drain.** If included: make `respond` await a `'drain'` event when `write` returns `false`, threaded through the `chain` so ordering is preserved. This is hard to unit-test deterministically without a fake stdout; I recommend a focused test using a mock writable.
+
+**Failing test (harness = injectable writer, see §2):**
+```ts
+it('awaits drain before continuing when stdout signals backpressure', async () => {
+  // see §2 "in-process loop harness": feed two requests, stub write to return false once
+});
+```
+
+**Verdict:** **Defer B4** unless time allows; flag in the PR description. It does not block the audit's value. If you do it, gate it behind the loop refactor in §2 so it is testable.
+
+---
+
+## Stream A — WIDEN (the five new tools)
+
+### Shared refactor prerequisite (do this first, one commit)
+
+Three cores are currently command-private and must be **exported** so MCP can reuse them without the stdout-polluting `run*` wrappers:
+
+1. **`verify.ts:136` `dryApplyIntoSandbox`** → add `export`. Signature unchanged: `(tuckDir: string, bundle?: string) => Promise<DryApplyResult>`. `DryApplyResult`/`DryApplyChange`/`DryApplyConflict` are already exported (`verify.ts:68`,`:78`,`:83`).
+2. **`diff.ts:48` `getFileDiff`** → add `export` (or export a thin `collectChangedDiffs(tuckDir, paths?, category?)` that reproduces the loop at `diff.ts:305-348` minus the logger/`emitJsonOk`). Prefer the latter so the tool gets the same filtering (`.tuckignore` `:330`, category `:325`) the CLI gives, returning `FileDiff[]`. Export `FileDiff` (currently the `interface` at `diff.ts:28` is unexported).
+3. **`scan.ts` untracked computation** → extract the inline loop (`scan.ts:272-296`) into `export const collectUntrackedDotfiles = async (tuckDir: string, category?: string): Promise<SelectableFile[]>` returning only `alreadyTracked===false` entries; `runScan` then calls it. Export the minimal shape.
+
+**Failing tests first** (`tests/commands/verify.test.ts`, `tests/commands/diff.test.ts`, `tests/commands/scan.test.ts` — likely already exist): add one "the extracted helper is exported and returns the documented shape against a temp repo" test per extraction, using the existing tmpdir fixtures (the integration tests at `tests/integration/full-workflow.test.ts` already `mkdtemp` a real tuck repo — reuse that scaffolding, e.g. a `makeTempTuckRepo()` helper).
+
+Example (verify):
+```ts
+import { dryApplyIntoSandbox } from '../../src/commands/verify.js';
+it('dryApplyIntoSandbox returns changes/conflicts/wouldEscapeRoot for a temp repo', async () => {
+  const { tuckDir } = await makeTempTuckRepo({ tracked: ['~/.zshrc'] });
+  setWriteContext({ root: await mkdtemp(...), isSandbox: true });
+  const res = await dryApplyIntoSandbox(tuckDir);
+  expect(res).toMatchObject({ changes: expect.any(Array), conflicts: expect.any(Array), wouldEscapeRoot: expect.any(Array) });
+});
+```
+
+**Assert:** `pnpm vitest run tests/commands/verify.test.ts tests/commands/diff.test.ts tests/commands/scan.test.ts`
+
+**Commit:** `refactor: export dry-apply, file-diff, and untracked-scan cores for MCP reuse`
+
+---
+
+### A1. `verify` tool — drift report with exit-code semantics
+
+**Files:** `src/commands/mcp.ts` (new entry in `tools[]` after `mcp.ts:117`), `tests/commands/mcp.test.ts`.
+
+**Tool def:**
+```ts
+{
+  name: 'verify',
+  description: 'Verify that the live system, the repo, and the manifest agree. '
+    + 'Reports per-file drift state and a summary. drift=true mirrors `verify --exit-code` (CI gate).',
+  inputSchema: { type: 'object', properties: {} },
+  handler: async () => {
+    const tuckDir = getTuckDir();
+    await loadManifest(tuckDir);                  // throws → caught → isError (no NotInitializedError swallow needed)
+    const entries = await computeStateModel(tuckDir);
+    const summary = summarizeStateModel(entries);
+    return {
+      summary,
+      drift: hasDrift(summary),                   // exit-code semantics, as a boolean field — NOT process.exit
+      files: entries.map((e) => ({ source: e.source, state: e.state })),
+    };
+  },
+}
+```
+Add imports: `computeStateModel, summarizeStateModel` from `../lib/stateModel.js` and `hasDrift` from `./verify.js`. **Do not** import `runVerify`. The `--exit-code` CLI semantic becomes the `drift` boolean — an agent reads it; the server never exits.
+
+**Failing test first:**
+```ts
+it('verify tool reports a summary and a drift boolean (no process exit)', async () => {
+  await init();
+  // mock computeStateModel/summarizeStateModel via vi.mock on stateModel.js (see §2 mock list)
+  const resp = await dispatch(
+    { jsonrpc: '2.0', id: 30, method: 'tools/call', params: { name: 'verify', arguments: {} } },
+    state
+  );
+  const r = (resp as { result: { isError: boolean; content: { text: string }[] } }).result;
+  expect(r.isError).toBe(false);
+  const payload = JSON.parse(r.content[0].text);
+  expect(payload).toHaveProperty('drift');
+  expect(payload.summary).toHaveProperty('total');
+});
+```
+Mock `computeStateModel` to return one `drift-local` entry and assert `payload.drift === true`.
+
+**Assert:** `pnpm vitest run tests/commands/mcp.test.ts`
+**Commit:** `feat(mcp): add read-only verify tool with drift (exit-code) semantics`
+
+---
+
+### A2. `diff` tool — changed-file preview
+
+**Tool def:** inputSchema `{ paths?: string[], category?: string }` (both optional). Handler calls the extracted `collectChangedDiffs(tuckDir, args.paths, args.category)` and returns `{ count, files: [{source, destination, isBinary, isDirectory, systemSize, repoSize}] }` — **omit `systemContent`/`repoContent`** by default (mirror the CLI's "keep the envelope small" choice at `diff.ts:362-364`; large file bodies bloat the agent context and risk leaking secret-bearing lines). Optionally accept `includeContent?: boolean` later, but **not** in P0-3.
+
+**Failing test:** init → mock `collectChangedDiffs` to return one changed `FileDiff` → assert `JSON.parse(content).count === 1` and that no `systemContent` key is present. Add a negative: `params.arguments.paths = "x"` (string not array) → `isError` (exercises B2's array check).
+
+**Commit:** `feat(mcp): add read-only diff tool (metadata only, content elided)`
+
+---
+
+### A3. `scan_untracked` tool — dotfiles present but not tracked
+
+**Why a new tool vs widening `scan`:** existing `scan` (`mcp.ts:103-116`) returns **all** detected files via `detectDotfiles()` and does not know what is tracked. The audit (`row 90`, `:192`) specifically wants *untracked* — the actionable delta. Keep `scan` as-is; add `scan_untracked`.
+
+**Tool def:** inputSchema `{ category?: string }`. Handler: `await loadManifest(tuckDir)` then `collectUntrackedDotfiles(tuckDir, args.category)`; return `{ count, files: [{ path, category, sensitive }] }` (same projection as `mcp.ts:110-114`). The `sensitive` flag (`detect.ts` `DetectedFile`) tells the agent which to redact before any add.
+
+**Failing test:** mock `detectDotfiles` → 2 files; mock `buildSourceIndex` → a Map marking one as tracked; assert returned `count === 1` and it is the untracked one. (Or test the extracted `collectUntrackedDotfiles` directly in `scan.test.ts` and only smoke-test wiring in `mcp.test.ts`.)
+
+**Commit:** `feat(mcp): add scan_untracked tool (detected minus tracked)`
+
+---
+
+### A4. `secrets_status` tool — REDACTED secret scan over tracked files
+
+**This is the highest-value safety tool** (`audit :198`: "agents never propose committing a key"). 
+
+**Critical redaction rule:** `scanForSecrets` returns `ScanSummary.results[].matches[]` where each `SecretMatch` has BOTH `value` (raw secret, `scanner.ts:37`) and `redactedValue` (`scanner.ts:38`). The handler MUST map to a projection that **never** includes `value`, `context` (`scanner.ts:41`, may contain the secret), or `placeholder`. Return only `{ patternId, patternName, severity, line, column, redactedValue }` plus per-file counts.
+
+**Tool def:**
+```ts
+{
+  name: 'secrets_status',
+  description: 'Scan tracked files for likely secrets (values REDACTED). Use before sync/commit to avoid leaking keys.',
+  inputSchema: { type: 'object', properties: {} },
+  handler: async () => {
+    const tuckDir = getTuckDir();
+    await loadManifest(tuckDir);
+    const files = await getAllTrackedFiles(tuckDir);
+    const paths = Object.values(files).map((f) => expandPath(f.source));   // live copies
+    const summary = await scanForSecrets(paths, tuckDir);
+    return {
+      filesWithSecrets: summary.filesWithSecrets,
+      totalSecrets: summary.totalSecrets,
+      bySeverity: summary.bySeverity,
+      files: summary.results
+        .filter((r) => r.hasSecrets)
+        .map((r) => ({
+          path: r.collapsedPath,
+          counts: { critical: r.criticalCount, high: r.highCount, medium: r.mediumCount, low: r.lowCount },
+          matches: r.matches.map((m) => ({
+            patternId: m.patternId, patternName: m.patternName, severity: m.severity,
+            line: m.line, column: m.column, redactedValue: m.redactedValue,   // NO raw value/context/placeholder
+          })),
+        })),
+    };
+  },
+}
+```
+Imports: `scanForSecrets` from `../lib/secrets/index.js`, `expandPath` from `../lib/paths.js`, `getAllTrackedFiles` (already imported `mcp.ts:18`).
+
+**Failing test first — assert redaction is airtight:**
+```ts
+it('secrets_status NEVER returns raw secret values or context', async () => {
+  await init();
+  scanForSecretsMock.mockResolvedValueOnce({
+    filesWithSecrets: 1, totalSecrets: 1, bySeverity: { critical: 1, high: 0, medium: 0, low: 0 },
+    results: [{ collapsedPath: '~/.env', hasSecrets: true, criticalCount: 1, highCount: 0, mediumCount: 0, lowCount: 0, skipped: false,
+      matches: [{ patternId: 'aws', patternName: 'AWS Key', severity: 'critical',
+        value: 'AKIAIOSFODNN7EXAMPLE', redactedValue: '[REDACTED]', context: 'key=AKIAIOSFODNN7EXAMPLE', line: 3, column: 5, placeholder: '{{AWS}}' }] }],
+  });
+  const resp = await dispatch({ jsonrpc:'2.0', id:40, method:'tools/call', params:{ name:'secrets_status', arguments:{} } }, state);
+  const text = (resp as { result: { content: { text: string }[] } }).result.content[0].text;
+  expect(text).not.toContain('AKIAIOSFODNN7EXAMPLE');   // raw value
+  expect(text).not.toContain('{{AWS}}');                // placeholder
+  expect(text).toContain('[REDACTED]');
+  const payload = JSON.parse(text);
+  expect(payload.files[0].matches[0]).not.toHaveProperty('value');
+  expect(payload.files[0].matches[0]).not.toHaveProperty('context');
+});
+```
+Add `scanForSecretsMock` to the mock block (see §2). This negative-assertion test is the gate — it must exist before the handler.
+
+**Commit:** `feat(mcp): add secrets_status tool (REDACTED-only secret scan)`
+
+---
+
+### A5. `apply_plan` tool — sandboxed dry-run apply (read-only output, write-confined)
+
+**This is the most delicate tool.** It is a **dry-run** (audit calls it "apply-plan/dry-run"). It writes only into a throwaway sandbox via the existing `--root` write-confinement (`writeContext.ts`, `resolveWriteTarget`), reads the real home for comparison, returns the plan, and cleans up. Because it touches **no real file**, it is **read-only from the host's perspective** and should be callable **without** `TUCK_MCP_ALLOW_WRITE` — same posture as `verify --apply` (which the CLI does not gate). Document this explicitly in the tool description so an auditor sees the reasoning. (If you prefer maximum conservatism, gate it; but then an agent can never preview before asking for write — defeating the audit's "dry-run an apply" goal. **Recommendation: ungated, with the sandbox guarantee asserted by test.**)
+
+**Tool def:**
+```ts
+{
+  name: 'apply_plan',
+  description: 'Dry-run `tuck apply` into an isolated sandbox and report created/modified/unchanged files, '
+    + 'smart-merge conflicts, and any entry that would escape the sandbox. Writes NOTHING to the real system.',
+  inputSchema: { type: 'object', properties: { bundle: { type: 'string', description: 'Limit the plan to one bundle' } } },
+  handler: async (args) => {
+    const tuckDir = getTuckDir();
+    await loadManifest(tuckDir);
+    const { mkdtemp, rm } = await import('fs/promises');
+    const { tmpdir } = await import('os');
+    const sandboxRoot = await mkdtemp(join(tmpdir(), 'tuck-mcp-apply-'));
+    const prev = snapshotWriteContext();
+    setWriteContext({ root: sandboxRoot, isSandbox: true });
+    try {
+      const res = await dryApplyIntoSandbox(tuckDir, args.bundle ? String(args.bundle) : undefined);
+      return {
+        // Do NOT leak the sandbox tmp path (machine-specific noise); summarize.
+        summary: {
+          created: res.changes.filter((c) => c.status === 'created').length,
+          modified: res.changes.filter((c) => c.status === 'modified').length,
+          unchanged: res.changes.filter((c) => c.status === 'unchanged').length,
+          conflicts: res.conflicts.length,
+          wouldEscapeRoot: res.wouldEscapeRoot.length,
+        },
+        changes: res.changes.map((c) => ({ target: collapsePath(c.target), status: c.status, bytesBefore: c.bytesBefore, bytesAfter: c.bytesAfter })),
+        conflicts: res.conflicts.map((c) => ({ target: c.target, type: c.type, name: c.name })),
+        wouldEscapeRoot: res.wouldEscapeRoot,
+      };
+    } finally {
+      restoreWriteContext(prev);                          // restore prior boundary (long-running server!)
+      await rm(sandboxRoot, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+}
+```
+Imports: `dryApplyIntoSandbox` from `./verify.js` (newly exported), `snapshotWriteContext, setWriteContext, restoreWriteContext` from `../lib/writeContext.js`, `collapsePath` from `../lib/paths.js`, `join` from `path`. **Critical:** mirror `verify.ts:266-267` and `:313` exactly — `snapshot` *before* `setWriteContext`, `restore` in `finally`. A blind `resetWriteContext()` would drop a global `--root` boundary across the persistent server (the comment at `verify.ts:264-265` flags this precise hazard).
+
+**Why not just call `runVerifyApply`:** it calls `setJsonMode`+`emitJsonOk` (`verify.ts:241`,`:273`) → stdout corruption — the §0 constraint. Replicate the sandbox lifecycle in the handler instead.
+
+**Failing tests first (two):**
+
+1. *Returns a plan, gated-OR-ungated as designed:*
+```ts
+it('apply_plan returns a created/modified/unchanged summary without the write gate', async () => {
+  await init();                                  // TUCK_MCP_ALLOW_WRITE unset (beforeEach deletes it)
+  dryApplyMock.mockResolvedValueOnce({ changes: [{ target: '/sandbox/.zshrc', status: 'created', bytesBefore: 0, bytesAfter: 10 }], conflicts: [], wouldEscapeRoot: [] });
+  const resp = await dispatch({ jsonrpc:'2.0', id:50, method:'tools/call', params:{ name:'apply_plan', arguments:{} } }, state);
+  const r = (resp as { result: { isError: boolean; content: { text: string }[] } }).result;
+  expect(r.isError).toBe(false);
+  expect(JSON.parse(r.content[0].text).summary.created).toBe(1);
+});
+```
+
+2. *Write-context is restored even when the dry-apply throws (no leaked sandbox boundary):*
+```ts
+it('apply_plan restores the prior write context after a handler failure', async () => {
+  await init();
+  const before = snapshotWriteContext();
+  dryApplyMock.mockRejectedValueOnce(new Error('prepare blew up'));
+  const resp = await dispatch({ jsonrpc:'2.0', id:51, method:'tools/call', params:{ name:'apply_plan', arguments:{} } }, state);
+  expect((resp as { result: { isError: boolean } }).result.isError).toBe(true);     // surfaced as tool error
+  expect(snapshotWriteContext()).toEqual(before);                                    // boundary intact
+});
+```
+This second test is the safety lock for the long-running-server hazard. Mock `dryApplyIntoSandbox` (`dryApplyMock`) via `vi.mock('../../src/commands/verify.js', …)` keeping `hasDrift` actual (see §2).
+
+**Assert:** `pnpm vitest run tests/commands/mcp.test.ts`
+**Commit:** `feat(mcp): add sandboxed apply_plan dry-run tool (write-confined, no real writes)`
+
+---
+
+### A6. Update the tool-surface assertion + `WRITE_TOOLS`
+
+The existing test at `tests/commands/mcp.test.ts:130-139` asserts the exact known surface with `arrayContaining`. Extend that array to include `'verify'`, `'diff'`, `'scan_untracked'`, `'secrets_status'`, `'apply_plan'`. **None of the five new tools are added to `WRITE_TOOLS`** (`mcp.ts:33`) — all are read-only (apply_plan is dry-run). Verify `WRITE_TOOLS` stays `{ 'context_add' }`.
+
+**Failing test:** extend the `:130` `arrayContaining`; add `expect(names).not.toContain(...)` is unnecessary, but add an explicit `it('keeps apply_plan OUT of the write gate', …)` asserting `apply_plan` succeeds with the env var unset (covered by A5 test 1).
+
+**Commit:** `test(mcp): assert the widened 11-tool surface and read-only posture`
+
+---
+
+## 2. The test harness — exact shape
+
+The current suite tests the **pure `dispatch`** directly (`mcp.test.ts:13`, `:37`), never the stdio loop. **Keep that as the primary harness for all Stream A/B tool tests** — it is deterministic, no child process, no real stdin. Every test above plugs into the existing pattern: `state = createServerState()` in `beforeEach` (`:28`), `await init()` (`:37`), then `await dispatch({jsonrpc:'2.0', id, method:'tools/call', params:{name, arguments}}, state)`.
+
+**Mock block to extend** (`mcp.test.ts:19-25`). Add, alongside the existing `addContextFileMock`:
+```ts
+const computeStateModelMock = vi.hoisted(() => vi.fn());
+const dryApplyMock = vi.hoisted(() => vi.fn());
+const scanForSecretsMock = vi.hoisted(() => vi.fn());
+const detectDotfilesMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/lib/stateModel.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/stateModel.js')>('../../src/lib/stateModel.js');
+  return { ...actual, computeStateModel: computeStateModelMock };   // keep summarizeStateModel/classifyFileState real
+});
+vi.mock('../../src/commands/verify.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/commands/verify.js')>('../../src/commands/verify.js');
+  return { ...actual, dryApplyIntoSandbox: dryApplyMock };          // keep hasDrift real
+});
+vi.mock('../../src/lib/secrets/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/secrets/index.js')>('../../src/lib/secrets/index.js');
+  return { ...actual, scanForSecrets: scanForSecretsMock };
+});
+vi.mock('../../src/lib/detect.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/detect.js')>('../../src/lib/detect.js');
+  return { ...actual, detectDotfiles: detectDotfilesMock };
+});
+```
+Reset all four in `beforeEach` (next to `addContextFileMock.mockReset()` at `:31`). This mocks at the **library boundary**, so the tool handlers run their real projection/redaction logic (the part we must verify) over controlled inputs — exactly what the secrets-redaction test (A4) needs.
+
+**Loop-level harness (only for B2-array/B4-drain and one in-order integration test).** The current loop (`mcp.ts:286-303`) reads `process.stdin` and calls `process.exit(0)` on close — not unit-testable as-is. To test ordering/drain/max-line *through the loop*, do the minimal refactor: extract the loop body into
+
+```ts
+export const createDispatchLoop = (
+  input: NodeJS.ReadableStream,
+  write: (line: string) => boolean,    // injectable; defaults to process.stdout.write in runServe
+  state = createServerState(),
+): { done: Promise<void> } => { /* the rl + chain logic from mcp.ts:281-304, calling write() instead of respond() */ };
+```
+`runServe` becomes a one-liner wrapping `createDispatchLoop(process.stdin, (l)=>process.stdout.write(l), …)` and wiring `close→exit`. Then the harness feeds a `stream.PassThrough`, pushes JSON lines, and a `write` spy collects ordered output:
+```ts
+it('emits responses in request order under the serialized chain', async () => {
+  const input = new PassThrough();
+  const out: string[] = [];
+  const { done } = createDispatchLoop(input, (l) => { out.push(l); return true; });
+  input.write(JSON.stringify({ jsonrpc:'2.0', id:1, method:'initialize' }) + '\n');
+  input.write(JSON.stringify({ jsonrpc:'2.0', id:2, method:'ping' }) + '\n');
+  input.end(); await done;
+  expect(out.map((l) => JSON.parse(l).id)).toEqual([1, 2]);
+});
+```
+And the max-line guard through the loop:
+```ts
+it('rejects an over-limit stdin line with -32600 and keeps serving', async () => {
+  /* push a >1 MiB line, then a valid ping; assert first → error -32600, second → ok */
+});
+```
+This refactor is **optional for Stream A** (pure `dispatch` covers tools). Do it only to land B2's loop-path/B4, and ship it as its own commit: `refactor(mcp): extract injectable createDispatchLoop for loop-level tests`.
+
+**No child-process spawning is needed or recommended.** The repo's only process-spawning tests mock `child_process` (`tests/lib/git-errors.test.ts:48`); there is no existing pattern for spawning the built CLI under vitest, and doing so for MCP would be slow and flaky. Pure-`dispatch` + injectable-loop is the right call. (One end-to-end smoke — spawn `node dist/index.js mcp serve`, write an `initialize` line, read one response — could live as a single guarded integration test, but **flag it as optional/CI-only**; it requires a prior `pnpm build` and is not worth the flake budget for P0-3.)
+
+---
+
+## 3. Hand-rolled JSON-RPC vs. the real MCP SDK — explicit call-outs
+
+The file's header (`mcp.ts:7-12`) justifies hand-rolling to avoid an install-size dep on a tool you put on a fresh box. **For P0-3 this remains the right call** — every item above is implementable in the hand-rolled framer. But flag these boundaries so the reviewer/PR is honest:
+
+- **Protocol-version negotiation (B3):** the hand-rolled server can only *exact-match-echo* a supported version. Real bidirectional negotiation (client offers a range, server picks) needs `@modelcontextprotocol/sdk`'s `Server` class. **Do not** simulate it; ship exact-match.
+- **`readOnlyHint`/annotations (B1):** these are real MCP fields the SDK models; emitting them by hand is fine and forward-compatible, but we are responsible for keeping the field names spec-aligned. Low risk.
+- **Capabilities beyond `tools` (resources, prompts, sampling, progress notifications):** out of scope; the SDK would give them for free. If the roadmap (`audit :198-201`) later wants **resources** (e.g. exposing the manifest as an MCP resource) or **progress** on a long apply, that is the point to adopt the SDK. Note it in the PR as the migration trigger.
+- **`tools/call` cancellation / `$/cancelRequest`:** the serialized `chain` cannot cancel an in-flight handler. Acceptable for these short read tools; flag that `apply_plan` on a huge manifest is the only long one, and it is already sandbox-bounded.
+
+If/when two of those land, **switch to the SDK** rather than growing the hand-rolled parser. P0-3 itself stays hand-rolled.
+
+---
+
+## 4. Commit / verification sequence (run after each commit)
+
+```bash
+# After the shared-export refactor:
+pnpm vitest run tests/commands/verify.test.ts tests/commands/diff.test.ts tests/commands/scan.test.ts
+# After every mcp.ts change (Stream A tools + Stream B hardening):
+pnpm vitest run tests/commands/mcp.test.ts
+# Loop-level (only if createDispatchLoop landed):
+pnpm vitest run tests/commands/mcp-loop.test.ts
+# Before opening the PR — full gate, mirrors CLAUDE.md "Always run":
+pnpm lint && pnpm typecheck && pnpm vitest run
+# Manual smoke (real stdio, optional, requires build):
+pnpm build && printf '%s\n%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize"}' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | node dist/index.js mcp serve
+#   → expect serverInfo.version === package version, and 11 tools incl. verify/diff/scan_untracked/secrets_status/apply_plan
+```
+
+**Ordered commit list:**
+1. `refactor: export dry-apply, file-diff, and untracked-scan cores for MCP reuse`
+2. `feat(mcp): add read-only verify tool with drift (exit-code) semantics`
+3. `feat(mcp): add read-only diff tool (metadata only, content elided)`
+4. `feat(mcp): add scan_untracked tool (detected minus tracked)`
+5. `feat(mcp): add secrets_status tool (REDACTED-only secret scan)`
+6. `feat(mcp): add sandboxed apply_plan dry-run tool (write-confined, no real writes)`
+7. `test(mcp): assert the widened 11-tool surface and read-only posture`
+8. `feat(mcp): annotate write-gated tools with readOnlyHint in tools/list` (B1)
+9. `fix(mcp): type-check optional tool arguments, not just required ones` (B2)
+10. `fix(mcp): echo supported client protocolVersion on initialize` (B3)
+11. *(optional)* `refactor(mcp): extract injectable createDispatchLoop for loop-level tests` + `feat(mcp): drain stdout under backpressure` (B4)
+
+Also bump the doc: `mcp.ts:8` comment says "6 tools" and `mcp.ts` ships them; update the count in any doc/header (`audit :7` and `:90` say "6 tools") to 11, and tick `audit :216`.
+
+---
+
+## 5. Risk flags / things to double-check during implementation
+
+- **Stdout purity (the #1 risk):** none of the five handlers may transitively call `setJsonMode`/`emitJsonOk`/`console.log`/`process.exit`. The extracted cores (`computeStateModel`, `dryApplyIntoSandbox`, `getFileDiff`/`collectChangedDiffs`, `scanForSecrets`, `collectUntrackedDotfiles`) are pure of that — **but verify the diff extraction** does not retain the `logger.warning` calls at `diff.ts:341-348` (move them out of the extracted helper or make the helper return a `warnings[]` the tool ignores). Add a test asserting the tool produces exactly one JSON-RPC line on stdout (loop harness, count `out.length === 2` for init+call).
+- **`secrets_status` raw-value leak:** the A4 negative test is non-negotiable and must be written before the handler. Also confirm `r.context` (`scanner.ts:41`) is excluded — it embeds the matched line.
+- **`apply_plan` write-context restoration across the persistent server:** A5 test 2 guards it; do not skip. `snapshot→set→finally:restore`, never `resetWriteContext()`.
+- **`loadManifest` throw path:** the new handlers call `await loadManifest(tuckDir)` and let it throw; `dispatch`'s try/catch (`mcp.ts:262-271`) converts it to a clean `isError` tool result. That is the desired UX (agent sees "not initialized" as a tool error, not a transport crash). Do **not** wrap in `NotInitializedError` re-throw inside the handler — unnecessary.
+- **`apply_plan` ungated decision:** if a reviewer insists it be gated, the only change is adding `'apply_plan'` to `WRITE_TOOLS` (`mcp.ts:33`) and flipping A5 test 1 to expect the gate message. Decide before writing the test. My recommendation stands: ungated (dry-run, sandbox-confined, mirrors `verify --apply`).
+- **Files touched, total:** `src/commands/mcp.ts` (all tools + B1/B2/B3), `src/commands/verify.ts` (export `dryApplyIntoSandbox`), `src/commands/diff.ts` (export `getFileDiff`/add `collectChangedDiffs`, export `FileDiff`), `src/commands/scan.ts` (extract+export `collectUntrackedDotfiles`), `tests/commands/mcp.test.ts` (all new cases + mock block), plus per-helper tests in `tests/commands/{verify,diff,scan}.test.ts`. No new dependencies.

--- a/docs/superpowers/plans/2026-06-03-p0-4-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-03-p0-4-e2e-harness.md
@@ -1,0 +1,643 @@
+# P0-4 Design Plan — End-to-End Binary Test Harness for tuck
+
+> Spawn the **real built binary** (`node dist/index.js`) as a child process against a **real temp HOME**, asserting on-disk files and stdout. This closes the single biggest testing hole (zero tests exercise `parseAsync()` today; CI only smoke-tests `--version`/`--help`). It is the tuck-side analogue of chezmoi's 292 txtar golden tests.
+
+---
+
+## 0. The Core Constraint and How We Isolate It
+
+`tests/setup.ts` is loaded as a **global `setupFiles` entry** in `vitest.config.ts` (`setupFiles: ['./tests/setup.ts']`). It performs four process-wide `vi.mock()`s that make e2e impossible *in-process*:
+
+```ts
+// tests/setup.ts (verbatim, the problem)
+vi.mock('os', …)            // os.homedir() → '/test-home'
+vi.mock('fs', …)            // → memfs.fs
+vi.mock('fs/promises', …)   // → memfs.fs.promises
+vi.mock('fs-extra', …)      // → memfs-backed shim
+beforeEach(() => vol.reset()) // wipes the virtual disk every test
+```
+
+**Why this kills e2e:** an e2e test spawns a *separate Node process* (`dist/index.js`). `vi.mock` only patches the **parent test process's** module registry — the spawned child runs unmocked, touching the **real** filesystem and real `os.homedir()`. Meanwhile the *parent* test, if it ran under this setup, could only create/inspect files in **memfs**, which the child cannot see. The two halves live in different filesystems. There is no way to bridge them under the global memfs setup.
+
+**The fix — a separate Vitest project with NO setup file.** `setupFiles` is per-config, so a second config that simply omits `tests/setup.ts` gives the e2e tests the **real** `fs`/`os`. The parent test then creates a real temp HOME with `os.mkdtemp`, spawns the child with `HOME` pointed at it, and inspects real files with real `node:fs`.
+
+**Two key facts from the source that shape the harness** (verified, not assumed):
+
+1. **`os.homedir()` is the single source of truth for HOME.** `src/lib/paths.ts:expandPath` and `src/lib/state.ts:getBaseStateHome` both resolve `~` / state dirs via `homedir()`. Node's `os.homedir()` honors the `HOME` env var on POSIX and `USERPROFILE` on Windows. So **setting `HOME`/`USERPROFILE` in the child's env relocates the entire tuck universe** (`~/.tuck`, the keystore at `~/Library/Application Support/tuck` etc.) into the temp dir. This is the load-bearing mechanism.
+
+2. **`--root` / `TUCK_TARGET_ROOT` only confines WRITES, not READS** (`src/lib/writeContext.ts` header + `resolveWriteTarget`). `tuck add` *reads* its source from the real `homedir()` via `expandPath`. Therefore the harness must rely on **`HOME`** (so reads AND writes land in the temp dir); `--root` is a *belt-and-suspenders* extra layer, not a substitute. The default `runCli` helper sets `HOME` and **also** sets `TUCK_TARGET_ROOT=$HOME` so that even a bug that bypasses `HOME` for a write cannot escape the sandbox onto the operator's real `~`.
+
+---
+
+## 1. Files to Create / Touch (exact paths)
+
+| Path | Action | Purpose |
+|---|---|---|
+| `/Users/pranavkarra/Developer/tuck/vitest.e2e.config.ts` | **create** | E2E project config. **No `setupFiles`.** Real fs/os. |
+| `/Users/pranavkarra/Developer/tuck/tests/e2e/helpers/runCli.ts` | **create** | `runCli(args, {home, env, …})` child-process runner + `makeHome()` + on-disk assert helpers. |
+| `/Users/pranavkarra/Developer/tuck/tests/e2e/helpers/git.ts` | **create** | `hasGit()` gate + git-identity env (reuse existing pattern). |
+| `/Users/pranavkarra/Developer/tuck/tests/e2e/roundtrip.e2e.test.ts` | **create** | Case (a): init→add→sync→apply round-trip + idempotency. |
+| `/Users/pranavkarra/Developer/tuck/tests/e2e/verify-exit-code.e2e.test.ts` | **create** | Case (b): `verify --exit-code` semantics. |
+| `/Users/pranavkarra/Developer/tuck/tests/e2e/template.e2e.test.ts` | **create** | Case (c1): `add --template` → apply renders `{{os}}`. |
+| `/Users/pranavkarra/Developer/tuck/tests/e2e/encrypt.e2e.test.ts` | **create** | Case (c2): encrypt round-trip (gated; see §5.D for the keystore caveat). |
+| `/Users/pranavkarra/Developer/tuck/package.json` | **edit** | Add `test:e2e` + `pretest:e2e` scripts. |
+| `/Users/pranavkarra/Developer/tuck/vitest.config.ts` | **edit (optional)** | Add `exclude: ['tests/e2e/**']` so the **default** memfs run never picks up e2e tests. |
+| `/Users/pranavkarra/Developer/tuck/.github/workflows/ci.yml` | **edit** | Add an `e2e` job (build once, then `test:e2e`) on the OS matrix. |
+
+> Naming convention `*.e2e.test.ts` + their own dir gives a clean glob (`tests/e2e/**/*.e2e.test.ts`) and lets the default config exclude them with one line. Adopt chezmoi's `issueNNNN` convention later for regression cases (e.g. `tests/e2e/issue97-tracked-dir.e2e.test.ts`).
+
+---
+
+## 2. The E2E Vitest Config
+
+`/Users/pranavkarra/Developer/tuck/vitest.e2e.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+/**
+ * End-to-end config: spawns the REAL built binary (dist/index.js) against a
+ * REAL temp HOME. Deliberately has NO setupFiles — it must NOT load
+ * tests/setup.ts, whose global vi.mock(fs|fs/promises|fs-extra|os) would
+ * confine the PARENT test to memfs while the spawned child writes to the real
+ * disk (two different filesystems → unobservable). Real fs/os is required.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['tests/e2e/**/*.e2e.test.ts'],
+    setupFiles: [],            // <-- the whole point: no memfs/os mock
+    testTimeout: 60_000,       // child spawn + (optional) real git is slow vs unit tests
+    hookTimeout: 60_000,       // beforeAll builds the binary
+    // Each spawn is an isolated OS process; in-process pooling/threads buy
+    // nothing here and a single fork avoids cross-test cwd/env interference.
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    sequence: { shuffle: false },
+    // No coverage here — coverage is the unit suite's job; instrumenting a
+    // spawned child adds nothing and v8 coverage can't see the subprocess.
+  },
+});
+```
+
+Mirrors the existing `vitest.bench.config.ts` precedent (which already proves the repo runs a second config with a *different* setup against the real filesystem — `tests/benchmarks/setup.ts`, `pool: 'threads'`). We follow that pattern with `setupFiles: []`.
+
+---
+
+## 3. The `runCli` Helper (the heart of the harness)
+
+`/Users/pranavkarra/Developer/tuck/tests/e2e/helpers/runCli.ts`:
+
+```ts
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, mkdir, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// tests/e2e/helpers → repo root is three levels up.
+export const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+export const CLI_ENTRY = join(REPO_ROOT, 'dist', 'index.js');
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  /** Exit code; null only if the process was signalled (we treat that as failure). */
+  code: number;
+}
+
+export interface RunOptions {
+  /** Temp HOME the child must treat as ~ (sets HOME + USERPROFILE). */
+  home: string;
+  /** Extra env (e.g. TUCK_PASSWORD, git identity). Merged over the base env. */
+  env?: Record<string, string>;
+  /** Working directory for the child (default: home). */
+  cwd?: string;
+  /** Pipe to child stdin (e.g. for any prompt we cannot otherwise avoid). */
+  input?: string;
+  /** Override the implicit TUCK_TARGET_ROOT=home sandbox (default: on). */
+  sandbox?: boolean;
+}
+
+/**
+ * Spawn `node dist/index.js <args>` with a sanitized, hermetic environment:
+ *   - HOME/USERPROFILE → the temp home (relocates ~/.tuck, keystore, state dir).
+ *   - TUCK_TARGET_ROOT → home (belt-and-suspenders write confinement; the CLI
+ *     reads from real homedir(), so HOME is what actually relocates reads).
+ *   - CI=1, NO_UPDATE_NOTIFIER=1, no inherited TTY → forces non-interactive
+ *     paths and suppresses the update-notifier banner that would corrupt JSON.
+ * NEVER rejects on non-zero exit: the test asserts on { code, stdout, stderr }.
+ */
+export const runCli = (args: string[], opts: RunOptions): Promise<RunResult> => {
+  const { home, env = {}, cwd = home, input, sandbox = true } = opts;
+
+  const childEnv: NodeJS.ProcessEnv = {
+    // Minimal base: PATH (so child `git`/`security`/`secret-tool` resolve),
+    // plus a few harmless locale vars. We do NOT spread all of process.env to
+    // avoid leaking the operator's real HOME/XDG_* into the child.
+    PATH: process.env.PATH,
+    SystemRoot: process.env.SystemRoot,        // Windows: node needs this
+    COMSPEC: process.env.COMSPEC,              // Windows
+    HOME: home,
+    USERPROFILE: home,                          // Windows homedir()
+    XDG_STATE_HOME: '',                         // force state dir under HOME, not host XDG
+    XDG_CONFIG_HOME: '',
+    CI: '1',                                    // many code paths check CI; also disables prompts
+    NO_UPDATE_NOTIFIER: '1',                    // update-notifier is also skipped for --json
+    FORCE_COLOR: '0',                           // deterministic, un-ANSI'd stdout for golden asserts
+    NO_COLOR: '1',
+    ...(sandbox ? { TUCK_TARGET_ROOT: home } : {}),
+    ...env,
+  };
+
+  return new Promise((res) => {
+    const child = execFile(
+      process.execPath,                         // the same node running vitest
+      [CLI_ENTRY, ...args],
+      { cwd, env: childEnv, maxBuffer: 16 * 1024 * 1024, timeout: 55_000 },
+      (err, stdout, stderr) => {
+        // execFile's callback `err` carries .code on non-zero exit; capture it
+        // rather than throwing, so the test can assert exit codes (case b).
+        const code =
+          err && typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 1            // signalled / spawn failure → treat as failure
+              : 0;
+        res({ stdout: String(stdout), stderr: String(stderr), code });
+      }
+    );
+    if (input !== undefined) {
+      child.stdin?.end(input);
+    }
+  });
+};
+
+/** Create a throwaway HOME under the OS temp dir; returns its absolute path. */
+export const makeHome = async (): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), 'tuck-e2e-'));
+  return dir;
+};
+
+export const cleanupHome = async (home: string): Promise<void> => {
+  await rm(home, { recursive: true, force: true });
+};
+
+// ---- On-disk assertion helpers (REAL fs, not memfs) ----
+
+export const homePath = (home: string, rel: string): string => join(home, rel);
+
+export const fileExists = async (p: string): Promise<boolean> => {
+  try { await stat(p); return true; } catch { return false; }
+};
+
+export const readHomeFile = (home: string, rel: string): Promise<string> =>
+  readFile(join(home, rel), 'utf-8');
+
+/** Write a dotfile into the temp HOME before running `tuck add`. */
+export const seedHomeFile = async (
+  home: string, rel: string, content: string,
+): Promise<string> => {
+  const full = join(home, rel);
+  await mkdir(dirname(full), { recursive: true });
+  await (await import('node:fs/promises')).writeFile(full, content);
+  return full;
+};
+
+/** Parse the single-line JSON envelope tuck emits on stdout under --json. */
+export const parseEnvelope = (stdout: string): { ok: boolean; command: string; data?: unknown; error?: unknown } => {
+  // The envelope contract (src/lib/jsonOutput.ts) is "exactly one JSON object
+  // on stdout". Grab the last non-empty line to tolerate any stray banner that
+  // slipped onto an earlier line (defensive; --json already suppresses them).
+  const line = stdout.trim().split('\n').filter(Boolean).at(-1) ?? '';
+  return JSON.parse(line);
+};
+```
+
+**Design notes baked into the helper (each tied to a verified source fact):**
+
+- **`HOME` + `USERPROFILE`** — `os.homedir()` reads `HOME` on POSIX, `USERPROFILE` on Windows. Setting both makes `makeHome()` the universal `~` cross-platform.
+- **`XDG_STATE_HOME=''`** — `src/lib/state.ts:getBaseStateHome()` honors `XDG_STATE_HOME` *first*; clearing it forces the state/keystore dir back under `HOME` (`~/.local/state/tuck` on Linux), so the keystore for the encrypt case lands inside the temp HOME.
+- **`CI=1` + no inherited stdio TTY** — every interactive command gates on `process.stdout.isTTY` (e.g. `apply.ts:1290`, `sync.ts`). `execFile` gives the child piped (non-TTY) stdio, so `isTTY` is `undefined` ⇒ the non-interactive branch runs. We **never** rely on this alone — we always pass `--json`/`--yes`/`--bare`/`--force` explicitly.
+- **`FORCE_COLOR=0`/`NO_COLOR=1`** — chalk emits ANSI otherwise; stripping it makes human-stdout assertions stable (groundwork for a future golden corpus, item P0 §5.2 of the audit).
+- **Does NOT spread `process.env`** — prevents the operator's real `HOME`/`XDG_*`/git config from leaking into the child and breaking hermeticity.
+- **Never throws on non-zero exit** — case (b) must *read* exit codes, so we capture `err.code` instead of rejecting.
+
+---
+
+## 4. Building `dist/index.js` Once
+
+Two complementary mechanisms (use both):
+
+**(i) `beforeAll` build guard** in a shared helper, imported by every e2e file, so a local `vitest --config vitest.e2e.config.ts` run "just works" without remembering to build:
+
+```ts
+// tests/e2e/helpers/build.ts
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { stat } from 'node:fs/promises';
+import { CLI_ENTRY, REPO_ROOT } from './runCli.js';
+
+const execFileAsync = promisify(execFile);
+let built = false;
+
+/** Build dist/index.js exactly once per `vitest` process (idempotent). */
+export const ensureBuilt = async (): Promise<void> => {
+  if (built) return;
+  // Cheap skip: if a fresh dist exists (CI's pretest:e2e already built it),
+  // don't rebuild. Local runs with a stale/missing dist trigger a build.
+  try {
+    await stat(CLI_ENTRY);
+    if (process.env.TUCK_E2E_SKIP_BUILD === '1') { built = true; return; }
+  } catch { /* missing → build */ }
+  // pnpm build === tsup (see package.json scripts.build). Build to ESM dist.
+  await execFileAsync('pnpm', ['build'], { cwd: REPO_ROOT, timeout: 180_000 });
+  built = true;
+};
+```
+
+Each test file: `beforeAll(async () => { await ensureBuilt(); }, 180_000);`
+
+**(ii) `pretest:e2e` script** so CI builds before the runner spawns (faster, single build, and lets us set `TUCK_E2E_SKIP_BUILD=1` to make `ensureBuilt()` a no-op in CI):
+
+`package.json` additions:
+```jsonc
+{
+  "scripts": {
+    "pretest:e2e": "pnpm build",
+    "test:e2e": "TUCK_E2E_SKIP_BUILD=1 vitest run --config vitest.e2e.config.ts"
+  }
+}
+```
+> On Windows the `TUCK_E2E_SKIP_BUILD=1 …` inline-env form fails in cmd.exe. Either rely on the `beforeAll` `stat()` short-circuit (fresh dist from `pretest:e2e` ⇒ no rebuild) **or** add `cross-env` (already-idiomatic) — recommend the `stat` short-circuit to avoid a new dep, and drop the inline env var from the script (keep just `vitest run --config vitest.e2e.config.ts`).
+
+**`tsup` note:** `tsup.config.ts` already emits `dist/index.js` (ESM) with a `#!/usr/bin/env node` banner and `dts: true`. `dts` generation is the slow part of `pnpm build`; if e2e build time becomes a problem, add a `build:fast` script (`tsup --no-dts`) and point `pretest:e2e` at it. Not required for correctness.
+
+---
+
+## 5. The E2E Cases (TDD order — write the test first, watch it drive out / confirm behavior)
+
+> Follow `test-driven-development`: each case is RED first (assert the *intended* on-disk result), then we run the real binary; if it's already correct it goes GREEN and locks in a regression guard against flag-wiring/`parseAsync` breakage. Where a case surfaces a real bug, it stays RED until fixed (that is the point of the harness).
+
+### Case (a) — init → add → sync(--json) → apply round-trip + idempotency  `roundtrip.e2e.test.ts`
+
+The flagship. Verified command surface that makes this fully non-interactive:
+- `tuck init --bare --json` → `runInit` with `bare`; emits `{ok:true, command:"tuck init", data:{initialized:true, …}}` (init.ts:1804-1822). `--bare` ⇒ local mode, **no remote, no GitHub, no network**.
+- `tuck add <path> --json --yes` → `runAdd` non-interactive; emits `{data:{added:N, files:[{source,category}]}}` (add.ts:273-279). Reads source from `homedir()` ⇒ the temp HOME.
+- `tuck sync --json --no-push` → `runSyncCommand`; commits locally, **never pushes** (sync.ts: `options.push !== false && hasRemote(...)` gate; `--bare` repo has no remote anyway). Emits `{data:{modified, deleted, commitHash, noop}}` (sync.ts:1099-1166).
+- `tuck apply <DIR> --json --force` → `runApply`; **`<source>` is the local `~/.tuck` dir** (apply.ts `resolveSource` returns kind `'local'` for an existing dir — apply.ts:173-177, 244-250; `cloneSource` materializes a local dir with **no remote**, apply.ts:359-365). Emits `{data:{applied:N, source, dryRun:false, skipped:[]}}` (apply.ts:1220-1227).
+
+```ts
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { ensureBuilt } from './helpers/build.js';
+import {
+  runCli, makeHome, cleanupHome, seedHomeFile, readHomeFile, fileExists,
+  parseEnvelope, homePath,
+} from './helpers/runCli.js';
+import { hasGit, gitIdentityEnv } from './helpers/git.js';
+
+describe('e2e: init → add → sync → apply round-trip', () => {
+  beforeAll(async () => { await ensureBuilt(); }, 180_000);
+
+  const homes: string[] = [];
+  afterEach(async () => { await Promise.all(homes.splice(0).map(cleanupHome)); });
+
+  it('tracks a dotfile, commits it, and re-materializes it on a clean machine', async () => {
+    if (!(await hasGit())) return;   // real-git gate (sync commits; see §6.A)
+
+    // ── machine 1: author the dotfile and tuck it ───────────────────────────
+    const src = await makeHome(); homes.push(src);
+    const env = { ...gitIdentityEnv() };               // GIT_AUTHOR_*/COMMITTER_* (§6.A)
+
+    await seedHomeFile(src, '.zshrc', 'export EDITOR=vim\n');
+
+    const init = await runCli(['init', '--bare', '--json'], { home: src, env });
+    expect(init.code).toBe(0);
+    expect(parseEnvelope(init.stdout)).toMatchObject({ ok: true, data: { initialized: true } });
+    expect(await fileExists(homePath(src, '.tuck/.tuckmanifest.json'))).toBe(true);
+
+    const add = await runCli(['add', join(src, '.zshrc'), '--json', '--yes'], { home: src, env });
+    expect(add.code).toBe(0);
+    const addEnv = parseEnvelope(add.stdout);
+    expect(addEnv).toMatchObject({ ok: true, data: { added: 1 } });
+    // The repo copy exists on REAL disk under ~/.tuck/files/…
+    expect(await fileExists(homePath(src, '.tuck/files/shell/zshrc'))).toBe(true);
+
+    const sync = await runCli(['sync', '--json', '--no-push'], { home: src, env });
+    expect(sync.code).toBe(0);
+    const syncEnv = parseEnvelope(sync.stdout) as { ok: boolean; data: { commitHash: string | null; noop: boolean } };
+    expect(syncEnv.ok).toBe(true);
+    expect(syncEnv.data.commitHash).toBeTruthy();      // a real commit happened
+    expect(syncEnv.data.noop).toBe(false);
+
+    // ── machine 2: empty home, apply FROM the machine-1 repo dir ─────────────
+    const dst = await makeHome(); homes.push(dst);
+    const repoDir = homePath(src, '.tuck');             // local dir source ⇒ no network
+    const apply = await runCli(['apply', repoDir, '--json', '--force'], { home: dst, env });
+    expect(apply.code).toBe(0);
+    expect(parseEnvelope(apply.stdout)).toMatchObject({ ok: true, data: { applied: 1, dryRun: false, skipped: [] } });
+
+    // THE on-disk assertion: the file was re-materialized into the new HOME.
+    expect(await readHomeFile(dst, '.zshrc')).toBe('export EDITOR=vim\n');
+  });
+
+  it('apply is idempotent — a second apply changes nothing on disk', async () => {
+    if (!(await hasGit())) return;
+    const src = await makeHome(); homes.push(src);
+    const env = { ...gitIdentityEnv() };
+    await seedHomeFile(src, '.gitconfig', '[user]\n  name = Ada\n');
+    await runCli(['init', '--bare', '--json'], { home: src, env });
+    await runCli(['add', join(src, '.gitconfig'), '--json', '--yes'], { home: src, env });
+    await runCli(['sync', '--json', '--no-push'], { home: src, env });
+
+    const dst = await makeHome(); homes.push(dst);
+    const repoDir = homePath(src, '.tuck');
+
+    const first = await runCli(['apply', repoDir, '--json', '--force'], { home: dst, env });
+    expect(parseEnvelope(first.stdout)).toMatchObject({ data: { applied: 1 } });
+    const after1 = await readHomeFile(dst, '.gitconfig');
+
+    const second = await runCli(['apply', repoDir, '--json', '--force'], { home: dst, env });
+    expect(second.code).toBe(0);                        // second run still succeeds
+    const after2 = await readHomeFile(dst, '.gitconfig');
+
+    // Idempotency assertion: byte-identical content after the 2nd apply.
+    expect(after2).toBe(after1);
+    expect(after2).toBe('[user]\n  name = Ada\n');
+  });
+});
+```
+
+> **Idempotency nuance to encode in the assertion (not over-assert):** for **shell** files (`.zshrc`, `.bashrc`) `apply` runs `smartMerge` (apply.ts:661-678), which can legitimately *append/reorder managed blocks* — a second apply of a shell file is content-stable but not guaranteed *byte-identical* on the first transition. So the idempotency test uses a **non-shell** file (`.gitconfig`) where merge is a straight write, making "byte-identical after 2nd apply" a sound invariant. The round-trip test uses `.zshrc` only to assert the *value* survives, not byte-stability. (This distinction is exactly the kind of bug the harness exists to catch — document it in the test comment.)
+
+### Case (b) — `verify --exit-code` semantics  `verify-exit-code.e2e.test.ts`
+
+Verified: `verify.ts:398-399` sets `process.exitCode = 1` when `hasDrift(summary)` and `--exit-code` is passed (the read-only path), and `verify.ts:306-307` does the same for the `--apply` conflict/escape path. Clean ⇒ exit 0.
+
+```ts
+describe('e2e: verify --exit-code CI gate', () => {
+  beforeAll(async () => { await ensureBuilt(); }, 180_000);
+  const homes: string[] = [];
+  afterEach(async () => { await Promise.all(homes.splice(0).map(cleanupHome)); });
+
+  const setupTracked = async () => {
+    const home = await makeHome(); homes.push(home);
+    const env = { ...gitIdentityEnv() };
+    await seedHomeFile(home, '.vimrc', 'set number\n');
+    await runCli(['init', '--bare', '--json'], { home, env });
+    await runCli(['add', join(home, '.vimrc'), '--json', '--yes'], { home, env });
+    return { home, env };
+  };
+
+  it('exits 0 when everything is in sync', async () => {
+    const { home, env } = await setupTracked();
+    const r = await runCli(['verify', '--exit-code', '--json'], { home, env });
+    expect(r.code).toBe(0);
+    expect(parseEnvelope(r.stdout)).toMatchObject({ ok: true });
+  });
+
+  it('exits 1 when the live file has drifted from the repo copy', async () => {
+    const { home, env } = await setupTracked();
+    // Mutate the LIVE file so live ≠ repo ⇒ drift.
+    await seedHomeFile(home, '.vimrc', 'set number\nset relativenumber\n');
+    const r = await runCli(['verify', '--exit-code', '--json'], { home, env });
+    expect(r.code).toBe(1);                              // CI gate trips
+    // The JSON envelope is still ok:true (verify succeeded); exit code carries drift.
+    const env_ = parseEnvelope(r.stdout) as { ok: boolean; data: { summary?: unknown } };
+    expect(env_.ok).toBe(true);
+  });
+
+  it('exits 0 on drift WITHOUT --exit-code (report-only mode)', async () => {
+    const { home, env } = await setupTracked();
+    await seedHomeFile(home, '.vimrc', 'set number\nset relativenumber\n');
+    const r = await runCli(['verify', '--json'], { home, env });   // no --exit-code
+    expect(r.code).toBe(0);                              // reporting drift must not fail CI
+  });
+});
+```
+
+> This case needs **no git commit** (verify reads manifest + repo copy + live file), so it runs even when `hasGit()` is false — *except* `tuck add` still uses git? No: `add` writes the repo copy + manifest and does not require a commit. (If a future `add` change requires git, add the `hasGit()` gate.) Verifying the **negative** (no `--exit-code` ⇒ exit 0 on drift) is the highest-value assertion: it proves the flag actually gates, which a memfs unit test that mocks `process.exitCode` cannot prove end-to-end.
+
+### Case (c1) — Template round-trip: `add --template` → apply renders `{{os}}`  `template.e2e.test.ts`
+
+Verified pipeline:
+- `add --template` sets `template:true` in the manifest and stores the file **verbatim** (fileTracking.ts:296; templates are rendered at *apply* time, never storage time — template.ts header).
+- `apply` calls `materializeForLive → renderTemplate(text, ctx)` when `file.template` (materialize.ts:62-63), with `ctx.os = process.platform` (template.ts:212, `defaultTemplateContext`). So `{{os}}` renders to the **child process's** `process.platform` — i.e. `darwin`/`linux`/`win32` of the *runner*, which the test knows via `process.platform`.
+
+```ts
+import { platform } from 'node:process';
+
+it('renders {{os}} on apply but stores the template verbatim', async () => {
+  if (!(await hasGit())) return;
+  const src = await makeHome(); homes.push(src);
+  const env = { ...gitIdentityEnv() };
+
+  // A file with a tuck template token.
+  await seedHomeFile(src, '.config/tuck-demo/os.txt', 'platform={{os}}\n');
+
+  await runCli(['init', '--bare', '--json'], { home: src, env });
+  const add = await runCli(
+    ['add', join(src, '.config/tuck-demo/os.txt'), '--template', '--json', '--yes'],
+    { home: src, env },
+  );
+  expect(add.code).toBe(0);
+
+  // Stored verbatim in the repo (NOT pre-rendered): the literal {{os}} survives.
+  const repoCopy = await readHomeFile(src, '.tuck/files/misc/config/tuck-demo/os.txt');
+  expect(repoCopy).toContain('{{os}}');                 // proves storage-time is NOT rendered
+
+  await runCli(['sync', '--json', '--no-push'], { home: src, env });
+
+  // Apply into a clean home → token renders to the runner's platform.
+  const dst = await makeHome(); homes.push(dst);
+  const apply = await runCli(['apply', homePath(src, '.tuck'), '--json', '--force'], { home: dst, env });
+  expect(apply.code).toBe(0);
+
+  const rendered = await readHomeFile(dst, '.config/tuck-demo/os.txt');
+  expect(rendered).toBe(`platform=${platform}\n`);      // {{os}} → darwin|linux|win32
+  expect(rendered).not.toContain('{{os}}');
+});
+```
+
+> The exact repo destination (`files/misc/config/tuck-demo/os.txt`) follows `getRelativeDestinationFromSource` (paths.ts:113-126): category defaults to `misc` for an unrecognized path, and the **full home-relative path** is preserved under the category. If the destination assertion is brittle across category-detection changes, relax it to "read the manifest envelope's `files[0]` or glob `**/os.txt` under `.tuck/files`". Keep the **rendered-output** assertion strict — that is the load-bearing one.
+
+### Case (c2) — Encrypt round-trip: `add --encrypt` → apply decrypts  `encrypt.e2e.test.ts`
+
+**This is the case the branch's new feature unlocks, and the one with the sharpest CI/cross-platform caveat.** Verified mechanics:
+- `add --encrypt` stores **TCKE1 ciphertext** in the repo (`fileTracking.ts:267-274`, magic `TCKE1` per `crypto/fileEncryption.ts:34`), encrypting with `keystorePassphrase()`.
+- `apply` decrypts via `materializeForLive(..., {getPassphrase: keystorePassphrase})` (apply.ts:634); a failed/absent passphrase **never writes ciphertext** — it skips loudly (apply.ts:635-647).
+- **`keystorePassphrase()` reads ONLY the keystore** — `getKeystore().retrieve(TUCK_SERVICE, TUCK_ACCOUNT)` (materialize.ts:73-76). **There is no `TUCK_PASSWORD` fallback for FILE encryption** (only the standalone `encryption encrypt/decrypt <file>` subcommands honor `TUCK_PASSWORD`, and those do not populate the keystore).
+
+**Therefore the round-trip requires the keystore to be pre-seeded, which is the hard part:**
+
+| Platform | `getKeystore()` chooses | Hermetic under temp HOME? |
+|---|---|---|
+| **Linux (CI)** | `LinuxKeystore` only if `DBUS_SESSION_BUS_ADDRESS` set **or** `$XDG_RUNTIME_DIR/bus` exists (linux.ts:22-25). On GitHub `ubuntu-latest` neither is set under our sanitized env ⇒ **falls back to `FallbackKeystore`**, an encrypted file at `~/.local/state/tuck/keystore/…` keyed off `~/.tuck/keystore.key` (fallback.ts:105, state.ts:60). **Fully hermetic.** | ✅ |
+| **Windows (CI)** | `WindowsKeystore.isAvailable()` is **always false by design** (index.ts:40-51) ⇒ `FallbackKeystore` under `~/AppData/Local/tuck`. **Hermetic.** | ✅ |
+| **macOS (CI + dev)** | `MacOSKeystore.isAvailable()` returns **true whenever `/usr/bin/security` exists** (macos.ts:37-46) — i.e. *always*. It then `add-generic-password`s into the **operator's REAL login Keychain**, ignoring `HOME`. **NOT hermetic, and a footgun** (Keychain GUI prompts in CI, leftover entries on dev machines). | ❌ |
+
+**Plan for case (c2), in priority order:**
+
+1. **Recommended (M, isolated):** Drive the round-trip entirely on the **FallbackKeystore** and **skip macOS** for this single case until a keystore override exists:
+   ```ts
+   const fallbackKeystoreOnly = process.platform !== 'darwin';   // see §6.D
+   it.skipIf(!fallbackKeystoreOnly)('encrypts at rest and decrypts on apply', async () => { … });
+   ```
+   The blocker even on Linux/Windows: **`tuck encryption setup` is interactive** (`prompts.password`, encryption.ts:85-92) with no `--password`/env path. To seed the FallbackKeystore non-interactively we must either (a) pipe stdin to `setup` — but `@clack/prompts` reads the raw TTY, not stdin pipes, so this is unreliable; or (b) **add a tiny, low-risk non-interactive seam** — the cleanest being a `TUCK_PASSWORD` (or `TUCK_ENCRYPTION_PASSWORD`) env fallback inside `runSetup`/`setupEncryption` **when not a TTY**, mirroring the seam that already exists for the standalone `encrypt/decrypt` subcommands (encryption.ts:254, 306). That is a **prerequisite implementation change**, so:
+
+2. **Make the prerequisite explicit (P0 §5 item 7 of the audit already anticipates this):** Before the encrypt e2e can be hermetic, land a small change so encryption can be configured non-interactively:
+   - Add `process.env.TUCK_PASSWORD` (non-TTY) fallback to `runSetup` in `src/commands/encryption.ts`, **or**
+   - Add an `--password <pw>` option to `encryption setup`.
+   Then the e2e seeds the keystore with `runCli(['encryption','setup','--password','pw'], {home, env})` (or `env:{TUCK_PASSWORD:'pw'}`), and `add --encrypt`/`apply` both read that same FallbackKeystore. **Document this dependency in the plan; the encrypt test is RED until it lands** — which is correct TDD: the test specifies the missing seam.
+
+3. **Pure-binary fallback that needs NO source change (proves decrypt-on-apply today):** Use the standalone, already-non-interactive subcommands to *manufacture* an encrypted repo, bypassing the keystore for the *write* but exercising the real decrypt-on-apply path — **only viable if `apply`'s decrypt also accepts `TUCK_PASSWORD`**, which it does NOT (it uses `keystorePassphrase`). So this fallback **cannot** complete the round-trip without (2). Conclusion: **(2) is a true prerequisite.**
+
+```ts
+// encrypt.e2e.test.ts — final shape AFTER the §6.D seam lands
+const KEYSTORE_HERMETIC = process.platform !== 'darwin';   // macOS uses real Keychain (footgun)
+
+describe.skipIf(!KEYSTORE_HERMETIC)('e2e: encrypt round-trip', () => {
+  beforeAll(async () => { await ensureBuilt(); }, 180_000);
+  const homes: string[] = [];
+  afterEach(async () => { await Promise.all(homes.splice(0).map(cleanupHome)); });
+
+  it('stores TCKE1 ciphertext at rest and decrypts the plaintext on apply', async () => {
+    if (!(await hasGit())) return;
+    const src = await makeHome(); homes.push(src);
+    const env = { ...gitIdentityEnv(), TUCK_PASSWORD: 'correct horse battery staple' };
+
+    await seedHomeFile(src, '.netrc', 'machine example login me password s3cret\n');
+    await runCli(['init', '--bare', '--json'], { home: src, env });
+    // Seed the FallbackKeystore non-interactively (requires §6.D seam).
+    const setup = await runCli(['encryption', 'setup'], { home: src, env });   // reads TUCK_PASSWORD (non-TTY)
+    expect(setup.code).toBe(0);
+
+    const add = await runCli(['add', join(src, '.netrc'), '--encrypt', '--json', '--yes'], { home: src, env });
+    expect(add.code).toBe(0);
+
+    // At rest: the repo copy is TCKE1 ciphertext, NOT the plaintext secret.
+    const repoBytes = await (await import('node:fs/promises'))
+      .readFile(homePath(src, '.tuck/files/misc/netrc'));
+    expect(repoBytes.subarray(0, 5).toString('ascii')).toBe('TCKE1');
+    expect(repoBytes.toString('utf8')).not.toContain('s3cret');   // plaintext never committed
+
+    await runCli(['sync', '--json', '--no-push'], { home: src, env });
+
+    // Apply into a clean home WITH the same keystore password ⇒ decrypts.
+    const dst = await makeHome(); homes.push(dst);
+    const dstEnv = { ...env };                                  // same TUCK_PASSWORD seeds dst keystore
+    await runCli(['encryption', 'setup'], { home: dst, env: dstEnv });
+    const apply = await runCli(['apply', homePath(src, '.tuck'), '--json', '--force'], { home: dst, env: dstEnv });
+    expect(apply.code).toBe(0);
+
+    expect(await readHomeFile(dst, '.netrc')).toBe('machine example login me password s3cret\n');
+  });
+
+  it('refuses to write ciphertext when the passphrase is wrong/absent', async () => {
+    // … add+sync as above on `src`; then apply on a `dst` whose keystore has a
+    // DIFFERENT password → apply must skip the file loudly and NOT write TCKE1
+    // bytes to ~/.netrc (apply.ts:635-647). Assert: file absent OR not ciphertext.
+  });
+});
+```
+
+---
+
+## 6. Flakiness, Cross-Platform, and Environment Concerns (each with a mitigation)
+
+**A. Git identity & presence (affects every case that calls `sync`, i.e. (a), and `add`+`sync` chains in (c)).**
+`src/lib/git.ts:initRepo` runs `git init` but **does not set `user.name`/`user.email`**. A fresh CI runner with no global git identity makes `git commit` fail. Mitigation in `tests/e2e/helpers/git.ts`:
+```ts
+import simpleGit from 'simple-git';
+export const hasGit = async (): Promise<boolean> => {
+  try { await simpleGit().raw(['--version']); return true; } catch { return false; }
+};
+/** Identity via env so we never mutate the runner's global git config. */
+export const gitIdentityEnv = (): Record<string, string> => ({
+  GIT_AUTHOR_NAME: 'tuck-e2e', GIT_AUTHOR_EMAIL: 'e2e@tuck.test',
+  GIT_COMMITTER_NAME: 'tuck-e2e', GIT_COMMITTER_EMAIL: 'e2e@tuck.test',
+});
+```
+Reuses the **existing** `hasGit()` gate already proven in `tests/integration/provider-e2e.test.ts:57` and `tests/lib/mergeConflicts.test.ts:107`. GitHub runners ship git on all three OSes, so the gate rarely skips in CI but keeps local runs robust.
+
+**B. `$EDITOR` / interactive prompts.** No e2e command should ever open `$EDITOR`. We defend three ways: (1) always pass `--json`/`--yes`/`--bare`/`--force`; (2) `execFile` gives a non-TTY stdio so `process.stdout.isTTY` is falsy (every interactive branch checks it, e.g. `apply.ts:1290`); (3) set `EDITOR`/`VISUAL`/`GIT_EDITOR=true` and `GIT_TERMINAL_PROMPT=0` in `childEnv` (add to `runCli`) so any stray editor/credential prompt exits immediately instead of hanging. `@clack/prompts` reads the raw TTY — with no TTY it would error, surfacing as a non-zero exit the test catches, never an infinite hang (the 55 s `execFile` timeout is the final backstop).
+
+**C. Windows specifics.**
+- `USERPROFILE` (set in `runCli`) is what `os.homedir()` uses on Windows.
+- `mkdtemp(tmpdir())` paths contain backslashes; pass them as-is to `--root`/`apply <dir>` — tuck's path code normalizes (`toPosixPath`, `expandWindowsEnvVars`). Assertions use `node:path.join`, so they're separator-correct.
+- Inline `VAR=val cmd` in npm scripts breaks on cmd.exe → keep `test:e2e` as a bare `vitest run --config …` and rely on the `ensureBuilt()` `stat` short-circuit (don't use `TUCK_E2E_SKIP_BUILD=1 …` inline).
+- Symlink-strategy paths require Developer Mode/admin on Windows — **none of the four cases use `--symlink`**, so this is avoided.
+- `pretest:e2e` runs `pnpm build` (tsup) which is OS-agnostic.
+
+**D. Keystore in CI / macOS Keychain footgun (the headline caveat).** As detailed in §5.C2: macOS `MacOSKeystore.isAvailable()` is `true` whenever `/usr/bin/security` exists, so any keystore write hits the **real login Keychain** regardless of `HOME` — non-hermetic and prompt-prone in CI, and pollutes dev machines. **Mitigations:** (i) **gate the encrypt case `describe.skipIf(process.platform === 'darwin')`** until a keystore override exists; (ii) **recommend adding `TUCK_KEYSTORE=fallback` (or `TUCK_FORCE_FALLBACK_KEYSTORE=1`) env override** in `src/lib/crypto/keystore/index.ts:getKeystore()` so e2e (and cautious users) can force the encrypted-file keystore on all platforms — this is the clean long-term fix that also makes the macOS encrypt case hermetic; (iii) the **non-interactive `encryption setup` seam** (TUCK_PASSWORD non-TTY fallback or `--password`) is a hard prerequisite for the round-trip on *any* platform. Items (ii) and (iii) are small, well-scoped source changes; the e2e test is written first (RED) and these changes turn it GREEN — proper TDD.
+
+**E. Build-once race / stale dist.** `ensureBuilt()` guards with a module-level `built` flag (one build per `vitest` process) and a `stat(CLI_ENTRY)` short-circuit; `pretest:e2e` builds in CI before the runner starts and `singleFork` serializes files so no two suites race a `pnpm build`.
+
+**F. Temp dir cleanup & leakage.** Each test pushes its homes onto an array and `afterEach` `rm -rf`s them; even on assertion failure the temp dirs are removed. `mkdtemp` under `os.tmpdir()` keeps them off the operator's `~`. The implicit `TUCK_TARGET_ROOT=$HOME` in `runCli` is the safety net: even a bug that ignores `HOME` for a write is confined to the temp dir (writeContext.ts rejects escapes), so **a broken binary can never scribble on the developer's real `~`** — exactly the guarantee that makes running the real binary safe.
+
+**G. Output determinism for future golden tests.** `FORCE_COLOR=0`/`NO_COLOR=1` strip ANSI; `--json` envelopes are single-line and version-stable (jsonOutput.ts:4-9). This positions the harness to grow into the txtar/golden corpus called for in audit §5.2 (P0) with minimal extra work — assert on `parseEnvelope(stdout)` for machine paths, and on normalized human stdout for golden paths.
+
+---
+
+## 7. CI Wiring
+
+Add an `e2e` job to `/Users/pranavkarra/Developer/tuck/.github/workflows/ci.yml`, paralleling the existing `test` matrix (ubuntu/macos/windows × node 18/20/22 is overkill for e2e — use one node, all three OSes):
+
+```yaml
+  e2e:
+    name: E2E (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    needs: [lint]                      # build happens inside (pretest:e2e); don't block on unit `test`
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'pnpm' }
+      - run: pnpm install --frozen-lockfile
+      - name: Configure git identity (commit author for sync round-trip)
+        run: |
+          git config --global user.name  "tuck-e2e"
+          git config --global user.email "e2e@tuck.test"
+      - name: Run e2e suite
+        run: pnpm test:e2e             # pretest:e2e builds dist/ first
+        env:
+          CI: '1'
+```
+
+> The global `git config` step is a belt-and-suspenders complement to the `GIT_*` env in `runCli` (some git versions/paths still consult global config). On macOS, the encrypt case self-skips (§6.D), so no Keychain prompt blocks CI. Keep e2e a **separate job** so a real-git/keystore environment quirk on one OS doesn't mask unit-test results, and so the `build` artifact job stays untouched.
+
+---
+
+## 8. Suggested Commit Sequence (Conventional Commits; one logical change each)
+
+1. `test(e2e): add isolated e2e vitest project with no memfs setup` — `vitest.e2e.config.ts`, `package.json` scripts (`test:e2e`, `pretest:e2e`), `vitest.config.ts` `exclude: ['tests/e2e/**']`.
+2. `test(e2e): add runCli child-process harness + temp-HOME helpers` — `tests/e2e/helpers/{runCli,build,git}.ts`.
+3. `test(e2e): init→add→sync→apply round-trip + idempotency` — `tests/e2e/roundtrip.e2e.test.ts` (Case a).
+4. `test(e2e): verify --exit-code CI-gate semantics` — `tests/e2e/verify-exit-code.e2e.test.ts` (Case b).
+5. `test(e2e): template round-trip asserts {{os}} renders on apply` — `tests/e2e/template.e2e.test.ts` (Case c1).
+6. `feat(encryption): non-interactive setup via TUCK_PASSWORD (non-TTY) + TUCK_KEYSTORE=fallback override` — the §6.D prerequisite seam in `src/commands/encryption.ts` and `src/lib/crypto/keystore/index.ts` (**ships RED→GREEN with the test in the next commit; the smallest possible production change**).
+7. `test(e2e): encrypt round-trip — TCKE1 at rest, decrypt on apply` — `tests/e2e/encrypt.e2e.test.ts` (Case c2), `skipIf(darwin)` until `TUCK_KEYSTORE=fallback` proves out the Keychain-free path on macOS too.
+8. `ci: add e2e job (build-once → test:e2e) across ubuntu/macos/windows` — `.github/workflows/ci.yml`.
+
+Each commit ends with:
+```
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## 9. Open Questions / Decisions to Confirm Before Coding
+
+1. **Encrypt prerequisite scope (commit 6):** confirm appetite for the two small source seams (`TUCK_PASSWORD` non-TTY fallback in `encryption setup`; `TUCK_KEYSTORE=fallback` override). Without them the encrypt round-trip cannot be hermetic on any OS, and is impossible on macOS CI. If out of scope now, ship cases (a)/(b)/(c1) and leave (c2) as a `it.todo` with this plan referenced.
+2. **`dts` build time:** if `pnpm build` (with `dts:true`) makes `pretest:e2e` slow, add `build:e2e: tsup --no-dts` and point `pretest:e2e` at it. Functionally optional.
+3. **Coverage ratchet (audit P2 §5.10):** once e2e lands, raise `vitest.config.ts` thresholds gradually — e2e itself isn't instrumented, but it de-risks raising the unit thresholds.
+
+**Net:** Cases (a), (b), (c1) are implementable against the binary **today** with zero source changes (modulo the `hasGit()` skip and git-identity env). Case (c2) requires the small encryption seam in commit 6 and a macOS skip — the test is written first and specifies that missing seam, which is the harness doing its job.

--- a/docs/superpowers/plans/2026-06-03-templating-and-decrypt-on-apply.md
+++ b/docs/superpowers/plans/2026-06-03-templating-and-decrypt-on-apply.md
@@ -1,0 +1,492 @@
+# Templating + Decrypt-on-Apply Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `template:true` files render and `encrypted:true` files decrypt when written to the live system by `tuck apply`/`tuck restore`, expose `tuck add --template/--encrypt`, and stop `tuck sync` from clobbering the repo source of these one-directional files.
+
+**Architecture:** A single shared `materializeForLive(repoBytes, file, ctx, deps)` transform (decrypt → render) is the only place repo→live content conversion happens. `apply` and `restore` route single-file writes through it; `stateModel` uses it to compute the expected live content so status/verify don't show false drift; `sync.detectChanges` skips materialized files (capture is one-directional). The read side (decrypt/render) is built before the write side (`add --encrypt`) so encryption can never create a file the apply path can't decrypt.
+
+**Tech Stack:** TypeScript (ESM, strict), Vitest, Node crypto (AES-256-GCM/PBKDF2 via existing `fileEncryption.ts`), per-OS keystore (`crypto/keystore`), `renderTemplate` (`lib/template.ts`).
+
+Reference spec: `docs/superpowers/specs/2026-06-03-templating-and-decrypt-on-apply-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `src/lib/materialize.ts` — the repo→live transform + `MaterializeError`-using logic. One responsibility: "given repo bytes + a tracked-file's flags + context, produce the bytes that belong on the live system."
+- **Modify** `src/errors.ts` — add `MaterializeError extends TuckError`.
+- **Modify** `src/commands/apply.ts` — thread `TemplateContext` + `getPassphrase` into `applyWithMerge`/`applyWithReplace`; materialize before `resolveFileSecrets`; ensure `ApplyFile` carries `template`/`encrypted`.
+- **Modify** `src/commands/restore.ts` — materialize single-file writes (currently a raw `copyFileOrDir`).
+- **Modify** `src/lib/stateModel.ts` — compare materialized files as `live vs materialize(repo)`, degrade gracefully when the keystore is locked.
+- **Modify** `src/commands/sync.ts` — `detectChanges` skips `template||encrypted` files with a warning.
+- **Modify** `src/commands/add.ts` + `src/types.ts` + `src/lib/fileTracking.ts` — `--template`/`--encrypt` flags; encrypt-on-store; set manifest flags.
+- **Create** tests alongside: `tests/lib/materialize.test.ts`, plus additions to `tests/commands/{apply,restore,sync,add}.test.ts` and `tests/lib/stateModel.test.ts`.
+
+Conventions to follow: existing tests use Vitest + `tests/utils/factories.ts` + `tests/utils/testHelpers.ts` (temp HOME / temp tuck dir). Mirror the closest existing test file for setup.
+
+---
+
+## Task 1: `materializeForLive` foundation + `MaterializeError`
+
+**Files:**
+- Modify: `src/errors.ts`
+- Create: `src/lib/materialize.ts`
+- Test: `tests/lib/materialize.test.ts`
+
+- [ ] **Step 1: Add the error class** in `src/errors.ts` next to the other `TuckError` subclasses:
+
+```ts
+export class MaterializeError extends TuckError {
+  constructor(source: string, reason: string) {
+    super(
+      `Cannot materialize ${source}: ${reason}`,
+      'MATERIALIZE_FAILED',
+      ['Check the encryption password (tuck encryption setup)', 'Verify the repo file is not corrupted']
+    );
+  }
+}
+```
+(Match the exact `TuckError` constructor signature already used in the file — adjust arg order if it differs, e.g. `(message, code, suggestions)`.)
+
+- [ ] **Step 2: Write the failing test** `tests/lib/materialize.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { materializeForLive } from '../../src/lib/materialize.js';
+import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
+import { MaterializeError } from '../../src/errors.js';
+
+const ctx = { os: 'darwin', hostname: 'mac1' };
+const deps = (pass: string | null = 'pw') => ({ getPassphrase: async () => pass });
+
+describe('materializeForLive', () => {
+  it('renders a template file using the context', async () => {
+    const repo = Buffer.from('host={{hostname}} os={{os}}');
+    const out = await materializeForLive(repo, { template: true, encrypted: false, source: '~/.x' }, ctx, deps());
+    expect(out).toBe('host=mac1 os=darwin');
+  });
+
+  it('passes plain non-template files through unchanged', async () => {
+    const repo = Buffer.from('literal {{not-a-var-because-not-template}}');
+    const out = await materializeForLive(repo, { template: false, encrypted: false, source: '~/.x' }, ctx, deps());
+    expect(out).toBe('literal {{not-a-var-because-not-template}}');
+  });
+
+  it('decrypts an encrypted file', async () => {
+    const repo = await encryptFileContent(Buffer.from('secret-body'), 'pw');
+    const out = await materializeForLive(repo, { template: false, encrypted: true, source: '~/.s' }, ctx, deps('pw'));
+    expect(out).toBe('secret-body');
+  });
+
+  it('decrypts THEN renders for encrypted+template files', async () => {
+    const repo = await encryptFileContent(Buffer.from('os={{os}}'), 'pw');
+    const out = await materializeForLive(repo, { template: true, encrypted: true, source: '~/.s' }, ctx, deps('pw'));
+    expect(out).toBe('os=darwin');
+  });
+
+  it('throws MaterializeError when an encrypted file has no passphrase', async () => {
+    const repo = await encryptFileContent(Buffer.from('x'), 'pw');
+    await expect(
+      materializeForLive(repo, { template: false, encrypted: true, source: '~/.s' }, ctx, deps(null))
+    ).rejects.toBeInstanceOf(MaterializeError);
+  });
+
+  it('throws on wrong passphrase (never returns ciphertext)', async () => {
+    const repo = await encryptFileContent(Buffer.from('x'), 'right');
+    await expect(
+      materializeForLive(repo, { template: false, encrypted: true, source: '~/.s' }, ctx, deps('wrong'))
+    ).rejects.toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 3: Run it, verify it fails**
+
+Run: `pnpm vitest run tests/lib/materialize.test.ts`
+Expected: FAIL — `materializeForLive` not found.
+
+- [ ] **Step 4: Implement** `src/lib/materialize.ts`:
+
+```ts
+import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
+import { renderTemplate, type TemplateContext } from './template.js';
+import { isEncryptedFile, decryptFileContent } from './crypto/fileEncryption.js';
+import { MaterializeError } from '../errors.js';
+
+export interface MaterializeDeps {
+  /** Returns the file-encryption passphrase, or null if none is configured/available. */
+  getPassphrase: () => Promise<string | null>;
+}
+
+export type MaterializableFile = Pick<TrackedFileOutput, 'template' | 'encrypted' | 'source'>;
+
+/**
+ * Convert a repo file's raw bytes into the content that belongs on the live
+ * system. Order: decrypt -> render template. Secret-placeholder resolution stays
+ * in apply and runs AFTER this step. Text-oriented (dotfiles are text); callers
+ * handle directories/binary separately.
+ */
+export const materializeForLive = async (
+  repoBytes: Buffer,
+  file: MaterializableFile,
+  ctx: TemplateContext,
+  deps: MaterializeDeps
+): Promise<string> => {
+  let bytes = repoBytes;
+  if (file.encrypted || isEncryptedFile(repoBytes)) {
+    const pass = await deps.getPassphrase();
+    if (!pass) throw new MaterializeError(file.source, 'no encryption password configured');
+    try {
+      bytes = await decryptFileContent(bytes, pass);
+    } catch (err) {
+      throw new MaterializeError(file.source, err instanceof Error ? err.message : 'decryption failed');
+    }
+  }
+  let text = bytes.toString('utf8');
+  if (file.template) text = renderTemplate(text, ctx);
+  return text;
+};
+
+/** Shared passphrase getter: the single per-OS keystore "encryption password". */
+export const keystorePassphrase = async (): Promise<string | null> => {
+  const { getKeystore, TUCK_SERVICE, TUCK_ACCOUNT } = await import('./crypto/keystore/index.js');
+  return (await getKeystore()).retrieve(TUCK_SERVICE, TUCK_ACCOUNT);
+};
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `pnpm vitest run tests/lib/materialize.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: typecheck + commit**
+
+```bash
+pnpm typecheck
+git add src/lib/materialize.ts src/errors.ts tests/lib/materialize.test.ts
+git commit -m "feat(materialize): add repo->live decrypt+render transform
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire materialize into `apply` (render + decrypt on apply)
+
+**Files:**
+- Modify: `src/commands/apply.ts` (ApplyFile interface; `applyWithMerge`/`applyWithReplace`; both call sites at ~1050 and ~1170)
+- Test: `tests/commands/apply.test.ts`
+
+- [ ] **Step 1: Write failing tests** in `tests/commands/apply.test.ts` (follow the file's existing temp-HOME/manifest setup; craft repo files + a manifest with the flags set, then run the apply path):
+
+```ts
+it('renders a template file on apply (P0-1)', async () => {
+  // Arrange: repo file containing {{os}}, manifest entry template:true (use factories).
+  // Act: run the apply/replace path against a temp HOME.
+  // Assert: the written live file contains process.platform, NOT the literal "{{os}}".
+});
+
+it('decrypts an encrypted file on apply (P0-2)', async () => {
+  // Arrange: repo file = encryptFileContent("plain-body","pw"); manifest encrypted:true;
+  //          stub keystorePassphrase()/getPassphrase to return "pw".
+  // Assert: the written live file equals "plain-body" (decrypted), not ciphertext.
+});
+```
+(Use the same stubbing approach the suite already uses for keystore/secret backends; assert on file contents read back from the temp HOME.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm vitest run tests/commands/apply.test.ts`
+Expected: FAIL — template literal still present / file is ciphertext.
+
+- [ ] **Step 3: Implement.** (a) Ensure `ApplyFile` includes `template: boolean` and `encrypted: boolean`, populated by `prepareFilesToApply` from the manifest entry. (b) Build context + passphrase getter once and pass them into both apply functions:
+
+```ts
+// near the top of apply.ts
+import { materializeForLive, keystorePassphrase } from '../lib/materialize.js';
+import { renderTemplate, defaultTemplateContext } from '../lib/template.js';
+import { loadConfig } from '../lib/config.js';
+import { MaterializeError } from '../errors.js';
+
+// helper used by both apply functions:
+const buildMaterializeCtx = async (tuckDir: string) => {
+  const config = await loadConfig(tuckDir);
+  return defaultTemplateContext(config.templates?.variables ?? {});
+};
+```
+
+In `applyWithMerge` and `applyWithReplace`, replace the single-file read:
+
+```ts
+// BEFORE:
+let fileContent = await readFile(file.repoPath, 'utf-8');
+// AFTER:
+let fileContent: string;
+try {
+  const raw = await readFile(file.repoPath);
+  fileContent = await materializeForLive(raw, file, ctx, { getPassphrase: keystorePassphrase });
+} catch (err) {
+  if (err instanceof MaterializeError) {
+    logger.warning?.(err.message);
+    result.filesWithPlaceholders.push({ path: collapsePath(file.destination), placeholders: ['<decrypt-failed>'] });
+    continue; // never write ciphertext/partial output
+  }
+  throw err;
+}
+```
+Thread `ctx` in by changing the signatures to `applyWith*(files, dryRun, ctx)` and building `ctx = await buildMaterializeCtx(getTuckDir())` at both call sites (~1050, ~1170) before dispatch. The existing `resolveFileSecrets` call stays immediately after (secrets resolve on the already-rendered/decrypted text).
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `pnpm vitest run tests/commands/apply.test.ts`
+Expected: PASS (new + existing apply tests).
+
+- [ ] **Step 5: commit**
+
+```bash
+pnpm typecheck
+git add src/commands/apply.ts tests/commands/apply.test.ts
+git commit -m "feat(apply): render templates and decrypt encrypted files on apply (P0-1/P0-2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire materialize into `restore` (parity with apply)
+
+**Files:**
+- Modify: `src/commands/restore.ts` (single-file write at ~282; `prepareFilesToRestore` to carry flags)
+- Test: `tests/commands/restore.test.ts`
+
+- [ ] **Step 1: Write failing tests** mirroring Task 2's two assertions but via the restore path (template renders; encrypted decrypts).
+
+- [ ] **Step 2: Run, verify fail** — `pnpm vitest run tests/commands/restore.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement.** For single (non-directory) files, replace the raw copy:
+
+```ts
+// restore.ts, single-file branch (~282)
+// BEFORE: await copyFileOrDir(file.destination /* repo copy */, targetPath, { overwrite: true });
+// AFTER:
+if ((await stat(repoCopyPath)).isDirectory()) {
+  await copyFileOrDir(repoCopyPath, targetPath, { overwrite: true });
+} else {
+  const raw = await readFile(repoCopyPath);
+  const content = await materializeForLive(raw, file, ctx, { getPassphrase: keystorePassphrase });
+  await ensureDir(dirname(targetPath));
+  await writeFile(targetPath, content, 'utf-8');
+}
+```
+Build `ctx` once in the restore entry (same `buildMaterializeCtx` helper — export it from a shared spot or duplicate the 2-line build). Carry `template`/`encrypted` onto the restore file descriptor from the manifest. Wrap in the same `MaterializeError` guard (log + skip the one file, never write ciphertext).
+
+- [ ] **Step 4: Run, verify pass** — `pnpm vitest run tests/commands/restore.test.ts` → PASS.
+
+- [ ] **Step 5: commit**
+
+```bash
+pnpm typecheck
+git add src/commands/restore.ts tests/commands/restore.test.ts
+git commit -m "feat(restore): materialize (render+decrypt) on restore for apply parity
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Materialize-aware `stateModel` (no false drift; stale templates flagged)
+
+**Files:**
+- Modify: `src/lib/stateModel.ts` (`computeFileState`)
+- Test: `tests/lib/stateModel.test.ts`
+
+- [ ] **Step 1: Write failing tests:**
+
+```ts
+it('reports a correctly-applied template file as ok (not drift-local)', async () => {
+  // repo file "{{os}}"; live file = process.platform; manifest template:true
+  // expect computeFileState(...).state === 'ok'
+});
+it('reports an edited live template as drift-local (needs apply)', async () => {
+  // live file = "hand edited"; expect state === 'drift-local'
+});
+it('degrades to ok-by-presence for an encrypted file when the keystore is locked', async () => {
+  // encrypted:true, getPassphrase -> null, both sides exist; expect state === 'ok' (no throw)
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `pnpm vitest run tests/lib/stateModel.test.ts` → FAIL (template file currently reports drift-local).
+
+- [ ] **Step 3: Implement** a branch in `computeFileState` before the plain `classifyFileState`:
+
+```ts
+if ((file.template || file.encrypted) && repoChecksum !== null && liveChecksum !== null) {
+  // Compare live against the MATERIALIZED repo content, not the raw repo bytes.
+  try {
+    const raw = await readFile(repoAbs);
+    const ctx = defaultTemplateContext(/* config vars threaded by caller, or built here */);
+    const expected = await materializeForLive(raw, file, ctx, { getPassphrase: keystorePassphrase });
+    const expectedChecksum = sha256Hex(Buffer.from(expected, 'utf8'));
+    const liveMatches = liveChecksum === expectedChecksum;
+    const state: FileState = !liveMatches
+      ? 'drift-local'                                   // remedy: tuck apply (presentation layer)
+      : repoChecksum !== file.checksum ? 'drift-repo' : 'ok';
+    return { id, source: file.source, destination: file.destination, state, liveChecksum, repoChecksum, manifestChecksum: file.checksum };
+  } catch {
+    // Locked keystore / undecryptable: degrade to presence-based ok rather than failing status/verify.
+    return { id, source: file.source, destination: file.destination, state: 'ok', liveChecksum, repoChecksum, manifestChecksum: file.checksum };
+  }
+}
+```
+(Use the project's existing checksum helper for `sha256Hex`/`getFileChecksum`-on-buffer; if only a path-based `getFileChecksum` exists, hash the buffer with `createHash('sha256')` to match its format. Verify the format matches `getFileChecksum` so comparisons are valid.)
+
+- [ ] **Step 4: Run, verify pass** — `pnpm vitest run tests/lib/stateModel.test.ts` → PASS.
+
+- [ ] **Step 5: commit**
+
+```bash
+pnpm typecheck
+git add src/lib/stateModel.ts tests/lib/stateModel.test.ts
+git commit -m "feat(stateModel): compare template/encrypted files vs materialize(repo)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `sync` capture guard (the safety guard — never clobber/leak)
+
+**Files:**
+- Modify: `src/commands/sync.ts` (`detectChanges`, ~90-150)
+- Test: `tests/commands/sync.test.ts`
+
+- [ ] **Step 1: Write the failing safety test:**
+
+```ts
+it('does NOT capture template files live->repo (source not clobbered)', async () => {
+  // Arrange: track a template file (manifest template:true); repo source = "{{os}}".
+  //          Write a DIFFERENT live file (simulating a rendered/edited copy).
+  // Act: detectChanges(tuckDir) (or run the sync change-detection path).
+  // Assert: the template file is NOT in the returned changes; repo source bytes unchanged.
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — the template file currently appears as a change.
+
+- [ ] **Step 3: Implement** — in `detectChanges`, skip materialized files:
+
+```ts
+for (const [id, file] of Object.entries(manifest.files)) {
+  if (file.template || file.encrypted) {
+    addJsonWarning?.(`${file.source} is ${file.template ? 'a template' : 'encrypted'}; live edits are not captured — edit the repo source and run \`tuck apply\``);
+    continue; // one-directional: repo is the source of truth
+  }
+  // ... existing change-detection ...
+}
+```
+(Use the existing warning channel the file already imports — `addJsonWarning` for JSON mode and/or `logger.warning`; match the file's pattern. Place the skip before the `getFileChecksum` work.)
+
+- [ ] **Step 4: Run, verify pass** — `pnpm vitest run tests/commands/sync.test.ts` → PASS.
+
+- [ ] **Step 5: commit**
+
+```bash
+pnpm typecheck
+git add src/commands/sync.ts tests/commands/sync.test.ts
+git commit -m "fix(sync): never capture template/encrypted files live->repo (no clobber/leak)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `add --template` / `add --encrypt` flags (write side, last)
+
+**Files:**
+- Modify: `src/types.ts` (`AddOptions`: add `template?: boolean; encrypt?: boolean`)
+- Modify: `src/commands/add.ts` (options at 298-317; pass through `addFiles`→`trackFilesWithProgress`)
+- Modify: `src/lib/fileTracking.ts` (accept `template`/`encrypt`; encrypt-on-store; set manifest flags at :281-282 instead of hardcoded `false`)
+- Test: `tests/commands/add.test.ts`
+
+- [ ] **Step 1: Write failing tests:**
+
+```ts
+it('add --template sets template:true in the manifest', async () => { /* assert manifest.files[id].template === true */ });
+it('add --encrypt stores TCKE1 ciphertext and sets encrypted:true', async () => {
+  // stub keystore passphrase = "pw"; after add, the repo copy must satisfy isEncryptedFile()
+  // and decryptFileContent(repoBytes,"pw") === original live content.
+});
+it('add --encrypt errors clearly when no passphrase is configured', async () => { /* getPassphrase -> null => throws */ });
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.** Add the two `commander` options:
+
+```ts
+.option('--template', 'Track as a template (rendered on apply; sync will not capture live edits)')
+.option('--encrypt', 'Encrypt the file at rest in the repo (decrypted on apply)')
+```
+Add `template?: boolean; encrypt?: boolean` to `AddOptions` (`src/types.ts`). Thread them through `addFiles` → `FileTrackingOptions` → `trackFilesWithProgress`. In `trackFilesWithProgress` (`fileTracking.ts`), un-comment the `encrypt`/`template` options (`:59-68`, `:143-147`) and, in the copy branch:
+
+```ts
+if (encrypt) {
+  const pass = await keystorePassphrase();
+  if (!pass) throw new EncryptionError('No encryption password set. Run `tuck encryption setup` first.');
+  const plaintext = await readFile(expandedPath);
+  await ensureDir(dirname(destination));
+  await writeFile(destination, await encryptFileContent(plaintext, pass));
+} else {
+  await copyFileOrDir(expandedPath, destination, { overwrite: true });
+}
+```
+and set the manifest fields (replace `:281-282`):
+
+```ts
+encrypted: Boolean(encrypt),
+template: Boolean(template),
+```
+(`checksum = getFileChecksum(destination)` already hashes the stored bytes, so it correctly hashes ciphertext for encrypted files. Symlink strategy is incompatible with `--encrypt` — reject that combination with a clear error, mirroring the existing `--symlink --repo` guard in `add.ts:27-31`.)
+
+- [ ] **Step 4: Run, verify pass** — `pnpm vitest run tests/commands/add.test.ts` → PASS.
+
+- [ ] **Step 5: commit**
+
+```bash
+pnpm typecheck
+git add src/types.ts src/commands/add.ts src/lib/fileTracking.ts tests/commands/add.test.ts
+git commit -m "feat(add): --template and --encrypt flags (encrypt-on-store)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full green gate
+
+- [ ] **Step 1:** `pnpm typecheck` → clean.
+- [ ] **Step 2:** `pnpm lint` → clean (fix any new lint; do not introduce `no-useless-escape` etc.).
+- [ ] **Step 3:** `pnpm test` → all green (existing 831 + new). Investigate any regression before proceeding.
+- [ ] **Step 4:** `pnpm build` → succeeds (tsup).
+- [ ] **Step 5: docs** — add a short "Templates & Encryption" section to README/docs noting: repo stores the source, apply renders/decrypts, sync does not capture these files (edit the source + apply), one keystore password drives `--encrypt`.
+- [ ] **Step 6: final commit**
+
+```bash
+git add -A
+git commit -m "docs+chore: document templating/encryption flow; green gate
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (against the spec)
+
+- **Spec §4.1 materialize** → Task 1. ✅
+- **Spec §4.2 passphrase / §4.3 context** → Task 1 (`keystorePassphrase`) + Task 2 (`buildMaterializeCtx` using `config.templates.variables`). ✅
+- **Spec §5 apply** → Task 2; **restore** → Task 3; **stateModel** → Task 4; **sync guard** → Task 5; **add flags + encrypt-on-store** → Task 6; **errors.ts** → Task 1. ✅
+- **Spec §6 error handling** (never write ciphertext/partial; stateModel degrades; render is total) → Tasks 2/3 guard + Task 4 degrade. ✅
+- **Spec §7 testing** (materialize units, apply render+decrypt, restore parity, sync-skip safety, add flags, stateModel) → Tasks 1-6 each have the matching test. ✅
+- **Type consistency:** `materializeForLive(repoBytes, file, ctx, deps)`, `MaterializeDeps.getPassphrase`, `keystorePassphrase()`, `defaultTemplateContext(vars)` are used identically across Tasks 1-4. ✅
+- **Open detail to confirm during impl (not a placeholder):** the exact `getFileChecksum` hashing so Task 4's buffer hash matches; the exact `ApplyFile`/restore-descriptor field plumbing for `template`/`encrypted`. Both are read-and-match, not design decisions.

--- a/docs/superpowers/specs/2026-06-03-templating-and-decrypt-on-apply-design.md
+++ b/docs/superpowers/specs/2026-06-03-templating-and-decrypt-on-apply-design.md
@@ -1,0 +1,188 @@
+# Templating + Decrypt-on-Apply — Design Spec (2026-06-03)
+
+> Status: **approved** (brainstorming, 2026-06-03). Implements P0-1 and P0-2 from
+> `docs/CHEZMOI-PARITY-AUDIT-2026-06.md`. Scope guidance from the user: **smallest
+> change that is still safe** — "apply-only" plus the minimal guards required so we
+> never silently lose data or leak secrets (tuck's Critical Rules).
+
+## 1. Problem
+
+tuck already ships a complete, tested template engine (`src/lib/template.ts`) and a
+complete file-encryption subsystem (`src/lib/crypto/fileEncryption.ts`, TCKE1 /
+AES-256-GCM, plus a per-OS keystore). **Neither is wired into the lifecycle:**
+
+- `renderTemplate` is referenced only by `template.ts` and `preset.ts` — **never by
+  `apply.ts` or `restore.ts`**. The manifest `template` flag is hardcoded `false`
+  (`fileTracking.ts:282`) and never read at apply time.
+- `apply.ts` contains no decrypt path, so an encrypted repo file (TCKE1 ciphertext)
+  would be written to the live system **as raw ciphertext**.
+
+So tuck's flagship "one repo, many machines" capability and its whole-file encryption
+do not actually work for tracked dotfiles.
+
+### The bidirectional hazard (why this needs a guard, not just a wire-up)
+
+tuck keeps **live ↔ repo** in sync bidirectionally. For a *materialized* file the
+repo holds the **source** (template text / ciphertext) and the live file holds the
+**materialized output** (rendered text / plaintext) — they intentionally differ.
+`sync.detectChanges` compares `checksum(live)` vs `checksum(repo)`
+(`sync.ts:136`); for these files that always differs, so `syncFiles` would copy the
+live file back over the repo source (`sync.ts:484`):
+
+- **template** → the rendered output (with this machine's `os`, `hostname`, …) overwrites
+  the `{{ }}` source. Source destroyed → violates *"never lose data / never silently overwrite."*
+- **encrypted** → **plaintext** is written into the repo. Secret leak → violates
+  *"never store secrets."*
+
+Therefore wiring rendering/decryption into `apply` **requires** a matching guard on the
+capture (live→repo) side. That guard is the only deviation from a literal "apply-only" change.
+
+## 2. Goals / Non-goals
+
+**Goals (P0)**
+- `tuck apply` and `tuck restore` render `template:true` files and decrypt `encrypted:true`
+  files before writing to the live system.
+- `tuck add --template` / `tuck add --encrypt` set the manifest flags (and `--encrypt`
+  stores TCKE1 ciphertext in the repo).
+- `tuck sync` never captures `template`/`encrypted` files live→repo (one-directional;
+  warns). This is the safety guard.
+- `tuck status` / `tuck verify` compare these files as `live vs materialize(repo)` so they
+  do not show as permanent false drift, and a stale template surfaces as "needs apply."
+
+**Non-goals (explicit fast-follows, NOT this spec)**
+- `tuck edit` (decrypt→edit→re-encrypt loop) — separate P1 item.
+- Re-encrypt-on-sync / auto-reverse-templating (bidirectional capture for materialized files).
+- A dedicated `.tuckdata.{yaml,toml,json}` machine-data file — separate P1.
+- age/GPG interop, autotemplate (auto-substitution on add), binary-file encryption.
+
+## 3. Model (the decision)
+
+**Materialized files are repo-authoritative and one-directional.** The repo copy is the
+source of truth; the live file is a derived artifact recomputed by `apply`/`restore`.
+You change such a file by editing the **repo source** (directly today; via `tuck edit`
+later) and running `apply`. `sync` will not capture live edits to them (it warns and
+points you at the source). This matches `template.ts`'s own header comment ("the file
+tracked in the repo is always the templated source") and chezmoi's source→target model.
+
+## 4. Architecture
+
+One shared transform converts a repo file into its live form. Both `apply` and `restore`
+single-file writes route through it; `stateModel` uses it to compute the expected live
+content for comparison.
+
+### 4.1 New module: `src/lib/materialize.ts`
+
+```ts
+import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
+import type { TemplateContext } from './template.js';
+
+export interface MaterializeDeps {
+  /** Returns the file-encryption passphrase, or null if none is configured/available. */
+  getPassphrase: () => Promise<string | null>;
+}
+
+/**
+ * Convert a repo file's raw bytes into the content that should land on the live
+ * system. Order: decrypt → render template. Secret-placeholder resolution stays
+ * in apply (it already runs there) and happens after this step.
+ *
+ * Throws MaterializeError on a required-but-failed decryption (wrong/absent
+ * passphrase, bad ciphertext) — the caller must NOT write partial/ciphertext output.
+ */
+export const materializeForLive = async (
+  repoBytes: Buffer,
+  file: Pick<TrackedFileOutput, 'template' | 'encrypted' | 'source'>,
+  ctx: TemplateContext,
+  deps: MaterializeDeps
+): Promise<string> => {
+  let bytes = repoBytes;
+  if (file.encrypted || isEncryptedFile(repoBytes)) {
+    const pass = await deps.getPassphrase();
+    if (!pass) throw new MaterializeError(file.source, 'no encryption password configured');
+    bytes = await decryptFileContent(bytes, pass); // throws DecryptionError on failure
+  }
+  let text = bytes.toString('utf8');
+  if (file.template) text = renderTemplate(text, ctx);
+  return text;
+};
+```
+
+Notes:
+- Single-file, text-oriented (dotfiles are text; matches apply's existing `readFile(..,'utf-8')`
+  assumption). Directories and binary files are not materialized (copied verbatim, as today).
+- `isEncryptedFile` is also checked defensively so a mislabeled file still decrypts rather
+  than shipping ciphertext.
+- A tiny `MaterializeError` is added to `errors.ts` (extends `TuckError`) so callers can
+  fail one file loudly with the path and a remedy, without aborting the whole apply.
+
+### 4.2 Passphrase source
+
+`getPassphrase` = `(await getKeystore()).retrieve(TUCK_SERVICE, TUCK_ACCOUNT)`
+(`crypto/keystore`). This is the single "encryption password" tuck already stores per-OS.
+`null` means none is set → encrypted files fail with "run `tuck encryption setup`". (The dead
+scrypt backup scheme in `crypto/manager.ts` is untouched and out of scope.)
+
+### 4.3 Template context
+
+`defaultTemplateContext(config.templates.variables)` — the existing built-ins
+(`os, arch, hostname, user, home, ci`) merged with the user's `config.templates.variables`
+(`config.schema.ts:71`, a `Record<string,string>`, currently inert). Built once per
+command and threaded in.
+
+## 5. Component changes
+
+| File | Change |
+|---|---|
+| `src/lib/materialize.ts` (new) | `materializeForLive` + `MaterializeError`. |
+| `src/commands/apply.ts` | In `applyWithMerge`/`applyWithReplace`, replace `readFile(repoPath,'utf-8')` with `materializeForLive(readFile(repoPath), file, ctx, deps)`; keep the existing `resolveFileSecrets` step **after** it. Build `ctx` + `getPassphrase` once at command entry. On `MaterializeError`/`DecryptionError`: record the file as failed, never write. |
+| `src/commands/restore.ts` | Route single-file writes (`restore.ts:282`) through `materializeForLive` instead of raw `copyFileOrDir`; directories still copy verbatim. Same error handling. |
+| `src/commands/add.ts` + `src/lib/fileTracking.ts` | Add `--template` / `--encrypt` options (un-comment `fileTracking.ts:59-68`); thread through `trackFilesWithProgress`. Set `template`/`encrypted` in the manifest instead of hardcoded `false` (`:281-282`). When `--encrypt`: encrypt the bytes with the keystore passphrase before writing to the repo; `checksum` is of the stored (cipher)text, as today. Refuse `--encrypt` with a clear error if no passphrase is set. |
+| `src/commands/sync.ts` | In `detectChanges` (`sync.ts:90`), skip files where `file.template || file.encrypted` from live→repo capture; push a JSON-mode-safe warning ("X is template/encrypted; edit the repo source and run `tuck apply`"). |
+| `src/lib/stateModel.ts` | In `computeFileState`, for `template`/`encrypted` files compare `liveChecksum` against `checksum(materializeForLive(repoBytes, …))` rather than the raw `repoChecksum`; keep the raw `repoChecksum` vs `manifestChecksum` check for `drift-repo`. If the passphrase is unavailable for an encrypted file, degrade to "ok-by-presence" (both sides exist → `ok`) rather than throwing. Template-only files need no passphrase (render is pure). When such a file differs from `materialize(repo)` it classifies as `drift-local`, but `status`/`verify` must present its remedy as **`tuck apply`** (re-render/re-decrypt), not `tuck sync` — since `sync` intentionally skips these files. |
+| `src/schemas/manifest.schema.ts` | No change — `template`/`encrypted` already exist (`:11-12`). |
+| `src/errors.ts` | Add `MaterializeError`. |
+
+## 6. Error handling
+
+- Decrypt failure (wrong/absent passphrase, corrupt ciphertext) → fail **that file** with
+  its path + remedy; never write ciphertext-as-plaintext or partial output. Apply continues
+  with other files and reports the failure (and a non-zero summary).
+- Template render is total (never throws; unbalanced blocks flush verbatim — see
+  `template.ts:129`), so rendering cannot abort an apply.
+- `stateModel` never throws on a locked keystore (degrades as above) — `status`/`verify`
+  stay usable offline.
+
+## 7. Testing plan (TDD — write tests first)
+
+Unit (`tests/lib/materialize.test.ts`):
+- render-only: `{{os}}` / `tuck:if` substituted using ctx.
+- decrypt-only: a TCKE1 buffer with the right passphrase → plaintext; wrong passphrase → throws, no output.
+- encrypted **and** template: decrypt then render (order asserted).
+- no passphrase + encrypted → `MaterializeError`, nothing written.
+
+Command/integration:
+- `apply`: a `template:true` repo file lands rendered (`{{os}}` → real platform) in a temp HOME.
+- `apply`: a TCKE1 `encrypted:true` repo file lands **decrypted** on disk (not ciphertext).
+- `restore`: same two assertions (proves apply/restore parity through the shared helper).
+- **sync-skip (the safety test)**: add a template file, edit its live copy, run `sync`,
+  assert the **repo source is byte-unchanged** and a warning was emitted.
+- `add --template` / `add --encrypt`: manifest flags set; `--encrypt` stores TCKE1 ciphertext
+  (round-trips via decrypt); `--encrypt` with no passphrase errors.
+- `stateModel`/`status`: a correctly-applied template file reports `ok` (not false `drift-local`);
+  an edited live template reports drift (needs apply).
+
+Gate: `pnpm typecheck && pnpm lint && pnpm test` green before commit; keep existing 831 tests passing.
+
+## 8. Risks & mitigations
+
+- **Binary/non-UTF-8 encrypted files**: out of scope; the transform is text-oriented and such
+  files should be tracked without `--encrypt`/`--template` (documented limitation).
+- **stateModel keystore dependency**: mitigated by the "ok-by-presence" degrade path; template-only
+  files (the common case) need no keystore.
+- **Behavior change for would-be template/encrypted files**: none today, because the flags were
+  never settable; this spec is the first path that sets them, so there is no migration concern.
+
+## 9. Out of scope (tracked fast-follows)
+
+`tuck edit`, re-encrypt-on-sync (bidirectional encrypted capture), `.tuckdata` machine-data file,
+age/GPG interop, autotemplate-on-add. Each is a separate roadmap item.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:security": "vitest run --dir tests/security",
     "test:integration": "vitest run --dir tests/integration",
     "test:unit": "vitest run --dir tests/lib --dir tests/commands",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "bench": "vitest bench --config vitest.bench.config.ts",
     "bench:watch": "vitest bench --config vitest.bench.config.ts --watch",
     "prepare": "husky install",

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -73,6 +73,8 @@ const addFiles = async (
     showCategory: true,
     // Repo scope is always copy; --symlink is rejected upstream for repo adds.
     strategy: options.symlink ? 'symlink' : undefined,
+    encrypt: options.encrypt,
+    template: options.template,
     actionVerb: 'Tracking',
   });
 };
@@ -301,6 +303,8 @@ export const addCommand = new Command('add')
   .option('-c, --category <name>', 'Category to organize under')
   .option('-n, --name <name>', 'Custom name for the file in manifest')
   .option('--symlink', 'Copy into tuck repo, then replace source path with a symlink')
+  .option('--template', 'Mark as a template: rendered on apply (sync will not capture live edits)')
+  .option('--encrypt', 'Encrypt the file at rest in the repo (decrypted on apply; needs an encryption password)')
   .option(
     '--repo [dir]',
     'Track as repo-scoped (file lives in a git repo; auto-detects the root from the path when no dir is given)'

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -31,9 +31,10 @@ import { findPlaceholders, restoreContent, restoreFiles as restoreSecrets, getAl
 import { createResolver } from '../lib/secretBackends/index.js';
 import { loadConfig } from '../lib/config.js';
 import { IS_WINDOWS } from '../lib/platform.js';
-import { RepositoryNotFoundError } from '../errors.js';
+import { RepositoryNotFoundError, MaterializeError } from '../errors.js';
 import { getProvider, type ProviderMode, type RemoteConfig as ProviderRemoteConfig } from '../lib/providers/index.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from '../lib/materialize.js';
 
 // Track if Windows permission warning has been shown this session
 let windowsPermissionWarningShown = false;
@@ -143,6 +144,10 @@ export interface ApplyFile {
   repoTarget?: RepoWriteTarget;
   /** Recorded octal permissions (e.g. "755"), reapplied to the written file. */
   permissions?: string;
+  /** Render the repo source as a template before writing to the live system. */
+  template: boolean;
+  /** Decrypt the repo source (TCKE1) before writing to the live system. */
+  encrypted: boolean;
 }
 
 interface ApplyResult {
@@ -551,6 +556,8 @@ export const prepareFilesToApply = async (
       repoPath: repoFilePath,
       repoTarget,
       permissions: file.permissions,
+      template: file.template,
+      encrypted: file.encrypted,
     });
   }
 
@@ -610,6 +617,8 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
 
   // Get tuck directory for secret resolution
   const tuckDir = getTuckDir();
+  // Template context (built-in vars + config.templates.variables), built once per apply.
+  const ctx = await buildMaterializeCtx(tuckDir);
 
   for (const file of files) {
     // Directory entries are copied as a tree; readFile / secret-resolution /
@@ -619,7 +628,23 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
       result.appliedCount++;
       continue;
     }
-    let fileContent = await readFile(file.repoPath, 'utf-8');
+    let fileContent: string;
+    try {
+      const rawBytes = await readFile(file.repoPath);
+      fileContent = await materializeForLive(rawBytes, file, ctx, { getPassphrase: keystorePassphrase });
+    } catch (err) {
+      // A failed / absent-passphrase decryption must NEVER write ciphertext or
+      // partial output to the live system: skip this file loudly, keep the rest.
+      if (err instanceof MaterializeError) {
+        logger.warning(err.message);
+        result.filesWithPlaceholders.push({
+          path: collapsePath(file.destination),
+          placeholders: ['<materialize-failed>'],
+        });
+        continue;
+      }
+      throw err;
+    }
 
     // Resolve placeholders using configured backend (1Password, Bitwarden, pass, or local)
     const secretsResult = await resolveFileSecrets(fileContent, tuckDir);
@@ -691,6 +716,8 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
 
   // Get tuck directory for secret resolution
   const tuckDir = getTuckDir();
+  // Template context (built-in vars + config.templates.variables), built once per apply.
+  const ctx = await buildMaterializeCtx(tuckDir);
 
   for (const file of files) {
     // Directory entries are copied as a tree; readFile / secret-resolution /
@@ -700,7 +727,23 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       result.appliedCount++;
       continue;
     }
-    let fileContent = await readFile(file.repoPath, 'utf-8');
+    let fileContent: string;
+    try {
+      const rawBytes = await readFile(file.repoPath);
+      fileContent = await materializeForLive(rawBytes, file, ctx, { getPassphrase: keystorePassphrase });
+    } catch (err) {
+      // A failed / absent-passphrase decryption must NEVER write ciphertext or
+      // partial output to the live system: skip this file loudly, keep the rest.
+      if (err instanceof MaterializeError) {
+        logger.warning(err.message);
+        result.filesWithPlaceholders.push({
+          path: collapsePath(file.destination),
+          placeholders: ['<materialize-failed>'],
+        });
+        continue;
+      }
+      throw err;
+    }
 
     // Resolve placeholders using configured backend (1Password, Bitwarden, pass, or local)
     const secretsResult = await resolveFileSecrets(fileContent, tuckDir);

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -33,7 +33,7 @@ import { loadConfig } from '../lib/config.js';
 import { IS_WINDOWS } from '../lib/platform.js';
 import { RepositoryNotFoundError, MaterializeError } from '../errors.js';
 import { getProvider, type ProviderMode, type RemoteConfig as ProviderRemoteConfig } from '../lib/providers/index.js';
-import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from '../lib/materialize.js';
 
 // Track if Windows permission warning has been shown this session
@@ -636,11 +636,12 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
       // A failed / absent-passphrase decryption must NEVER write ciphertext or
       // partial output to the live system: skip this file loudly, keep the rest.
       if (err instanceof MaterializeError) {
+        // Skip the file loudly and write NOTHING. This is NOT an unresolved secret
+        // placeholder — pushing it into filesWithPlaceholders would misreport it
+        // (as "unresolved placeholder, run tuck secrets set") AND trigger a
+        // spurious local-secret restore against a file we never wrote.
         logger.warning(err.message);
-        result.filesWithPlaceholders.push({
-          path: collapsePath(file.destination),
-          placeholders: ['<materialize-failed>'],
-        });
+        if (isJsonMode()) addJsonWarning(err.message);
         continue;
       }
       throw err;
@@ -735,11 +736,12 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       // A failed / absent-passphrase decryption must NEVER write ciphertext or
       // partial output to the live system: skip this file loudly, keep the rest.
       if (err instanceof MaterializeError) {
+        // Skip the file loudly and write NOTHING. This is NOT an unresolved secret
+        // placeholder — pushing it into filesWithPlaceholders would misreport it
+        // (as "unresolved placeholder, run tuck secrets set") AND trigger a
+        // spurious local-secret restore against a file we never wrote.
         logger.warning(err.message);
-        result.filesWithPlaceholders.push({
-          path: collapsePath(file.destination),
-          placeholders: ['<materialize-failed>'],
-        });
+        if (isJsonMode()) addJsonWarning(err.message);
         continue;
       }
       throw err;

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -25,7 +25,7 @@ import { isIgnored } from '../lib/tuckignore.js';
 import type { DiffOptions } from '../types.js';
 import { readFile } from 'fs/promises';
 
-interface FileDiff {
+export interface FileDiff {
   source: string;
   destination: string;
   hasChanges: boolean;
@@ -45,7 +45,7 @@ const isBinary = async (path: string): Promise<boolean> => {
   return await isBinaryExecutable(path);
 };
 
-const getFileDiff = async (tuckDir: string, source: string): Promise<FileDiff | null> => {
+export const getFileDiff = async (tuckDir: string, source: string): Promise<FileDiff | null> => {
   const tracked = await getTrackedFileBySource(tuckDir, source);
   if (!tracked) {
     throw new FileNotFoundError(`Not tracked: ${source}`);

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -14,7 +14,7 @@
 
 import { Command } from 'commander';
 import { createInterface } from 'readline';
-import { getTuckDir, expandPath, collapsePath } from '../lib/paths.js';
+import { getTuckDir, collapsePath } from '../lib/paths.js';
 import { loadManifest, getAllTrackedFiles } from '../lib/manifest.js';
 import {
   addContextFile,
@@ -30,7 +30,8 @@ import { hasDrift, dryApplyIntoSandbox } from './verify.js';
 import { getFileDiff } from './diff.js';
 import { scanForSecrets } from '../lib/secrets/index.js';
 import { snapshotWriteContext, setWriteContext, restoreWriteContext } from '../lib/writeContext.js';
-import { join } from 'path';
+import { resolveLiveTarget } from '../lib/repoScope.js';
+import { join, relative } from 'path';
 
 /** Max accepted stdin line length (1 MiB) — guards against memory abuse. */
 const MAX_LINE_BYTES = 1024 * 1024;
@@ -253,7 +254,12 @@ const tools: ToolDef[] = [
       const tuckDir = getTuckDir();
       await loadManifest(tuckDir);
       const all = await getAllTrackedFiles(tuckDir);
-      const paths = Object.values(all).map((f) => expandPath(f.source));
+      // Resolve each tracked file to its real LIVE path. expandPath would
+      // mis-resolve repo-scoped sources (a stable "key:rel" identity, not a home
+      // path) and silently skip them; resolveLiveTarget returns null for repos not
+      // bound on this machine, which we drop.
+      const resolved = await Promise.all(Object.values(all).map((f) => resolveLiveTarget(f)));
+      const paths = resolved.filter((p): p is string => p !== null);
       const summary = await scanForSecrets(paths, tuckDir);
       return {
         filesWithSecrets: summary.filesWithSecrets,
@@ -312,7 +318,9 @@ const tools: ToolDef[] = [
             wouldEscapeRoot: res.wouldEscapeRoot.length,
           },
           changes: res.changes.map((c) => ({
-            target: collapsePath(c.target),
+            // Sandbox-relative target — the sandbox root is under the OS temp dir,
+            // so collapsePath wouldn't shorten it (it would leak the host temp path).
+            target: c.target.startsWith(sandboxRoot) ? relative(sandboxRoot, c.target) || '.' : collapsePath(c.target),
             status: c.status,
             bytesBefore: c.bytesBefore,
             bytesAfter: c.bytesAfter,

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -14,7 +14,7 @@
 
 import { Command } from 'commander';
 import { createInterface } from 'readline';
-import { getTuckDir } from '../lib/paths.js';
+import { getTuckDir, expandPath, collapsePath } from '../lib/paths.js';
 import { loadManifest, getAllTrackedFiles } from '../lib/manifest.js';
 import {
   addContextFile,
@@ -25,6 +25,12 @@ import { detectDotfiles } from '../lib/detect.js';
 import { getStatus } from '../lib/git.js';
 import { VERSION } from '../constants.js';
 import { setJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { computeStateModel, summarizeStateModel } from '../lib/stateModel.js';
+import { hasDrift, dryApplyIntoSandbox } from './verify.js';
+import { getFileDiff } from './diff.js';
+import { scanForSecrets } from '../lib/secrets/index.js';
+import { snapshotWriteContext, setWriteContext, restoreWriteContext } from '../lib/writeContext.js';
+import { join } from 'path';
 
 /** Max accepted stdin line length (1 MiB) — guards against memory abuse. */
 const MAX_LINE_BYTES = 1024 * 1024;
@@ -159,6 +165,167 @@ const tools: ToolDef[] = [
       return { agent: classifyAgentPath(String(args.path)) };
     },
   },
+  {
+    name: 'verify',
+    description:
+      'Verify that the live system, the repo, and the manifest agree. Reports per-file drift state and a ' +
+      'summary. `drift:true` mirrors `tuck verify --exit-code` (the CI gate) as a boolean — the server never exits.',
+    inputSchema: { type: 'object', properties: {} },
+    handler: async () => {
+      const tuckDir = getTuckDir();
+      await loadManifest(tuckDir); // throws → caught → isError tool result
+      const entries = await computeStateModel(tuckDir);
+      const summary = summarizeStateModel(entries);
+      return {
+        summary,
+        drift: hasDrift(summary),
+        files: entries.map((e) => ({ source: e.source, state: e.state })),
+      };
+    },
+  },
+  {
+    name: 'diff',
+    description:
+      'Preview which tracked files differ between the live system and the repo. Returns METADATA ONLY ' +
+      '(sizes/flags); file contents are elided to keep the response small and avoid leaking secret-bearing lines.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        paths: { type: 'array', description: 'Limit to these tracked source paths (default: all tracked files)' },
+        category: { type: 'string', description: 'Limit to a single category' },
+      },
+    },
+    handler: async (args) => {
+      const tuckDir = getTuckDir();
+      const all = await getAllTrackedFiles(tuckDir);
+      const paths = Array.isArray(args.paths) ? (args.paths as unknown[]).map(String) : null;
+      const category = args.category ? String(args.category) : undefined;
+      const wanted = Object.values(all).filter(
+        (f) => (!paths || paths.includes(f.source)) && (!category || f.category === category)
+      );
+      const files: Array<Record<string, unknown>> = [];
+      for (const f of wanted) {
+        // getFileDiff is read-only; swallow per-file errors (permission/missing) so
+        // one unreadable file never aborts the whole preview.
+        const d = await getFileDiff(tuckDir, f.source).catch(() => null);
+        if (d && d.hasChanges) {
+          files.push({
+            source: d.source,
+            destination: d.destination,
+            isBinary: d.isBinary ?? false,
+            isDirectory: d.isDirectory ?? false,
+            systemSize: d.systemSize,
+            repoSize: d.repoSize,
+          });
+        }
+      }
+      return { count: files.length, files };
+    },
+  },
+  {
+    name: 'scan_untracked',
+    description:
+      'List dotfiles detected on this system that tuck does NOT yet track (the actionable delta). Each entry ' +
+      'carries a `sensitive` flag so an agent knows which to review before adding.',
+    inputSchema: { type: 'object', properties: { category: { type: 'string' } } },
+    handler: async (args) => {
+      const tuckDir = getTuckDir();
+      const all = await getAllTrackedFiles(tuckDir);
+      const tracked = new Set(Object.values(all).map((f) => f.source));
+      const category = args.category ? String(args.category) : undefined;
+      const detected = await detectDotfiles();
+      const untracked = detected.filter(
+        (d) => !tracked.has(d.path) && (!category || d.category === category)
+      );
+      return {
+        count: untracked.length,
+        files: untracked.map((d) => ({ path: d.path, category: d.category, sensitive: d.sensitive })),
+      };
+    },
+  },
+  {
+    name: 'secrets_status',
+    description:
+      'Scan tracked files for likely secrets — values are REDACTED. Run before sync/commit so an agent never ' +
+      'proposes committing a key. Never returns raw secret values, context, or placeholders.',
+    inputSchema: { type: 'object', properties: {} },
+    handler: async () => {
+      const tuckDir = getTuckDir();
+      await loadManifest(tuckDir);
+      const all = await getAllTrackedFiles(tuckDir);
+      const paths = Object.values(all).map((f) => expandPath(f.source));
+      const summary = await scanForSecrets(paths, tuckDir);
+      return {
+        filesWithSecrets: summary.filesWithSecrets,
+        totalSecrets: summary.totalSecrets,
+        bySeverity: summary.bySeverity,
+        files: summary.results
+          .filter((r) => r.hasSecrets)
+          .map((r) => ({
+            path: r.collapsedPath,
+            counts: {
+              critical: r.criticalCount,
+              high: r.highCount,
+              medium: r.mediumCount,
+              low: r.lowCount,
+            },
+            // REDACTION: project ONLY safe fields — never value / context / placeholder.
+            matches: r.matches.map((m) => ({
+              patternId: m.patternId,
+              patternName: m.patternName,
+              severity: m.severity,
+              line: m.line,
+              column: m.column,
+              redactedValue: m.redactedValue,
+            })),
+          })),
+      };
+    },
+  },
+  {
+    name: 'apply_plan',
+    description:
+      'Dry-run `tuck apply` into an isolated sandbox and report created/modified/unchanged files, smart-merge ' +
+      'conflicts, and any entry that would escape the sandbox. Writes NOTHING to the real system (read-only from the host).',
+    inputSchema: {
+      type: 'object',
+      properties: { bundle: { type: 'string', description: 'Limit the plan to a single bundle' } },
+    },
+    handler: async (args) => {
+      const tuckDir = getTuckDir();
+      await loadManifest(tuckDir);
+      const { mkdtemp, rm } = await import('fs/promises');
+      const { tmpdir } = await import('os');
+      const sandboxRoot = await mkdtemp(join(tmpdir(), 'tuck-mcp-apply-'));
+      // Snapshot BEFORE setting the sandbox boundary, restore in finally — so a
+      // global --root boundary is preserved across this long-running server.
+      const prev = snapshotWriteContext();
+      setWriteContext({ root: sandboxRoot, isSandbox: true });
+      try {
+        const res = await dryApplyIntoSandbox(tuckDir, args.bundle ? String(args.bundle) : undefined);
+        return {
+          summary: {
+            created: res.changes.filter((c) => c.status === 'created').length,
+            modified: res.changes.filter((c) => c.status === 'modified').length,
+            unchanged: res.changes.filter((c) => c.status === 'unchanged').length,
+            conflicts: res.conflicts.length,
+            wouldEscapeRoot: res.wouldEscapeRoot.length,
+          },
+          changes: res.changes.map((c) => ({
+            target: collapsePath(c.target),
+            status: c.status,
+            bytesBefore: c.bytesBefore,
+            bytesAfter: c.bytesAfter,
+          })),
+          conflicts: res.conflicts.map((c) => ({ target: c.target, type: c.type, name: c.name })),
+          wouldEscapeRoot: res.wouldEscapeRoot,
+        };
+      } finally {
+        restoreWriteContext(prev);
+        await rm(sandboxRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  },
 ];
 
 const respond = (resp: JsonRpcResponse): void => {
@@ -186,13 +353,33 @@ const toolError = (id: string | number | null, message: string): JsonRpcResponse
 
 /** Validate call arguments against a tool's declared inputSchema. */
 const validateArgs = (tool: ToolDef, args: Record<string, unknown>): string | null => {
+  // 1) Required args must be present (and non-null).
   for (const key of tool.inputSchema.required ?? []) {
     if (!(key in args) || args[key] === undefined || args[key] === null) {
       return `Missing required argument: ${key}`;
     }
+  }
+  // 2) Type-check EVERY present key that has a declared type (required OR
+  //    optional). Unknown keys are tolerated (forward-compat — hosts may attach
+  //    extra metadata); we validate against declared types, not strict-reject.
+  for (const [key, val] of Object.entries(args)) {
+    if (val === undefined || val === null) continue;
     const expected = (tool.inputSchema.properties[key] as { type?: string } | undefined)?.type;
-    if (expected === 'string' && typeof args[key] !== 'string') {
-      return `Argument "${key}" must be a string`;
+    if (!expected) continue;
+    const ok =
+      expected === 'string'
+        ? typeof val === 'string'
+        : expected === 'boolean'
+          ? typeof val === 'boolean'
+          : expected === 'number'
+            ? typeof val === 'number'
+            : expected === 'array'
+              ? Array.isArray(val)
+              : expected === 'object'
+                ? typeof val === 'object' && !Array.isArray(val)
+                : true;
+    if (!ok) {
+      return `Argument "${key}" must be ${expected === 'array' ? 'an array' : `a ${expected}`}`;
     }
   }
   return null;
@@ -237,6 +424,10 @@ export const dispatch = async (
             name: t.name,
             description: t.description,
             inputSchema: t.inputSchema,
+            // Surface the write-gate so a list-then-call agent knows which tools
+            // need TUCK_MCP_ALLOW_WRITE. `readOnlyHint` is a real MCP annotation.
+            writeGated: WRITE_TOOLS.has(t.name),
+            annotations: { readOnlyHint: !WRITE_TOOLS.has(t.name) },
           })),
         },
       };

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { colors as c } from '../ui/theme.js';
-import { chmod, stat } from 'fs/promises';
+import { chmod, stat, readFile, writeFile } from 'fs/promises';
 import { prompts, logger, withSpinner } from '../ui/index.js';
 import {
   getTuckDir,
@@ -23,9 +23,11 @@ import {
 } from '../lib/repoScope.js';
 import { loadConfig } from '../lib/config.js';
 import { copyFileOrDir, createSymlink, setFilePermissions } from '../lib/files.js';
+import { ensureDir } from 'fs-extra';
+import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from '../lib/materialize.js';
 import { createBackup } from '../lib/backup.js';
 import { runPreRestoreHook, runPostRestoreHook, type HookOptions } from '../lib/hooks.js';
-import { NotInitializedError, FileNotFoundError, TuckError } from '../errors.js';
+import { NotInitializedError, FileNotFoundError, TuckError, MaterializeError } from '../errors.js';
 import { CATEGORIES } from '../constants.js';
 import type { RestoreOptions } from '../types.js';
 import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
@@ -98,6 +100,10 @@ interface FileToRestore {
   repoRelative?: string;
   /** Recorded octal permissions (e.g. "755"), reapplied to the restored file. */
   permissions?: string;
+  /** Render the repo source as a template before writing to the live system. */
+  template: boolean;
+  /** Decrypt the repo source (TCKE1) before writing to the live system. */
+  encrypted: boolean;
 }
 
 interface RestoreResult {
@@ -149,6 +155,8 @@ const prepareFilesToRestore = async (
         repoKey: tracked.file.repoKey,
         repoRelative: tracked.file.repoRelative,
         permissions: tracked.file.permissions,
+        template: tracked.file.template,
+        encrypted: tracked.file.encrypted,
       });
     }
   } else {
@@ -172,6 +180,8 @@ const prepareFilesToRestore = async (
         repoKey: file.repoKey,
         repoRelative: file.repoRelative,
         permissions: file.permissions,
+        template: file.template,
+        encrypted: file.encrypted,
       });
     }
   }
@@ -186,6 +196,8 @@ const restoreFilesInternal = async (
 ): Promise<RestoreResult> => {
   const config = await loadConfig(tuckDir);
   const useSymlink = options.symlink || config.files.strategy === 'symlink';
+  // Template context (built-in vars + config.templates.variables), built once per restore.
+  const ctx = await buildMaterializeCtx(tuckDir);
   const shouldBackup = options.backup ?? config.files.backupOnRestore;
 
   // Prepare hook options
@@ -274,10 +286,36 @@ const restoreFilesInternal = async (
       });
     }
 
+    // Pre-materialize template/encrypted files (decrypt/render) BEFORE any write,
+    // so a failed / absent-passphrase decryption skips this file and never ships
+    // ciphertext or partial output. Directories are never template/encrypted.
+    let materialized: string | null = null;
+    if (!useSymlink && (file.template || file.encrypted)) {
+      try {
+        const isDir = (await stat(file.destination)).isDirectory();
+        if (!isDir) {
+          const raw = await readFile(file.destination);
+          materialized = await materializeForLive(raw, file, ctx, { getPassphrase: keystorePassphrase });
+        }
+      } catch (err) {
+        if (err instanceof MaterializeError) {
+          logger.warning(err.message);
+          if (isJsonMode()) addJsonWarning(err.message);
+          skipped.push(file.source);
+          continue;
+        }
+        throw err;
+      }
+    }
+
     // Restore file
     await withSpinner(`Restoring ${file.source}...`, async () => {
       if (useSymlink) {
         await createSymlink(file.destination, targetPath, { overwrite: true });
+      } else if (materialized !== null) {
+        // Decrypted/rendered content written directly (not a raw repo copy).
+        await ensureDir(dirname(targetPath));
+        await writeFile(targetPath, materialized, 'utf-8');
       } else {
         await copyFileOrDir(file.destination, targetPath, { overwrite: true });
       }

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -286,11 +286,17 @@ const restoreFilesInternal = async (
       });
     }
 
+    // Template/encrypted files are COPY-ONLY: they must be decrypted/rendered into
+    // place, never SYMLINKED — a symlink would expose raw TCKE1 ciphertext or the
+    // {{ }} template source at the live path. Force copy+materialize for them even
+    // when the symlink strategy is otherwise in effect (--symlink / config).
+    const linkThisFile = useSymlink && !file.template && !file.encrypted;
+
     // Pre-materialize template/encrypted files (decrypt/render) BEFORE any write,
     // so a failed / absent-passphrase decryption skips this file and never ships
-    // ciphertext or partial output. Directories are never template/encrypted.
+    // ciphertext or partial output. Directories fall through to a verbatim copy.
     let materialized: string | null = null;
-    if (!useSymlink && (file.template || file.encrypted)) {
+    if (file.template || file.encrypted) {
       try {
         const isDir = (await stat(file.destination)).isDirectory();
         if (!isDir) {
@@ -310,7 +316,7 @@ const restoreFilesInternal = async (
 
     // Restore file
     await withSpinner(`Restoring ${file.source}...`, async () => {
-      if (useSymlink) {
+      if (linkThisFile) {
         await createSymlink(file.destination, targetPath, { overwrite: true });
       } else if (materialized !== null) {
         // Decrypted/rendered content written directly (not a raw repo copy).
@@ -324,7 +330,7 @@ const restoreFilesInternal = async (
       // and a 0600 file is not left world-readable. Symlinks have no own mode,
       // so only copies are adjusted. The SSH/GPG fixups below still run and act
       // as a stricter safety floor for those directories.
-      if (file.permissions && !useSymlink) {
+      if (file.permissions && !linkThisFile) {
         try {
           await setFilePermissions(targetPath, file.permissions);
         } catch {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1113,12 +1113,47 @@ export const runSyncCommand = async (
   if (options.json || options.yes) {
     const changes = await detectChanges(tuckDir);
     if (changes.length === 0) {
+      // No tracked-file DRIFT — but the working tree may still hold uncommitted
+      // changes: the INITIAL `tuck add` (which copies into ~/.tuck without
+      // committing), a prior `pull`, or manual repo edits. Commit those instead
+      // of falsely reporting a no-op — otherwise the initial add is never
+      // committed and a later `tuck push` would push nothing. Mirrors the
+      // interactive path's gitStatus.hasChanges handling (runInteractiveSync).
+      // (Files reach the repo via `tuck add`, which already secret-scans them.)
+      const gitStatus = await getStatus(tuckDir);
+      if (!gitStatus.hasChanges) {
+        if (options.json) {
+          // Idempotent: nothing to do is a no-op, not a failure. Agents key on
+          // `noop` to tell "nothing changed" from "synced".
+          emitJsonOk({ modified: [], deleted: [], commitHash: null, noop: true });
+        } else {
+          logger.info('No changes detected');
+        }
+        return;
+      }
+      await stageAll(tuckDir);
+      const commitHash = await commit(tuckDir, messageArg || options.message || 'Update dotfiles');
+      let pushError: string | undefined;
+      if (options.push !== false && !(await checkLocalMode(tuckDir)) && (await hasRemote(tuckDir))) {
+        const config = await loadConfig(tuckDir);
+        assertRemoteAvailable(config.remote, 'push');
+        try {
+          await push(tuckDir);
+        } catch (err) {
+          if (!options.json) throw err;
+          pushError = err instanceof Error ? err.message : String(err);
+        }
+      }
       if (options.json) {
-        // Idempotent: re-running sync with nothing to do is a no-op, not a
-        // failure. Agents key on `noop` to tell "nothing changed" from "synced".
-        emitJsonOk({ modified: [], deleted: [], commitHash: null, noop: true });
+        emitJsonOk({
+          modified: [],
+          deleted: [],
+          commitHash,
+          noop: false,
+          ...(pushError ? { pushError } : {}),
+        });
       } else {
-        logger.info('No changes detected');
+        logger.success(`Committed pending repository changes: ${commitHash.slice(0, 7)}`);
       }
       return;
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -101,6 +101,19 @@ const detectChanges = async (tuckDir: string): Promise<TrackedFileChange[]> => {
     }
     validateSafeManifestDestination(file.destination);
 
+    // Template/encrypted files are ONE-DIRECTIONAL: the repo holds the SOURCE
+    // (template text / ciphertext) and the live file is a derived artifact
+    // (rendered / decrypted). Capturing the live file back into the repo would
+    // destroy the template source or write plaintext secrets — so sync NEVER
+    // captures these. Update them by editing the repo source and running
+    // `tuck apply`. (`tuck status` reports their real drift via the state model.)
+    if (file.template || file.encrypted) {
+      logger.debug?.(
+        `sync: skipping one-directional ${file.template ? 'template' : 'encrypted'} file ${file.source}`
+      );
+      continue;
+    }
+
     // Skip if in .tuckignore
     if (ignoredPaths.has(file.source)) {
       continue;

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -133,7 +133,7 @@ const fixMissingRepo = async (tuckDir: string, entries: FileStateEntry[]): Promi
  *   the content that WOULD be written (reusing `getFileChecksum`, not a private
  *   hash). The live read uses the REAL home; the write stays in the sandbox.
  */
-const dryApplyIntoSandbox = async (
+export const dryApplyIntoSandbox = async (
   tuckDir: string,
   bundle?: string
 ): Promise<DryApplyResult> => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -185,6 +185,15 @@ export class DecryptionError extends TuckError {
   }
 }
 
+export class MaterializeError extends TuckError {
+  constructor(source: string, reason: string) {
+    super(`Cannot materialize ${source}: ${reason}`, 'MATERIALIZE_FAILED', [
+      'Check the encryption password (run `tuck encryption setup`)',
+      'Verify the repo file is not corrupted or truncated',
+    ]);
+  }
+}
+
 export class SecretsDetectedError extends TuckError {
   constructor(count: number, files: string[]) {
     const fileList =

--- a/src/lib/fileTracking.ts
+++ b/src/lib/fileTracking.ts
@@ -17,6 +17,10 @@ import { dirname, join } from 'path';
 import type { FileStrategy } from '../types.js';
 import { toPosixPath } from './platform.js';
 import { bindRepo } from './repoScope.js';
+import { readFile, writeFile } from 'fs/promises';
+import { encryptFileContent } from './crypto/fileEncryption.js';
+import { keystorePassphrase } from './materialize.js';
+import { EncryptionError } from '../errors.js';
 
 export interface FileToTrack {
   path: string;
@@ -56,16 +60,11 @@ export interface FileTrackingOptions {
    */
   strategy?: FileStrategy;
 
-  // TODO: Encryption and templating are planned for a future version
-  // /**
-  //  * Encrypt files
-  //  */
-  // encrypt?: boolean;
-  //
-  // /**
-  //  * Treat as template
-  //  */
-  // template?: boolean;
+  /** Encrypt the file at rest in the repo using the keystore passphrase (decrypted on apply). */
+  encrypt?: boolean;
+
+  /** Mark the file as a template — stored verbatim, rendered on apply/restore. */
+  template?: boolean;
 
   /**
    * Delay between file operations in milliseconds
@@ -140,9 +139,8 @@ export const trackFilesWithProgress = async (
   const {
     showCategory = true,
     strategy: customStrategy,
-    // TODO: Encryption and templating are planned for a future version
-    // encrypt = false,
-    // template = false,
+    encrypt = false,
+    template = false,
     actionVerb = 'Tracking',
     onProgress,
   } = options;
@@ -155,6 +153,15 @@ export const trackFilesWithProgress = async (
 
   const config = await loadConfig(tuckDir);
   const strategy: FileStrategy = customStrategy || config.files.strategy || 'copy';
+
+  // Encrypted/template files are COPY-ONLY: they are decrypted/rendered into place
+  // on apply, never symlinked (a symlink would expose ciphertext or the raw {{ }}
+  // source at the live path). Reject the combination up front with a clear message.
+  if ((encrypt || template) && strategy === 'symlink') {
+    throw new Error(
+      'The symlink strategy cannot be combined with --encrypt/--template: these files are copied (and decrypted/rendered on apply), not linked.'
+    );
+  }
   const total = files.length;
   const errors: Array<{ path: string; error: Error }> = [];
   const sensitiveFiles: string[] = [];
@@ -257,6 +264,14 @@ export const trackFilesWithProgress = async (
           // caller records it and the user is never told this silently "worked".
           throw symlinkError;
         }
+      } else if (encrypt) {
+        // Encrypt at rest: store TCKE1 ciphertext in the repo (decrypted on apply).
+        const passphrase = await keystorePassphrase();
+        if (!passphrase) {
+          throw new EncryptionError('No encryption password set. Run `tuck encryption setup` first.');
+        }
+        const plaintext = await readFile(expandedPath);
+        await writeFile(destination, await encryptFileContent(plaintext, passphrase));
       } else {
         // Default: copy file into the repository (from the absolute live path).
         await copyFileOrDir(expandedPath, destination, { overwrite: true });
@@ -277,9 +292,8 @@ export const trackFilesWithProgress = async (
         category,
         // Repo scope is copy-only regardless of the configured global strategy.
         strategy: isRepo ? 'copy' : strategy,
-        // TODO: Encryption and templating are planned for a future version
-        encrypted: false,
-        template: false,
+        encrypted: encrypt,
+        template,
         permissions: info.permissions,
         added: now,
         modified: now,

--- a/src/lib/materialize.ts
+++ b/src/lib/materialize.ts
@@ -81,7 +81,13 @@ export const keystorePassphrase = async (): Promise<string | null> => {
  * `config.templates.variables`. Built once per command, not per file.
  */
 export const buildMaterializeCtx = async (tuckDir: string): Promise<TemplateContext> => {
-  const { loadConfig } = await import('./config.js');
-  const config = await loadConfig(tuckDir);
-  return defaultTemplateContext(config.templates?.variables ?? {});
+  // Resilient: a missing/corrupt config must not break apply/restore — fall back
+  // to the built-in machine variables (os/arch/hostname/…) only.
+  try {
+    const { loadConfig } = await import('./config.js');
+    const config = await loadConfig(tuckDir);
+    return defaultTemplateContext(config?.templates?.variables ?? {});
+  } catch {
+    return defaultTemplateContext({});
+  }
 };

--- a/src/lib/materialize.ts
+++ b/src/lib/materialize.ts
@@ -1,0 +1,87 @@
+/**
+ * Repo → live materialization.
+ *
+ * A tracked file's REPO copy may hold a *source* form that differs from what
+ * belongs on the live system:
+ *   - encrypted files hold TCKE1 ciphertext (decrypt → plaintext)
+ *   - template files hold {{ }} / `tuck:` source (render → machine-specific text)
+ *
+ * `materializeForLive` is the single place that conversion happens. `apply` and
+ * `restore` route single-file writes through it; `stateModel` uses it to compute
+ * the expected live content so status/verify don't report false drift.
+ *
+ * Order is decrypt → render. Secret-placeholder resolution (`{{PLACEHOLDER}}`)
+ * stays in `apply` and runs on the already-materialized text. Text-oriented:
+ * dotfiles are text, and callers handle directories/binary separately.
+ */
+
+import { renderTemplate, defaultTemplateContext, type TemplateContext } from './template.js';
+import { isEncryptedFile, decryptFileContent } from './crypto/fileEncryption.js';
+import { MaterializeError } from '../errors.js';
+import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
+
+export interface MaterializeDeps {
+  /** Returns the file-encryption passphrase, or null if none is configured/available. */
+  getPassphrase: () => Promise<string | null>;
+}
+
+/** The minimal slice of a tracked file `materializeForLive` needs. */
+export type MaterializableFile = Pick<TrackedFileOutput, 'template' | 'encrypted' | 'source'>;
+
+/**
+ * Convert a repo file's raw bytes into the content that belongs on the live
+ * system: decrypt (if encrypted) then render (if a template).
+ *
+ * Throws {@link MaterializeError} when a required decryption cannot be performed
+ * (no passphrase configured, wrong passphrase, corrupt ciphertext) so the caller
+ * NEVER writes ciphertext or partial output to the live system.
+ */
+export const materializeForLive = async (
+  repoBytes: Buffer,
+  file: MaterializableFile,
+  ctx: TemplateContext,
+  deps: MaterializeDeps
+): Promise<string> => {
+  let bytes = repoBytes;
+
+  // Decrypt if the file is flagged encrypted OR carries the magic header (defensive:
+  // a mislabeled file still decrypts rather than shipping ciphertext to disk).
+  if (file.encrypted || isEncryptedFile(repoBytes)) {
+    const pass = await deps.getPassphrase();
+    if (!pass) {
+      throw new MaterializeError(file.source, 'no encryption password configured');
+    }
+    try {
+      bytes = await decryptFileContent(bytes, pass);
+    } catch (err) {
+      throw new MaterializeError(file.source, err instanceof Error ? err.message : 'decryption failed');
+    }
+  }
+
+  let text = bytes.toString('utf8');
+  if (file.template) {
+    text = renderTemplate(text, ctx);
+  }
+  return text;
+};
+
+/**
+ * The single per-OS keystore "encryption password" used for TCKE1 file
+ * encryption. Returns null when none is set (the caller decides whether that is
+ * fatal — it is for an encrypted file, harmless otherwise).
+ */
+export const keystorePassphrase = async (): Promise<string | null> => {
+  const { getKeystore, TUCK_SERVICE, TUCK_ACCOUNT } = await import('./crypto/keystore/index.js');
+  return (await getKeystore()).retrieve(TUCK_SERVICE, TUCK_ACCOUNT);
+};
+
+/**
+ * Build the template context for a command run: the built-in machine variables
+ * (os/arch/hostname/user/home/ci) merged with the user's
+ * `config.templates.variables`. Built once per command, not per file.
+ */
+export const buildMaterializeCtx = async (tuckDir: string): Promise<TemplateContext> => {
+  const { loadConfig } = await import('./config.js');
+  const config = await loadConfig(tuckDir);
+  return defaultTemplateContext(config.templates?.variables ?? {});
+};

--- a/src/lib/stateModel.ts
+++ b/src/lib/stateModel.ts
@@ -136,7 +136,11 @@ export const computeFileState = async (
   // not the raw repo bytes. Hash the live file DIRECTLY (the mtime+size
   // short-circuit would wrongly return the recorded REPO checksum for an
   // encrypted file's plaintext live copy) and compare against materialize(repo).
-  if (file.template || file.encrypted) {
+  // DIRECTORIES are never materialized (readFile would EISDIR, then the catch
+  // would mask real drift as `ok`); a template/encrypted DIR falls through to the
+  // normal directory-checksum comparison below.
+  const repoIsDir = repoChecksum !== null && (await stat(repoAbs)).isDirectory();
+  if ((file.template || file.encrypted) && !repoIsDir) {
     const liveChecksum = (await pathExists(sourceAbs)) ? await getFileChecksum(sourceAbs) : null;
     if (liveChecksum === null && repoChecksum === null) return entry('missing-both', liveChecksum, repoChecksum);
     if (liveChecksum === null) return entry('missing-live', liveChecksum, repoChecksum);

--- a/src/lib/stateModel.ts
+++ b/src/lib/stateModel.ts
@@ -14,11 +14,14 @@
  */
 
 import { join } from 'path';
-import { stat } from 'fs/promises';
+import { stat, readFile } from 'fs/promises';
+import { createHash } from 'node:crypto';
 import { pathExists } from './paths.js';
 import { getFileChecksum } from './files.js';
 import { getAllTrackedFiles } from './manifest.js';
 import { resolveLiveTarget } from './repoScope.js';
+import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from './materialize.js';
+import type { TemplateContext } from './template.js';
 import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
 
 export type FileState =
@@ -101,44 +104,76 @@ const computeLiveChecksum = async (
 export const computeFileState = async (
   tuckDir: string,
   id: string,
-  file: TrackedFileOutput
+  file: TrackedFileOutput,
+  ctx?: TemplateContext
 ): Promise<FileStateEntry> => {
   const repoAbs = join(tuckDir, file.destination);
   const repoChecksum = (await pathExists(repoAbs)) ? await getFileChecksum(repoAbs) : null;
 
   // Resolve the LIVE location (home: expandPath; repo: bound root or null).
   const sourceAbs = await resolveLiveTarget(file);
-  if (sourceAbs === null) {
-    // Repo-scoped file whose repo is not bound on this machine — cannot compare.
-    return {
-      id,
-      source: file.source,
-      destination: file.destination,
-      state: 'unknown-repo',
-      liveChecksum: null,
-      repoChecksum,
-      manifestChecksum: file.checksum,
-    };
-  }
 
-  const liveChecksum = await computeLiveChecksum(sourceAbs, file);
-
-  return {
+  const entry = (
+    state: FileState,
+    liveChecksum: string | null,
+    repoChk: string | null
+  ): FileStateEntry => ({
     id,
     source: file.source,
     destination: file.destination,
-    state: classifyFileState(liveChecksum, repoChecksum, file.checksum),
+    state,
     liveChecksum,
-    repoChecksum,
+    repoChecksum: repoChk,
     manifestChecksum: file.checksum,
-  };
+  });
+
+  if (sourceAbs === null) {
+    // Repo-scoped file whose repo is not bound on this machine — cannot compare.
+    return entry('unknown-repo', null, repoChecksum);
+  }
+
+  // Materialized files (template/encrypted): the LIVE form is materialize(repo),
+  // not the raw repo bytes. Hash the live file DIRECTLY (the mtime+size
+  // short-circuit would wrongly return the recorded REPO checksum for an
+  // encrypted file's plaintext live copy) and compare against materialize(repo).
+  if (file.template || file.encrypted) {
+    const liveChecksum = (await pathExists(sourceAbs)) ? await getFileChecksum(sourceAbs) : null;
+    if (liveChecksum === null && repoChecksum === null) return entry('missing-both', liveChecksum, repoChecksum);
+    if (liveChecksum === null) return entry('missing-live', liveChecksum, repoChecksum);
+    if (repoChecksum === null) return entry('missing-repo', liveChecksum, repoChecksum);
+    try {
+      const useCtx = ctx ?? (await buildMaterializeCtx(tuckDir));
+      const raw = await readFile(repoAbs);
+      const expected = await materializeForLive(raw, file, useCtx, { getPassphrase: keystorePassphrase });
+      const expectedChecksum = createHash('sha256').update(Buffer.from(expected, 'utf8')).digest('hex');
+      // live ≠ materialize(repo) → stale/edited (remedy: `tuck apply`, since sync
+      // skips these files). Otherwise raw repo vs manifest distinguishes drift-repo.
+      const state: FileState =
+        liveChecksum !== expectedChecksum
+          ? 'drift-local'
+          : repoChecksum !== file.checksum
+            ? 'drift-repo'
+            : 'ok';
+      return entry(state, liveChecksum, repoChecksum);
+    } catch {
+      // Locked keystore / undecryptable repo file: can't compute the expected live
+      // form — degrade to ok-by-presence rather than failing status/verify offline.
+      return entry('ok', liveChecksum, repoChecksum);
+    }
+  }
+
+  const liveChecksum = await computeLiveChecksum(sourceAbs, file);
+  return entry(classifyFileState(liveChecksum, repoChecksum, file.checksum), liveChecksum, repoChecksum);
 };
 
 /** Compute the state of every tracked file in the manifest. */
 export const computeStateModel = async (tuckDir: string): Promise<FileStateEntry[]> => {
   const files = await getAllTrackedFiles(tuckDir);
+  // Build the template context ONCE (built-in vars + config.templates.variables)
+  // and reuse it across every materialized-file comparison.
+  const ctx = await buildMaterializeCtx(tuckDir);
   return Promise.all(
-    Object.entries(files).map(([id, file]) => computeFileState(tuckDir, id, file))
+    Object.entries(files).map(([id, file]) => computeFileState(tuckDir, id, file, ctx))
   );
 };
 

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -221,6 +221,18 @@ describe('add command behavior', () => {
     );
   });
 
+  it('passes --template and --encrypt through to tracking', async () => {
+    const { addFilesFromPaths } = await import('../../src/commands/add.js');
+
+    await addFilesFromPaths(['~/.zshrc'], { force: true, template: true, encrypt: true });
+
+    expect(trackFilesWithProgressMock).toHaveBeenCalledWith(
+      [{ path: '~/.zshrc', category: 'shell' }],
+      '/test-home/.tuck',
+      expect.objectContaining({ template: true, encrypt: true })
+    );
+  });
+
   it('runs the full prepare pipeline for --plan and reflects the detected category', async () => {
     // detectCategory returns 'shell' from beforeEach; the plan must surface the
     // detected category, not the (undefined) raw --category input.

--- a/tests/commands/apply.test.ts
+++ b/tests/commands/apply.test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 import { join } from 'path';
 import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
 import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
 
 const cloneRepoMock = vi.fn();
 const createPreApplySnapshotMock = vi.fn();
@@ -102,6 +103,12 @@ vi.mock('../../src/lib/config.js', () => ({
       secretBackend: 'local',
     },
   }),
+}));
+
+vi.mock('../../src/lib/crypto/keystore/index.js', () => ({
+  getKeystore: vi.fn(async () => ({ retrieve: vi.fn(async () => 'pw') })),
+  TUCK_SERVICE: 'tuck-dotfiles',
+  TUCK_ACCOUNT: 'backup-encryption',
 }));
 
 vi.mock('../../src/lib/platform.js', () => ({
@@ -214,6 +221,53 @@ describe('apply command behavior', () => {
     if (clonedDir) {
       expect(vol.existsSync(clonedDir)).toBe(false);
     }
+  });
+
+  it('renders a template file on apply (P0-1)', async () => {
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          tmpl: createMockTrackedFile({
+            source: '~/.zshrc',
+            destination: 'files/shell/zshrc',
+            template: true,
+          }),
+        },
+      });
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), 'os={{os}}');
+    };
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true });
+
+    // The {{os}} placeholder is rendered with the machine's platform, not copied verbatim.
+    expect(vol.readFileSync(join(TEST_HOME, '.zshrc'), 'utf-8')).toBe(`os=${process.platform}`);
+  });
+
+  it('decrypts an encrypted file on apply (P0-2)', async () => {
+    const ciphertext = await encryptFileContent(Buffer.from('SECRET=1'), 'pw');
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          enc: createMockTrackedFile({
+            source: '~/.netrc',
+            destination: 'files/shell/netrc',
+            encrypted: true,
+          }),
+        },
+      });
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'netrc'), ciphertext);
+    };
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true });
+
+    // The TCKE1 ciphertext is decrypted to plaintext on disk (not shipped as ciphertext).
+    expect(vol.readFileSync(join(TEST_HOME, '.netrc'), 'utf-8')).toBe('SECRET=1');
   });
 
   it('throws when cloned repository has no tuck manifest', async () => {

--- a/tests/commands/apply.test.ts
+++ b/tests/commands/apply.test.ts
@@ -12,6 +12,7 @@ const restoreContentMock = vi.fn();
 const restoreSecretsMock = vi.fn();
 const getAllSecretsMock = vi.fn();
 const getSecretCountMock = vi.fn();
+const retrieveMock = vi.fn();
 
 const loggerInfoMock = vi.fn();
 const loggerSuccessMock = vi.fn();
@@ -106,7 +107,7 @@ vi.mock('../../src/lib/config.js', () => ({
 }));
 
 vi.mock('../../src/lib/crypto/keystore/index.js', () => ({
-  getKeystore: vi.fn(async () => ({ retrieve: vi.fn(async () => 'pw') })),
+  getKeystore: vi.fn(async () => ({ retrieve: retrieveMock })),
   TUCK_SERVICE: 'tuck-dotfiles',
   TUCK_ACCOUNT: 'backup-encryption',
 }));
@@ -142,6 +143,7 @@ describe('apply command behavior', () => {
     getAllSecretsMock.mockResolvedValue({});
     getSecretCountMock.mockResolvedValue(0);
     createPreApplySnapshotMock.mockResolvedValue({ id: 'snapshot-test' });
+    retrieveMock.mockResolvedValue('pw'); // default: keystore has the encryption password
   });
 
   afterEach(() => {
@@ -268,6 +270,29 @@ describe('apply command behavior', () => {
 
     // The TCKE1 ciphertext is decrypted to plaintext on disk (not shipped as ciphertext).
     expect(vol.readFileSync(join(TEST_HOME, '.netrc'), 'utf-8')).toBe('SECRET=1');
+  });
+
+  it('skips an undecryptable file without misreporting it as a secret placeholder', async () => {
+    retrieveMock.mockResolvedValue(null); // no passphrase ⇒ MaterializeError on the encrypted file
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          enc: createMockTrackedFile({ source: '~/.netrc', destination: 'files/shell/netrc', encrypted: true }),
+        },
+      });
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'netrc'), 'cannot-decrypt-without-passphrase');
+    };
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true });
+
+    // Never written (no ciphertext/partial on disk) ...
+    expect(vol.existsSync(join(TEST_HOME, '.netrc'))).toBe(false);
+    // ... and NOT misreported as an unresolved placeholder ⇒ no spurious local-secret
+    // restore (tryRestoreSecretsFromLocalStore only runs when filesWithPlaceholders > 0).
+    expect(getAllSecretsMock).not.toHaveBeenCalled();
   });
 
   it('throws when cloned repository has no tuck manifest', async () => {

--- a/tests/commands/mcp.test.ts
+++ b/tests/commands/mcp.test.ts
@@ -37,6 +37,7 @@ const scanForSecretsMock = vi.hoisted(() => vi.fn());
 const getFileDiffMock = vi.hoisted(() => vi.fn());
 const detectDotfilesMock = vi.hoisted(() => vi.fn());
 const dryApplyMock = vi.hoisted(() => vi.fn());
+const resolveLiveTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/lib/manifest.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/lib/manifest.js')>('../../src/lib/manifest.js');
@@ -62,6 +63,10 @@ vi.mock('../../src/commands/verify.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/commands/verify.js')>('../../src/commands/verify.js');
   return { ...actual, dryApplyIntoSandbox: dryApplyMock }; // keep hasDrift real
 });
+vi.mock('../../src/lib/repoScope.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/repoScope.js')>('../../src/lib/repoScope.js');
+  return { ...actual, resolveLiveTarget: resolveLiveTargetMock };
+});
 
 let state: ReturnType<typeof createServerState>;
 beforeEach(() => {
@@ -75,6 +80,9 @@ beforeEach(() => {
   getFileDiffMock.mockReset();
   detectDotfilesMock.mockReset().mockResolvedValue([]);
   dryApplyMock.mockReset();
+  // Default: home-scoped files resolve like expandPath; repo-scoped tests override.
+  resolveLiveTargetMock.mockReset();
+  resolveLiveTargetMock.mockImplementation(async (f: { source: string }) => f.source.replace(/^~\//, '/test-home/'));
   // apply_plan mkdtemp's under os.tmpdir(); the global setup resets memfs each
   // test, so recreate the temp root (real-path under the memfs vfs) here.
   vol.mkdirSync(tmpdir(), { recursive: true });
@@ -365,6 +373,28 @@ describe('mcp dispatch', () => {
     expect(m).not.toHaveProperty('context');
     expect(m).not.toHaveProperty('placeholder');
     expect(m.redactedValue).toBe('[REDACTED]');
+  });
+
+  it('secrets_status resolves repo-scoped files via resolveLiveTarget (not expandPath)', async () => {
+    await init();
+    getAllTrackedFilesMock.mockResolvedValueOnce({
+      r: {
+        source: 'repokey:cfg/app.conf',
+        destination: 'context/repo/x',
+        category: 'misc',
+        scope: 'repo',
+        repoKey: 'repokey',
+        repoRelative: 'cfg/app.conf',
+      },
+    });
+    resolveLiveTargetMock.mockResolvedValueOnce('/Users/me/projects/app/cfg/app.conf');
+    scanForSecretsMock.mockResolvedValueOnce({
+      totalFiles: 1, scannedFiles: 1, skippedFiles: 0, filesWithSecrets: 0, totalSecrets: 0,
+      bySeverity: { critical: 0, high: 0, medium: 0, low: 0 }, results: [],
+    });
+    await callTool(38, 'secrets_status');
+    // Scanned via the RESOLVED live path — never expandPath('repokey:cfg/app.conf').
+    expect(scanForSecretsMock).toHaveBeenCalledWith(['/Users/me/projects/app/cfg/app.conf'], expect.any(String));
   });
 
   it('apply_plan returns a created/modified/unchanged summary WITHOUT the write gate', async () => {

--- a/tests/commands/mcp.test.ts
+++ b/tests/commands/mcp.test.ts
@@ -12,6 +12,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { dispatch, createServerState } from '../../src/commands/mcp.js';
 import { VERSION } from '../../src/constants.js';
+import { snapshotWriteContext } from '../../src/lib/writeContext.js';
+import { vol } from 'memfs';
+import { tmpdir } from 'os';
 
 // Keep the real classifier/listing behaviour (other tests depend on it) but
 // replace the single state-mutating entry point so write-gate tests can run
@@ -24,11 +27,57 @@ vi.mock('../../src/commands/context.js', async () => {
   return { ...actual, addContextFile: addContextFileMock };
 });
 
+// Library-boundary mocks for the new read tools: the tool HANDLERS run their real
+// projection/redaction logic over controlled inputs (so the redaction test is
+// meaningful), while the underlying fs/scan/state work is stubbed.
+const loadManifestMock = vi.hoisted(() => vi.fn());
+const getAllTrackedFilesMock = vi.hoisted(() => vi.fn());
+const computeStateModelMock = vi.hoisted(() => vi.fn());
+const scanForSecretsMock = vi.hoisted(() => vi.fn());
+const getFileDiffMock = vi.hoisted(() => vi.fn());
+const detectDotfilesMock = vi.hoisted(() => vi.fn());
+const dryApplyMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/lib/manifest.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/manifest.js')>('../../src/lib/manifest.js');
+  return { ...actual, loadManifest: loadManifestMock, getAllTrackedFiles: getAllTrackedFilesMock };
+});
+vi.mock('../../src/lib/stateModel.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/stateModel.js')>('../../src/lib/stateModel.js');
+  return { ...actual, computeStateModel: computeStateModelMock }; // keep summarizeStateModel real
+});
+vi.mock('../../src/lib/secrets/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/secrets/index.js')>('../../src/lib/secrets/index.js');
+  return { ...actual, scanForSecrets: scanForSecretsMock };
+});
+vi.mock('../../src/commands/diff.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/commands/diff.js')>('../../src/commands/diff.js');
+  return { ...actual, getFileDiff: getFileDiffMock };
+});
+vi.mock('../../src/lib/detect.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/detect.js')>('../../src/lib/detect.js');
+  return { ...actual, detectDotfiles: detectDotfilesMock };
+});
+vi.mock('../../src/commands/verify.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/commands/verify.js')>('../../src/commands/verify.js');
+  return { ...actual, dryApplyIntoSandbox: dryApplyMock }; // keep hasDrift real
+});
+
 let state: ReturnType<typeof createServerState>;
 beforeEach(() => {
   state = createServerState();
   delete process.env.TUCK_MCP_ALLOW_WRITE;
   addContextFileMock.mockReset();
+  loadManifestMock.mockReset().mockResolvedValue({ files: {} });
+  getAllTrackedFilesMock.mockReset().mockResolvedValue({});
+  computeStateModelMock.mockReset().mockResolvedValue([]);
+  scanForSecretsMock.mockReset();
+  getFileDiffMock.mockReset();
+  detectDotfilesMock.mockReset().mockResolvedValue([]);
+  dryApplyMock.mockReset();
+  // apply_plan mkdtemp's under os.tmpdir(); the global setup resets memfs each
+  // test, so recreate the temp root (real-path under the memfs vfs) here.
+  vol.mkdirSync(tmpdir(), { recursive: true });
 });
 afterEach(() => {
   delete process.env.TUCK_MCP_ALLOW_WRITE;
@@ -135,6 +184,11 @@ describe('mcp dispatch', () => {
         'context_list',
         'context_add',
         'classify_agent_file',
+        'verify',
+        'diff',
+        'scan_untracked',
+        'secrets_status',
+        'apply_plan',
       ])
     );
     // Each advertised tool carries its declared schema and description.
@@ -221,5 +275,127 @@ describe('mcp dispatch', () => {
     expect(addContextFileMock).toHaveBeenCalledTimes(1);
     const r = (resp as { result: { isError: boolean } }).result;
     expect(r.isError).toBe(false);
+  });
+
+  // ── widened read tools (P0-3) ──
+
+  const callTool = async (id: number, name: string, args: Record<string, unknown> = {}) =>
+    dispatch({ jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } }, state);
+  const okPayload = (resp: unknown): { isError: boolean; text: string } => {
+    const r = (resp as { result: { isError: boolean; content: { text: string }[] } }).result;
+    return { isError: r.isError, text: r.content[0].text };
+  };
+
+  it('verify tool reports a summary and a drift boolean (never exits the process)', async () => {
+    await init();
+    computeStateModelMock.mockResolvedValueOnce([
+      { id: 'a', source: '~/.zshrc', destination: 'files/shell/zshrc', state: 'drift-local', liveChecksum: 'x', repoChecksum: 'y', manifestChecksum: 'y' },
+    ]);
+    const { isError, text } = okPayload(await callTool(30, 'verify'));
+    expect(isError).toBe(false);
+    const payload = JSON.parse(text);
+    expect(payload.drift).toBe(true);
+    expect(payload.summary.total).toBe(1);
+    expect(payload.files[0]).toEqual({ source: '~/.zshrc', state: 'drift-local' });
+  });
+
+  it('diff tool returns changed files as metadata only (content elided)', async () => {
+    await init();
+    getAllTrackedFilesMock.mockResolvedValueOnce({
+      z: { source: '~/.zshrc', destination: 'files/shell/zshrc', category: 'shell' },
+    });
+    getFileDiffMock.mockResolvedValueOnce({
+      source: '~/.zshrc', destination: 'files/shell/zshrc', hasChanges: true,
+      systemSize: 10, repoSize: 8, systemContent: 'SECRET_LINE', repoContent: 'x',
+    });
+    const { isError, text } = okPayload(await callTool(31, 'diff'));
+    expect(isError).toBe(false);
+    const payload = JSON.parse(text);
+    expect(payload.count).toBe(1);
+    expect(payload.files[0].source).toBe('~/.zshrc');
+    expect(text).not.toContain('SECRET_LINE'); // contents are not exposed
+  });
+
+  it('diff tool rejects a non-array `paths` argument (B2 optional type-check)', async () => {
+    await init();
+    const { isError, text } = okPayload(await callTool(32, 'diff', { paths: 'x' }));
+    expect(isError).toBe(true);
+    expect(text).toMatch(/paths.*array/i);
+  });
+
+  it('scan_untracked returns detected minus tracked', async () => {
+    await init();
+    getAllTrackedFilesMock.mockResolvedValueOnce({
+      z: { source: '~/.zshrc', destination: 'd', category: 'shell' },
+    });
+    detectDotfilesMock.mockResolvedValueOnce([
+      { path: '~/.zshrc', category: 'shell', sensitive: false },
+      { path: '~/.gitconfig', category: 'git', sensitive: false },
+    ]);
+    const { text } = okPayload(await callTool(33, 'scan_untracked'));
+    const payload = JSON.parse(text);
+    expect(payload.count).toBe(1);
+    expect(payload.files[0].path).toBe('~/.gitconfig');
+  });
+
+  it('secrets_status NEVER returns raw values, context, or placeholders (redaction gate)', async () => {
+    await init();
+    getAllTrackedFilesMock.mockResolvedValueOnce({ e: { source: '~/.env', destination: 'd', category: 'env' } });
+    scanForSecretsMock.mockResolvedValueOnce({
+      totalFiles: 1, scannedFiles: 1, skippedFiles: 0, filesWithSecrets: 1, totalSecrets: 1,
+      bySeverity: { critical: 1, high: 0, medium: 0, low: 0 },
+      results: [{
+        path: '/home/u/.env', collapsedPath: '~/.env', hasSecrets: true,
+        criticalCount: 1, highCount: 0, mediumCount: 0, lowCount: 0, skipped: false,
+        matches: [{
+          patternId: 'aws', patternName: 'AWS Key', severity: 'critical',
+          value: 'AKIAIOSFODNN7EXAMPLE', redactedValue: '[REDACTED]', line: 3, column: 5,
+          context: 'key=AKIAIOSFODNN7EXAMPLE', placeholder: '{{AWS}}',
+        }],
+      }],
+    });
+    const { isError, text } = okPayload(await callTool(34, 'secrets_status'));
+    expect(isError).toBe(false);
+    expect(text).not.toContain('AKIAIOSFODNN7EXAMPLE'); // raw value
+    expect(text).not.toContain('key=AKIAIOSFODNN7EXAMPLE'); // context
+    expect(text).not.toContain('{{AWS}}'); // placeholder
+    expect(text).toContain('[REDACTED]');
+    const m = JSON.parse(text).files[0].matches[0];
+    expect(m).not.toHaveProperty('value');
+    expect(m).not.toHaveProperty('context');
+    expect(m).not.toHaveProperty('placeholder');
+    expect(m.redactedValue).toBe('[REDACTED]');
+  });
+
+  it('apply_plan returns a created/modified/unchanged summary WITHOUT the write gate', async () => {
+    await init(); // TUCK_MCP_ALLOW_WRITE unset (dry-run is read-only from the host)
+    dryApplyMock.mockResolvedValueOnce({
+      changes: [{ target: '/sandbox/.zshrc', status: 'created', bytesBefore: 0, bytesAfter: 10 }],
+      conflicts: [], wouldEscapeRoot: [],
+    });
+    const { isError, text } = okPayload(await callTool(35, 'apply_plan'));
+    expect(isError).toBe(false);
+    expect(JSON.parse(text).summary.created).toBe(1);
+  });
+
+  it('apply_plan restores the prior write context even when the dry-apply throws', async () => {
+    await init();
+    const before = snapshotWriteContext();
+    dryApplyMock.mockRejectedValueOnce(new Error('prepare blew up'));
+    const { isError } = okPayload(await callTool(36, 'apply_plan'));
+    expect(isError).toBe(true); // surfaced as a tool error
+    expect(snapshotWriteContext()).toEqual(before); // sandbox boundary not leaked
+  });
+
+  it('annotates write-gated tools in tools/list with writeGated + readOnlyHint', async () => {
+    await init();
+    const resp = await dispatch({ jsonrpc: '2.0', id: 37, method: 'tools/list' }, state);
+    const list = (resp as { result: { tools: Array<{ name: string; writeGated?: boolean; annotations?: { readOnlyHint?: boolean } }> } }).result.tools;
+    const ctxAdd = list.find((t) => t.name === 'context_add')!;
+    const verify = list.find((t) => t.name === 'verify')!;
+    expect(ctxAdd.writeGated).toBe(true);
+    expect(ctxAdd.annotations?.readOnlyHint).toBe(false);
+    expect(verify.writeGated).toBe(false);
+    expect(verify.annotations?.readOnlyHint).toBe(true);
   });
 });

--- a/tests/commands/restore.test.ts
+++ b/tests/commands/restore.test.ts
@@ -198,6 +198,29 @@ describe('restore command behavior', () => {
     expect(vol.readFileSync('/test-home/.netrc', 'utf-8')).toBe('SECRET=1');
   });
 
+  it('force-copies+materializes template/encrypted files under symlink strategy (never symlinks raw source)', async () => {
+    vol.reset();
+    vol.mkdirSync('/test-home/.tuck/files/shell', { recursive: true });
+    vol.writeFileSync('/test-home/.tuck/files/shell/zshrc', 'os={{os}}');
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        category: 'shell',
+        template: true,
+        encrypted: false,
+      },
+    });
+
+    const { runRestore } = await import('../../src/commands/restore.js');
+    // useSymlink via --symlink — a template file must STILL be rendered into place,
+    // NOT symlinked (a symlink would expose the raw {{ }} source / ciphertext).
+    await runRestore({ all: true, symlink: true, noHooks: true, noSecrets: true });
+
+    expect(vol.readFileSync('/test-home/.zshrc', 'utf-8')).toBe(`os=${process.platform}`);
+    expect(createSymlinkMock).not.toHaveBeenCalled();
+  });
+
   it('surfaces skipped-file warnings in the JSON envelope.warnings', async () => {
     // A tracked file whose repository copy is missing on disk triggers the
     // "Source not found in repository" skip path. In JSON mode that human

--- a/tests/commands/restore.test.ts
+++ b/tests/commands/restore.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { join } from 'path';
+import { vol } from 'memfs';
 import { NotInitializedError } from '../../src/errors.js';
+import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
 
 const loadManifestMock = vi.fn();
 const getAllTrackedFilesMock = vi.fn();
@@ -92,6 +94,12 @@ vi.mock('../../src/lib/secrets/index.js', () => ({
   getSecretCount: getSecretCountMock,
 }));
 
+vi.mock('../../src/lib/crypto/keystore/index.js', () => ({
+  getKeystore: vi.fn(async () => ({ retrieve: vi.fn(async () => 'pw') })),
+  TUCK_SERVICE: 'tuck-dotfiles',
+  TUCK_ACCOUNT: 'backup-encryption',
+}));
+
 describe('restore command behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -144,6 +152,50 @@ describe('restore command behavior', () => {
       '/test-home/.tuck',
       'restore source'
     );
+  });
+
+  it('renders a template file on restore (P0-1)', async () => {
+    vol.reset();
+    vol.mkdirSync('/test-home/.tuck/files/shell', { recursive: true });
+    vol.writeFileSync('/test-home/.tuck/files/shell/zshrc', 'os={{os}}');
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        category: 'shell',
+        template: true,
+        encrypted: false,
+      },
+    });
+
+    const { runRestore } = await import('../../src/commands/restore.js');
+    await runRestore({ all: true, noHooks: true, noSecrets: true });
+
+    // {{os}} is rendered with the machine platform; written directly, not raw-copied.
+    expect(vol.readFileSync('/test-home/.zshrc', 'utf-8')).toBe(`os=${process.platform}`);
+    expect(copyFileOrDirMock).not.toHaveBeenCalled();
+  });
+
+  it('decrypts an encrypted file on restore (P0-2)', async () => {
+    vol.reset();
+    const ciphertext = await encryptFileContent(Buffer.from('SECRET=1'), 'pw');
+    vol.mkdirSync('/test-home/.tuck/files/shell', { recursive: true });
+    vol.writeFileSync('/test-home/.tuck/files/shell/netrc', ciphertext);
+    getAllTrackedFilesMock.mockResolvedValue({
+      netrc: {
+        source: '~/.netrc',
+        destination: 'files/shell/netrc',
+        category: 'shell',
+        template: false,
+        encrypted: true,
+      },
+    });
+
+    const { runRestore } = await import('../../src/commands/restore.js');
+    await runRestore({ all: true, noHooks: true, noSecrets: true });
+
+    // TCKE1 ciphertext is decrypted to plaintext on disk, never written as ciphertext.
+    expect(vol.readFileSync('/test-home/.netrc', 'utf-8')).toBe('SECRET=1');
   });
 
   it('surfaces skipped-file warnings in the JSON envelope.warnings', async () => {

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -24,6 +24,7 @@ const commitMock = vi.fn();
 const hasRemoteMock = vi.fn();
 const pushMock = vi.fn();
 const loggerInfoMock = vi.fn();
+const getStatusMock = vi.fn();
 
 vi.mock('../../src/ui/index.js', () => ({
   prompts: {
@@ -93,7 +94,7 @@ vi.mock('../../src/lib/repoScope.js', () => ({
 vi.mock('../../src/lib/git.js', () => ({
   stageAll: stageAllMock,
   commit: commitMock,
-  getStatus: vi.fn().mockResolvedValue({ behind: 0 }),
+  getStatus: getStatusMock,
   push: pushMock,
   hasRemote: hasRemoteMock,
   fetch: vi.fn(),
@@ -180,6 +181,9 @@ describe('sync command behavior', () => {
     getFileChecksumMock.mockResolvedValue('new-checksum');
     hasRemoteMock.mockResolvedValue(false);
     commitMock.mockResolvedValue('abc123def456');
+    // Default: a clean working tree (no uncommitted changes). Tests that need a
+    // dirty tree (e.g. the initial-add commit) override hasChanges per-test.
+    getStatusMock.mockResolvedValue({ behind: 0, hasChanges: false });
     checkLocalModeMock.mockResolvedValue(false);
     validateSafeSourcePathMock.mockImplementation(() => {});
     validateSafeManifestDestinationMock.mockImplementation(() => {});
@@ -272,6 +276,36 @@ describe('sync command behavior', () => {
     );
     expect(stageAllMock).not.toHaveBeenCalled();
     expect(commitMock).not.toHaveBeenCalled();
+  });
+
+  it('commits pending repo changes even when no tracked file drifted (the initial add)', async () => {
+    // No tracked-file DRIFT (live == repo) ...
+    getAllTrackedFilesMock.mockResolvedValue({
+      zshrc: { source: '~/.zshrc', destination: 'files/shell/zshrc', checksum: 'same' },
+    });
+    getFileChecksumMock.mockResolvedValue('same'); // ⇒ detectChanges() is empty
+    // ... but the working tree HAS uncommitted changes (what `tuck add` leaves).
+    getStatusMock.mockResolvedValue({
+      behind: 0,
+      hasChanges: true,
+      staged: [],
+      modified: [],
+      untracked: ['files/shell/zshrc', '.tuckmanifest.json'],
+    });
+    commitMock.mockResolvedValue('deadbeefcafe');
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand(undefined, {
+      json: true,
+      noHooks: true,
+      scan: false,
+      pull: false,
+      push: false,
+    } as never);
+
+    // The initial add must be committed, not reported as a no-op.
+    expect(stageAllMock).toHaveBeenCalledTimes(1);
+    expect(commitMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not push in local-only mode even when a git remote exists', async () => {

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -214,6 +214,42 @@ describe('sync command behavior', () => {
     expect(copyFileOrDirMock).not.toHaveBeenCalled();
   });
 
+  it('does not capture template/encrypted files live->repo (no clobber/leak)', async () => {
+    // Both files' live copies differ from the recorded checksum — they WOULD be
+    // captured as 'modified' if they were not one-directional.
+    getAllTrackedFilesMock.mockResolvedValue({
+      gitconfig: {
+        source: '~/.gitconfig',
+        destination: 'files/git/gitconfig',
+        checksum: 'old',
+        template: true,
+        encrypted: false,
+      },
+      netrc: {
+        source: '~/.netrc',
+        destination: 'files/shell/netrc',
+        checksum: 'old',
+        template: false,
+        encrypted: true,
+      },
+    });
+    getFileChecksumMock.mockResolvedValue('new');
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+
+    await runSyncCommand('sync: should-skip', {
+      noCommit: true,
+      noHooks: true,
+      scan: false,
+      pull: false,
+    });
+
+    // The template source is never overwritten; no plaintext is written for the
+    // encrypted file; nothing is detected as a change.
+    expect(copyFileOrDirMock).not.toHaveBeenCalled();
+    expect(updateFileInManifestMock).not.toHaveBeenCalled();
+    expect(loggerInfoMock).toHaveBeenCalledWith('No changes detected');
+  });
+
   it('syncs modified files and updates manifest when changes exist', async () => {
     getAllTrackedFilesMock.mockResolvedValue({
       zshrc: {

--- a/tests/e2e/helpers/build.ts
+++ b/tests/e2e/helpers/build.ts
@@ -1,0 +1,22 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { REPO_ROOT } from './runCli.js';
+
+const execFileAsync = promisify(execFile);
+let built = false;
+
+/**
+ * Build dist/index.js exactly once per vitest process (idempotent). Set
+ * TUCK_E2E_SKIP_BUILD=1 to skip when you've already built a fresh dist (fast
+ * local iteration). `pnpm test:e2e` relies on this guard — there is no pretest
+ * build step (which would double-build).
+ */
+export const ensureBuilt = async (): Promise<void> => {
+  if (built) return;
+  if (process.env.TUCK_E2E_SKIP_BUILD === '1') {
+    built = true;
+    return;
+  }
+  await execFileAsync('pnpm', ['build'], { cwd: REPO_ROOT, timeout: 180_000 });
+  built = true;
+};

--- a/tests/e2e/helpers/git.ts
+++ b/tests/e2e/helpers/git.ts
@@ -1,0 +1,23 @@
+import simpleGit from 'simple-git';
+
+/** Whether a usable `git` binary is on PATH (gates commit-dependent e2e cases). */
+export const hasGit = async (): Promise<boolean> => {
+  try {
+    await simpleGit().raw(['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Commit identity via env so we never mutate the runner's global git config.
+ * `tuck`'s initRepo runs `git init` but sets no user.name/email, so a fresh CI
+ * runner with no global identity would fail `git commit` without this.
+ */
+export const gitIdentityEnv = (): Record<string, string> => ({
+  GIT_AUTHOR_NAME: 'tuck-e2e',
+  GIT_AUTHOR_EMAIL: 'e2e@tuck.test',
+  GIT_COMMITTER_NAME: 'tuck-e2e',
+  GIT_COMMITTER_EMAIL: 'e2e@tuck.test',
+});

--- a/tests/e2e/helpers/runCli.ts
+++ b/tests/e2e/helpers/runCli.ts
@@ -1,0 +1,118 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// tests/e2e/helpers → repo root is three levels up.
+export const REPO_ROOT = resolve(here, '..', '..', '..');
+export const CLI_ENTRY = join(REPO_ROOT, 'dist', 'index.js');
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  /** Exit code; signalled / spawn failures are normalized to 1. */
+  code: number;
+}
+
+export interface RunOptions {
+  /** Temp HOME the child must treat as ~ (sets HOME + USERPROFILE). */
+  home: string;
+  /** Extra env (e.g. git identity, TUCK_PASSWORD). Merged over the base env. */
+  env?: Record<string, string>;
+  /** Working directory for the child (default: home). */
+  cwd?: string;
+  /** Pipe to child stdin. */
+  input?: string;
+  /** Override the implicit TUCK_TARGET_ROOT=home write sandbox (default: on). */
+  sandbox?: boolean;
+}
+
+/**
+ * Spawn `node dist/index.js <args>` with a sanitized, hermetic environment:
+ *   - HOME/USERPROFILE → the temp home (relocates ~/.tuck, keystore, state dir);
+ *   - TUCK_TARGET_ROOT → home (belt-and-suspenders write confinement);
+ *   - CI=1, NO_UPDATE_NOTIFIER=1, non-TTY stdio → force non-interactive paths and
+ *     suppress the update banner that would corrupt JSON;
+ *   - EDITOR/GIT_EDITOR=true, GIT_TERMINAL_PROMPT=0 → any stray prompt exits fast.
+ * NEVER rejects on non-zero exit: the test asserts on { code, stdout, stderr }.
+ */
+export const runCli = (args: string[], opts: RunOptions): Promise<RunResult> => {
+  const { home, env = {}, cwd = home, input, sandbox = true } = opts;
+
+  const childEnv: NodeJS.ProcessEnv = {
+    // Minimal base (don't spread process.env — avoids leaking the operator's
+    // real HOME/XDG/git config into the child and breaking hermeticity).
+    PATH: process.env.PATH,
+    SystemRoot: process.env.SystemRoot, // Windows: node needs this
+    COMSPEC: process.env.COMSPEC, // Windows
+    HOME: home,
+    USERPROFILE: home, // Windows os.homedir()
+    XDG_STATE_HOME: '', // force the state/keystore dir under HOME, not host XDG
+    XDG_CONFIG_HOME: '',
+    CI: '1',
+    NO_UPDATE_NOTIFIER: '1',
+    FORCE_COLOR: '0',
+    NO_COLOR: '1',
+    EDITOR: 'true',
+    VISUAL: 'true',
+    GIT_EDITOR: 'true',
+    GIT_TERMINAL_PROMPT: '0',
+    ...(sandbox ? { TUCK_TARGET_ROOT: home } : {}),
+    ...env,
+  };
+
+  return new Promise((res) => {
+    const child = execFile(
+      process.execPath, // the same node running vitest
+      [CLI_ENTRY, ...args],
+      { cwd, env: childEnv, maxBuffer: 16 * 1024 * 1024, timeout: 55_000 },
+      (err, stdout, stderr) => {
+        const code =
+          err && typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 1 // signalled / spawn failure → treat as failure
+              : 0;
+        res({ stdout: String(stdout), stderr: String(stderr), code });
+      }
+    );
+    if (input !== undefined) child.stdin?.end(input);
+  });
+};
+
+/** Create a throwaway HOME under the OS temp dir; returns its absolute path. */
+export const makeHome = (): Promise<string> => mkdtemp(join(tmpdir(), 'tuck-e2e-'));
+
+export const cleanupHome = (home: string): Promise<void> => rm(home, { recursive: true, force: true });
+
+export const homePath = (home: string, rel: string): string => join(home, rel);
+
+export const fileExists = async (p: string): Promise<boolean> => {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const readHomeFile = (home: string, rel: string): Promise<string> =>
+  readFile(join(home, rel), 'utf-8');
+
+/** Write a dotfile into the temp HOME before running `tuck add`. */
+export const seedHomeFile = async (home: string, rel: string, content: string): Promise<string> => {
+  const full = join(home, rel);
+  await mkdir(dirname(full), { recursive: true });
+  await writeFile(full, content);
+  return full;
+};
+
+/** Parse the single-line JSON envelope tuck emits under --json (last non-empty line). */
+export const parseEnvelope = (
+  stdout: string
+): { ok: boolean; command?: string; data?: Record<string, unknown>; error?: unknown } => {
+  const line = stdout.trim().split('\n').filter(Boolean).at(-1) ?? '';
+  return JSON.parse(line);
+};

--- a/tests/e2e/roundtrip.e2e.test.ts
+++ b/tests/e2e/roundtrip.e2e.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { ensureBuilt } from './helpers/build.js';
+import {
+  runCli,
+  makeHome,
+  cleanupHome,
+  seedHomeFile,
+  readHomeFile,
+  fileExists,
+  parseEnvelope,
+  homePath,
+} from './helpers/runCli.js';
+import { hasGit, gitIdentityEnv } from './helpers/git.js';
+
+/**
+ * Case (a): the flagship lifecycle, end-to-end through the real binary —
+ * init (local/bare, no network) → add → sync (commit, no push) → apply FROM the
+ * local repo dir into a CLEAN home, asserting the dotfile re-materializes on disk.
+ */
+describe('e2e: init → add → sync → apply round-trip', () => {
+  beforeAll(async () => {
+    await ensureBuilt();
+  }, 180_000);
+
+  const homes: string[] = [];
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(cleanupHome));
+  });
+
+  it('tracks a dotfile, commits it, and re-materializes it on a clean machine', async () => {
+    if (!(await hasGit())) return;
+    const src = await makeHome();
+    homes.push(src);
+    const env = { ...gitIdentityEnv() };
+
+    await seedHomeFile(src, '.zshrc', 'export EDITOR=vim\n');
+
+    const init = await runCli(['init', '--bare', '--json'], { home: src, env });
+    expect(init.code).toBe(0);
+    expect(parseEnvelope(init.stdout).ok).toBe(true);
+    expect(await fileExists(homePath(src, '.tuck/.tuckmanifest.json'))).toBe(true);
+
+    const add = await runCli(['add', join(src, '.zshrc'), '--json', '--yes'], { home: src, env });
+    expect(add.code).toBe(0);
+    expect(parseEnvelope(add.stdout)).toMatchObject({ ok: true, data: { added: 1 } });
+
+    const sync = await runCli(['sync', '--json', '--no-push'], { home: src, env });
+    expect(sync.code).toBe(0);
+    // NOTE: `apply` reads the repo WORKING TREE, so clean-machine re-materialization
+    // does not require a git commit. Sync's commit-on-initial-add behavior is a
+    // separate axis — see the it.todo below (a real gap this harness surfaced).
+
+    // Clean machine: apply FROM the machine-1 repo dir (a local dir source ⇒ no network).
+    const dst = await makeHome();
+    homes.push(dst);
+    const apply = await runCli(['apply', homePath(src, '.tuck'), '--json', '--force'], { home: dst, env });
+    expect(apply.code).toBe(0);
+    expect(parseEnvelope(apply.stdout)).toMatchObject({ ok: true, data: { applied: 1 } });
+
+    // The load-bearing assertion: the file re-materialized into the new HOME.
+    expect(await readHomeFile(dst, '.zshrc')).toBe('export EDITOR=vim\n');
+  });
+
+  // Finding surfaced by this harness: after `tuck add`, `tuck sync` reports
+  // noop:true while ~/.tuck still has the new files UNCOMMITTED — so `tuck push`
+  // would push nothing for the initial add. Sync's no-op is keyed on tracked-file
+  // drift (live-vs-repo), not on the git working-tree state. Track the fix here.
+  it.todo('sync should commit the initial add (currently reports noop with uncommitted ~/.tuck files)');
+
+  it('apply is idempotent — a second apply changes nothing on disk (non-shell file)', async () => {
+    if (!(await hasGit())) return;
+    const src = await makeHome();
+    homes.push(src);
+    const env = { ...gitIdentityEnv() };
+    // A non-shell file: apply is a straight write (no smartMerge), so byte-identical
+    // after the 2nd apply is a sound idempotency invariant.
+    await seedHomeFile(src, '.gitconfig', '[user]\n  name = Ada\n');
+    await runCli(['init', '--bare', '--json'], { home: src, env });
+    await runCli(['add', join(src, '.gitconfig'), '--json', '--yes'], { home: src, env });
+    await runCli(['sync', '--json', '--no-push'], { home: src, env });
+
+    const dst = await makeHome();
+    homes.push(dst);
+    const repoDir = homePath(src, '.tuck');
+
+    const first = await runCli(['apply', repoDir, '--json', '--force'], { home: dst, env });
+    expect(first.code).toBe(0);
+    const after1 = await readHomeFile(dst, '.gitconfig');
+
+    const second = await runCli(['apply', repoDir, '--json', '--force'], { home: dst, env });
+    expect(second.code).toBe(0); // a second apply still succeeds
+    const after2 = await readHomeFile(dst, '.gitconfig');
+
+    expect(after2).toBe(after1);
+    expect(after2).toBe('[user]\n  name = Ada\n');
+  });
+});

--- a/tests/e2e/roundtrip.e2e.test.ts
+++ b/tests/e2e/roundtrip.e2e.test.ts
@@ -47,9 +47,9 @@ describe('e2e: init → add → sync → apply round-trip', () => {
 
     const sync = await runCli(['sync', '--json', '--no-push'], { home: src, env });
     expect(sync.code).toBe(0);
-    // NOTE: `apply` reads the repo WORKING TREE, so clean-machine re-materialization
-    // does not require a git commit. Sync's commit-on-initial-add behavior is a
-    // separate axis — see the it.todo below (a real gap this harness surfaced).
+    const syncData = parseEnvelope(sync.stdout).data as { commitHash: string | null; noop: boolean };
+    expect(syncData.commitHash).toBeTruthy(); // the initial add is committed (not a noop)
+    expect(syncData.noop).toBe(false);
 
     // Clean machine: apply FROM the machine-1 repo dir (a local dir source ⇒ no network).
     const dst = await makeHome();
@@ -61,12 +61,6 @@ describe('e2e: init → add → sync → apply round-trip', () => {
     // The load-bearing assertion: the file re-materialized into the new HOME.
     expect(await readHomeFile(dst, '.zshrc')).toBe('export EDITOR=vim\n');
   });
-
-  // Finding surfaced by this harness: after `tuck add`, `tuck sync` reports
-  // noop:true while ~/.tuck still has the new files UNCOMMITTED — so `tuck push`
-  // would push nothing for the initial add. Sync's no-op is keyed on tracked-file
-  // drift (live-vs-repo), not on the git working-tree state. Track the fix here.
-  it.todo('sync should commit the initial add (currently reports noop with uncommitted ~/.tuck files)');
 
   it('apply is idempotent — a second apply changes nothing on disk (non-shell file)', async () => {
     if (!(await hasGit())) return;

--- a/tests/e2e/template.e2e.test.ts
+++ b/tests/e2e/template.e2e.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { platform } from 'node:process';
+import { ensureBuilt } from './helpers/build.js';
+import { runCli, makeHome, cleanupHome, seedHomeFile, readHomeFile, homePath } from './helpers/runCli.js';
+import { hasGit, gitIdentityEnv } from './helpers/git.js';
+
+/**
+ * Case (c1): exercises the P0-1 templating feature through the REAL binary —
+ * `add --template` stores the source verbatim (NOT rendered at storage time),
+ * and `apply` renders `{{os}}` to the runner's platform on the way to disk.
+ */
+describe('e2e: template round-trip (add --template → apply renders {{os}})', () => {
+  beforeAll(async () => {
+    await ensureBuilt();
+  }, 180_000);
+
+  const homes: string[] = [];
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(cleanupHome));
+  });
+
+  it('stores the template verbatim and renders {{os}} on apply', async () => {
+    if (!(await hasGit())) return;
+    const src = await makeHome();
+    homes.push(src);
+    const env = { ...gitIdentityEnv() };
+
+    await seedHomeFile(src, '.config/tuck-demo/os.txt', 'platform={{os}}\n');
+
+    await runCli(['init', '--bare', '--json'], { home: src, env });
+    const add = await runCli(
+      ['add', join(src, '.config/tuck-demo/os.txt'), '--template', '--json', '--yes'],
+      { home: src, env }
+    );
+    expect(add.code).toBe(0);
+
+    // Stored VERBATIM — locate the repo copy via the manifest (robust to category detection).
+    const manifest = JSON.parse(await readFile(homePath(src, '.tuck/.tuckmanifest.json'), 'utf-8')) as {
+      files: Record<string, { destination: string; template: boolean }>;
+    };
+    const entry = Object.values(manifest.files)[0];
+    expect(entry.template).toBe(true);
+    const repoCopy = await readFile(homePath(src, join('.tuck', entry.destination)), 'utf-8');
+    expect(repoCopy).toContain('{{os}}'); // proves storage-time is NOT rendered
+
+    await runCli(['sync', '--json', '--no-push'], { home: src, env });
+
+    // Apply into a clean home → the token renders to the runner's platform.
+    const dst = await makeHome();
+    homes.push(dst);
+    const apply = await runCli(['apply', homePath(src, '.tuck'), '--json', '--force'], { home: dst, env });
+    expect(apply.code).toBe(0);
+
+    const rendered = await readHomeFile(dst, '.config/tuck-demo/os.txt');
+    expect(rendered).toBe(`platform=${platform}\n`); // {{os}} → darwin | linux | win32
+    expect(rendered).not.toContain('{{os}}');
+  });
+});

--- a/tests/e2e/verify-exit-code.e2e.test.ts
+++ b/tests/e2e/verify-exit-code.e2e.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { ensureBuilt } from './helpers/build.js';
+import { runCli, makeHome, cleanupHome, seedHomeFile, parseEnvelope } from './helpers/runCli.js';
+import { hasGit, gitIdentityEnv } from './helpers/git.js';
+
+/**
+ * Case (b): `tuck verify --exit-code` is the CI drift gate. A memfs unit test
+ * that stubs process.exitCode cannot prove the flag actually gates end-to-end;
+ * this spawns the real binary and reads the real exit code.
+ */
+describe('e2e: verify --exit-code CI gate', () => {
+  beforeAll(async () => {
+    await ensureBuilt();
+  }, 180_000);
+
+  const homes: string[] = [];
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(cleanupHome));
+  });
+
+  const setupTracked = async () => {
+    const home = await makeHome();
+    homes.push(home);
+    const env = { ...gitIdentityEnv() };
+    await seedHomeFile(home, '.vimrc', 'set number\n');
+    const init = await runCli(['init', '--bare', '--json'], { home, env });
+    expect(init.code).toBe(0);
+    const add = await runCli(['add', join(home, '.vimrc'), '--json', '--yes'], { home, env });
+    expect(add.code).toBe(0);
+    return { home, env };
+  };
+
+  it('exits 0 when everything is in sync', async () => {
+    if (!(await hasGit())) return;
+    const { home, env } = await setupTracked();
+    const r = await runCli(['verify', '--exit-code', '--json'], { home, env });
+    expect(r.code).toBe(0);
+    expect(parseEnvelope(r.stdout).ok).toBe(true);
+  });
+
+  it('exits 1 when the live file has drifted from the repo copy', async () => {
+    if (!(await hasGit())) return;
+    const { home, env } = await setupTracked();
+    // Mutate the LIVE file so live ≠ repo ⇒ drift.
+    await seedHomeFile(home, '.vimrc', 'set number\nset relativenumber\n');
+    const r = await runCli(['verify', '--exit-code', '--json'], { home, env });
+    expect(r.code).toBe(1); // the CI gate trips
+    expect(parseEnvelope(r.stdout).ok).toBe(true); // verify itself succeeded; exit code carries drift
+  });
+
+  it('exits 0 on drift WITHOUT --exit-code (report-only mode)', async () => {
+    if (!(await hasGit())) return;
+    const { home, env } = await setupTracked();
+    await seedHomeFile(home, '.vimrc', 'set number\nset relativenumber\n');
+    const r = await runCli(['verify', '--json'], { home, env }); // no --exit-code
+    expect(r.code).toBe(0); // reporting drift must not fail CI
+  });
+});

--- a/tests/lib/fileTracking.test.ts
+++ b/tests/lib/fileTracking.test.ts
@@ -4,6 +4,14 @@ import { join } from 'path';
 import { trackFilesWithProgress } from '../../src/lib/fileTracking.js';
 import { clearManifestCache, getTrackedFileBySource, loadManifest } from '../../src/lib/manifest.js';
 import { initTestTuck, createTestDotfile, TEST_TUCK_DIR } from '../utils/testHelpers.js';
+import { isEncryptedFile, decryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
+
+const retrieveMock = vi.fn();
+vi.mock('../../src/lib/crypto/keystore/index.js', () => ({
+  getKeystore: vi.fn(async () => ({ retrieve: retrieveMock })),
+  TUCK_SERVICE: 'tuck-dotfiles',
+  TUCK_ACCOUNT: 'backup-encryption',
+}));
 
 describe('fileTracking symlink strategy', () => {
   beforeEach(() => {
@@ -48,6 +56,74 @@ describe('fileTracking symlink strategy', () => {
 
     vol.writeFileSync(sourcePath, 'export TRACKING_TEST=2');
     expect(vol.readFileSync(repoPath, 'utf-8')).toBe('export TRACKING_TEST=2');
+
+    logSpy.mockRestore();
+  });
+
+  it('encrypts the file at rest when encrypt is set (encrypted:true, TCKE1 ciphertext)', async () => {
+    retrieveMock.mockResolvedValue('pw');
+    await initTestTuck();
+    createTestDotfile('.netrc', 'machine example login bob');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await trackFilesWithProgress([{ path: '~/.netrc', category: 'misc' }], TEST_TUCK_DIR, {
+      strategy: 'copy',
+      encrypt: true,
+      showCategory: false,
+      delayBetween: 0,
+    });
+    expect(result.succeeded).toBe(1);
+
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.netrc');
+    expect(tracked!.file.encrypted).toBe(true);
+
+    // The repo copy is TCKE1 ciphertext that round-trips back to the plaintext.
+    const repoPath = join(TEST_TUCK_DIR, tracked!.file.destination);
+    const stored = Buffer.from(vol.readFileSync(repoPath));
+    expect(isEncryptedFile(stored)).toBe(true);
+    expect((await decryptFileContent(stored, 'pw')).toString('utf8')).toBe('machine example login bob');
+
+    logSpy.mockRestore();
+  });
+
+  it('marks a file as a template (template:true) and stores the source verbatim', async () => {
+    await initTestTuck();
+    createTestDotfile('.gitconfig', '[user]\n  name = {{user}}');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await trackFilesWithProgress([{ path: '~/.gitconfig', category: 'git' }], TEST_TUCK_DIR, {
+      strategy: 'copy',
+      template: true,
+      showCategory: false,
+      delayBetween: 0,
+    });
+
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.gitconfig');
+    expect(tracked!.file.template).toBe(true);
+    // Stored verbatim — NOT rendered at storage time (the repo holds the source).
+    const repoPath = join(TEST_TUCK_DIR, tracked!.file.destination);
+    expect(vol.readFileSync(repoPath, 'utf-8')).toContain('{{user}}');
+
+    logSpy.mockRestore();
+  });
+
+  it('fails clearly when encrypt is set but no encryption password is configured', async () => {
+    retrieveMock.mockResolvedValue(null);
+    await initTestTuck();
+    createTestDotfile('.secret', 'top secret');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await trackFilesWithProgress([{ path: '~/.secret', category: 'misc' }], TEST_TUCK_DIR, {
+      strategy: 'copy',
+      encrypt: true,
+      showCategory: false,
+      delayBetween: 0,
+    });
+
+    // Per-file failure is captured (never throws away the whole batch, never writes plaintext).
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.errors[0].error.message).toMatch(/encryption password/i);
 
     logSpy.mockRestore();
   });

--- a/tests/lib/materialize.test.ts
+++ b/tests/lib/materialize.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { materializeForLive } from '../../src/lib/materialize.js';
+import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
+import { MaterializeError } from '../../src/errors.js';
+
+const ctx = { os: 'darwin', hostname: 'mac1' };
+const deps = (pass: string | null = 'pw') => ({ getPassphrase: async () => pass });
+
+describe('materializeForLive', () => {
+  it('renders a template file using the context', async () => {
+    const repo = Buffer.from('host={{hostname}} os={{os}}');
+    const out = await materializeForLive(
+      repo,
+      { template: true, encrypted: false, source: '~/.x' },
+      ctx,
+      deps()
+    );
+    expect(out).toBe('host=mac1 os=darwin');
+  });
+
+  it('passes plain non-template files through unchanged', async () => {
+    const repo = Buffer.from('literal {{kept-because-not-a-template}}');
+    const out = await materializeForLive(
+      repo,
+      { template: false, encrypted: false, source: '~/.x' },
+      ctx,
+      deps()
+    );
+    expect(out).toBe('literal {{kept-because-not-a-template}}');
+  });
+
+  it('decrypts an encrypted file', async () => {
+    const repo = await encryptFileContent(Buffer.from('secret-body'), 'pw');
+    const out = await materializeForLive(
+      repo,
+      { template: false, encrypted: true, source: '~/.s' },
+      ctx,
+      deps('pw')
+    );
+    expect(out).toBe('secret-body');
+  });
+
+  it('decrypts THEN renders for encrypted+template files', async () => {
+    const repo = await encryptFileContent(Buffer.from('os={{os}}'), 'pw');
+    const out = await materializeForLive(
+      repo,
+      { template: true, encrypted: true, source: '~/.s' },
+      ctx,
+      deps('pw')
+    );
+    expect(out).toBe('os=darwin');
+  });
+
+  it('decrypts a file detected by magic header even if the flag is unset', async () => {
+    const repo = await encryptFileContent(Buffer.from('detected'), 'pw');
+    const out = await materializeForLive(
+      repo,
+      { template: false, encrypted: false, source: '~/.s' },
+      ctx,
+      deps('pw')
+    );
+    expect(out).toBe('detected');
+  });
+
+  it('throws MaterializeError when an encrypted file has no passphrase', async () => {
+    const repo = await encryptFileContent(Buffer.from('x'), 'pw');
+    await expect(
+      materializeForLive(
+        repo,
+        { template: false, encrypted: true, source: '~/.s' },
+        ctx,
+        deps(null)
+      )
+    ).rejects.toBeInstanceOf(MaterializeError);
+  });
+
+  it('throws MaterializeError on a wrong passphrase (never returns ciphertext)', async () => {
+    const repo = await encryptFileContent(Buffer.from('x'), 'right');
+    await expect(
+      materializeForLive(
+        repo,
+        { template: false, encrypted: true, source: '~/.s' },
+        ctx,
+        deps('wrong')
+      )
+    ).rejects.toBeInstanceOf(MaterializeError);
+  });
+});

--- a/tests/lib/stateModel.test.ts
+++ b/tests/lib/stateModel.test.ts
@@ -7,10 +7,18 @@
  * recorded checksum — and classifies the drift. classifyFileState is the pure
  * core of that comparison.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { vol } from 'memfs';
 import { classifyFileState, computeStateModel } from '../../src/lib/stateModel.js';
 import { clearManifestCache } from '../../src/lib/manifest.js';
+import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
+
+const retrieveMock = vi.fn();
+vi.mock('../../src/lib/crypto/keystore/index.js', () => ({
+  getKeystore: vi.fn(async () => ({ retrieve: retrieveMock })),
+  TUCK_SERVICE: 'tuck-dotfiles',
+  TUCK_ACCOUNT: 'backup-encryption',
+}));
 
 describe('classifyFileState', () => {
   it('ok when live == repo == manifest', () => {
@@ -79,6 +87,58 @@ describe('computeStateModel', () => {
     expect(model).toHaveLength(1);
     expect(model[0].state).toBe('ok');
     expect(model[0].source).toBe('~/.zshrc');
+  });
+
+  const ts = '2026-01-01T00:00:00.000Z';
+  const writeManifest = (entry: Record<string, unknown>): void => {
+    vol.writeFileSync(
+      `${TUCK}/.tuckmanifest.json`,
+      JSON.stringify({ version: '1', created: ts, updated: ts, files: { f: entry }, bundles: {} })
+    );
+  };
+
+  it('reports ok for a correctly-applied template file (no false drift)', async () => {
+    vol.writeFileSync('/test-home/.zshrc', `os=${process.platform}`);
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'os={{os}}');
+    const { getFileChecksum } = await import('../../src/lib/files.js');
+    const repoChecksum = await getFileChecksum(`${TUCK}/files/shell/zshrc`);
+    writeManifest({
+      source: '~/.zshrc', destination: 'files/shell/zshrc', category: 'shell',
+      strategy: 'copy', template: true, encrypted: false, checksum: repoChecksum, added: ts, modified: ts,
+    });
+
+    const model = await computeStateModel(TUCK);
+    expect(model[0].state).toBe('ok');
+  });
+
+  it('reports drift-local for a hand-edited template live file (needs apply)', async () => {
+    vol.writeFileSync('/test-home/.zshrc', 'HAND EDITED');
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'os={{os}}');
+    const { getFileChecksum } = await import('../../src/lib/files.js');
+    const repoChecksum = await getFileChecksum(`${TUCK}/files/shell/zshrc`);
+    writeManifest({
+      source: '~/.zshrc', destination: 'files/shell/zshrc', category: 'shell',
+      strategy: 'copy', template: true, encrypted: false, checksum: repoChecksum, added: ts, modified: ts,
+    });
+
+    const model = await computeStateModel(TUCK);
+    expect(model[0].state).toBe('drift-local');
+  });
+
+  it('degrades to ok for an encrypted file when the keystore is locked', async () => {
+    retrieveMock.mockResolvedValue(null); // locked / no passphrase available
+    const ciphertext = await encryptFileContent(Buffer.from('SECRET=1'), 'pw');
+    vol.writeFileSync('/test-home/.netrc', 'SECRET=1');
+    vol.writeFileSync(`${TUCK}/files/shell/netrc`, ciphertext);
+    const { getFileChecksum } = await import('../../src/lib/files.js');
+    const repoChecksum = await getFileChecksum(`${TUCK}/files/shell/netrc`);
+    writeManifest({
+      source: '~/.netrc', destination: 'files/shell/netrc', category: 'shell',
+      strategy: 'copy', template: false, encrypted: true, checksum: repoChecksum, added: ts, modified: ts,
+    });
+
+    const model = await computeStateModel(TUCK);
+    expect(model[0].state).toBe('ok');
   });
 
   it('reports drift-local when the live file was edited', async () => {

--- a/tests/lib/stateModel.test.ts
+++ b/tests/lib/stateModel.test.ts
@@ -141,6 +141,22 @@ describe('computeStateModel', () => {
     expect(model[0].state).toBe('ok');
   });
 
+  it('reports drift for a template DIRECTORY (no false ok via the materialize catch)', async () => {
+    vol.mkdirSync(`${TUCK}/files/x`, { recursive: true });
+    vol.writeFileSync(`${TUCK}/files/x/a`, 'repo\n');
+    vol.mkdirSync('/test-home/x', { recursive: true });
+    vol.writeFileSync('/test-home/x/a', 'LIVE DIFFERENT\n'); // live dir differs from repo dir
+    const { getFileChecksum } = await import('../../src/lib/files.js');
+    const repoChecksum = await getFileChecksum(`${TUCK}/files/x`);
+    writeManifest({
+      source: '~/x', destination: 'files/x', category: 'misc',
+      strategy: 'copy', template: true, encrypted: false, checksum: repoChecksum, added: ts, modified: ts,
+    });
+
+    const model = await computeStateModel(TUCK);
+    expect(model[0].state).toBe('drift-local');
+  });
+
   it('reports drift-local when the live file was edited', async () => {
     vol.writeFileSync('/test-home/.zshrc', 'EDITED\n');
     vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'original\n');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
         lines: 40,
       },
     },
+    // e2e tests spawn the real built binary against a real temp HOME; they run
+    // under vitest.e2e.config.ts (no memfs setup) and must NOT be picked up by
+    // the default memfs run.
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests/e2e/**'],
     testTimeout: 10000,
     mockReset: true,
     restoreMocks: true,

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * End-to-end config: spawns the REAL built binary (dist/index.js) against a
+ * REAL temp HOME. Deliberately has NO setupFiles — it must NOT load
+ * tests/setup.ts, whose global vi.mock(fs|fs/promises|fs-extra|os) would confine
+ * the PARENT test to memfs while the spawned child writes to the real disk (two
+ * different filesystems → unobservable). Real fs/os is required here.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['tests/e2e/**/*.e2e.test.ts'],
+    setupFiles: [], // the whole point: no memfs / os mock
+    testTimeout: 60_000, // child spawn + (optional) real git is slow vs unit tests
+    hookTimeout: 180_000, // beforeAll may build the binary
+    // Each spawn is an isolated OS process; in-process pooling buys nothing and a
+    // single fork avoids cross-test cwd/env interference.
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    sequence: { shuffle: false },
+  },
+});


### PR DESCRIPTION
## Summary
Implements the **P0 tier** of the 2026-06 chezmoi-parity audit (`docs/CHEZMOI-PARITY-AUDIT-2026-06.md`), plus a correctness fix the new e2e harness surfaced. Built test-first with atomic commits; full gate green throughout.

- **P0-1 — templating wired into apply/restore.** A shared `materialize` step (`src/lib/materialize.ts`) renders `{{os}}`/`tuck:` templates and decrypts TCKE1 files on the way to the live system. `sync` no longer captures (clobbers) a template source or leaks plaintext for encrypted files; `status`/`verify` compare these files as `live vs materialize(repo)` so they don't show false drift.
- **P0-2 — decrypt-on-apply** + `tuck add --template` / `--encrypt` (encrypt-on-store; rejected with the symlink strategy).
- **P0-3 — MCP server widened 6 → 11 tools.** Adds `verify`, `diff` (metadata only), `scan_untracked`, `secrets_status` (values REDACTED — never returns raw value/context/placeholder), and `apply_plan` (sandboxed dry-run; write-context snapshot/restore so a global `--root` survives the long-running server). Hardening: `tools/list` `writeGated`/`readOnlyHint` annotations + optional-arg type-checking.
- **P0-4 — e2e binary harness.** Isolated vitest project (`vitest.e2e.config.ts`, no memfs) that spawns the real `dist/index.js` against a temp HOME: init→add→sync→apply round-trip + idempotency, `verify --exit-code` CI-gate semantics, and a template round-trip validating P0-1 through the real binary.
- **fix(sync)** — the e2e harness caught that `tuck sync` reported `noop` after the initial `add` while `~/.tuck` still had uncommitted files (so `push` pushed nothing). `runSyncCommand` now consults `getStatus().hasChanges` and commits pending repo changes, mirroring the interactive path.

Design specs + implementation plans under `docs/superpowers/{specs,plans}/`.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 1233 unit/integration tests green (124 files)
- [x] `pnpm test:e2e` — 6 real-binary e2e tests green
- [x] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)