### PR TITLE
fix(secrets): stop redaction corrupting live dotfiles and leaking partial secrets

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -9,6 +9,7 @@ import type { AddOptions } from '../types.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 import {
   preparePathsForTracking,
+  restoreRedactedLiveFiles,
   type PreparedTrackFile,
   type TrackPathCandidate,
 } from '../lib/trackPipeline.js';
@@ -77,6 +78,10 @@ const addFiles = async (
     template: options.template,
     actionVerb: 'Tracking',
   });
+
+  // The redacted copies are in the repo now — put the original values back in
+  // the LIVE files so the user's actual config keeps working (issue #100).
+  await restoreRedactedLiveFiles(filesToAdd, tuckDir);
 };
 
 const runInteractiveAdd = async (tuckDir: string, options: AddOptions = {}): Promise<void> => {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -70,18 +70,21 @@ const addFiles = async (
     return trackedFile;
   });
 
-  await trackFilesWithProgress(filesToTrack, tuckDir, {
-    showCategory: true,
-    // Repo scope is always copy; --symlink is rejected upstream for repo adds.
-    strategy: options.symlink ? 'symlink' : undefined,
-    encrypt: options.encrypt,
-    template: options.template,
-    actionVerb: 'Tracking',
-  });
-
-  // The redacted copies are in the repo now — put the original values back in
-  // the LIVE files so the user's actual config keeps working (issue #100).
-  await restoreRedactedLiveFiles(filesToAdd, tuckDir);
+  try {
+    await trackFilesWithProgress(filesToTrack, tuckDir, {
+      showCategory: true,
+      // Repo scope is always copy; --symlink is rejected upstream for repo adds.
+      strategy: options.symlink ? 'symlink' : undefined,
+      encrypt: options.encrypt,
+      template: options.template,
+      actionVerb: 'Tracking',
+    });
+  } finally {
+    // The redacted copies are in the repo now (or tracking failed and will be
+    // retried) — either way, put the original values back in the LIVE files so
+    // the user's actual config keeps working (issue #100).
+    await restoreRedactedLiveFiles(filesToAdd, tuckDir);
+  }
 };
 
 const runInteractiveAdd = async (tuckDir: string, options: AddOptions = {}): Promise<void> => {
@@ -129,36 +132,45 @@ const runInteractiveAdd = async (tuckDir: string, options: AddOptions = {}): Pro
     return;
   }
 
-  for (const file of filesToAdd) {
-    prompts.log.step(`${file.source}`);
+  // preparePathsForTracking may have redacted live files. Every exit from here
+  // on — declining the confirm, cancelling a prompt (OperationCancelledError),
+  // or a tracking failure — must put the original values back, or the user's
+  // live config is left with `{{PLACEHOLDER}}` in it (issue #100). addFiles
+  // restores on its own path too; a second restore is a no-op.
+  try {
+    for (const file of filesToAdd) {
+      prompts.log.step(`${file.source}`);
 
-    const categoryOptions = Object.entries(CATEGORIES).map(([name, config]) => ({
-      value: name,
-      label: `${config.icon} ${name}`,
-      hint: file.category === name ? '(auto-detected)' : undefined,
-    }));
+      const categoryOptions = Object.entries(CATEGORIES).map(([name, config]) => ({
+        value: name,
+        label: `${config.icon} ${name}`,
+        hint: file.category === name ? '(auto-detected)' : undefined,
+      }));
 
-    categoryOptions.sort((a, b) => {
-      if (a.value === file.category) return -1;
-      if (b.value === file.category) return 1;
-      return 0;
-    });
+      categoryOptions.sort((a, b) => {
+        if (a.value === file.category) return -1;
+        if (b.value === file.category) return 1;
+        return 0;
+      });
 
-    const selectedCategory = await prompts.select('Category:', categoryOptions);
-    file.category = selectedCategory as string;
+      const selectedCategory = await prompts.select('Category:', categoryOptions);
+      file.category = selectedCategory as string;
+    }
+
+    const confirm = await prompts.confirm(
+      `Add ${filesToAdd.length} ${filesToAdd.length === 1 ? 'file' : 'files'}?`,
+      true
+    );
+
+    if (!confirm) {
+      prompts.cancel('Operation cancelled');
+      return;
+    }
+
+    await addFiles(filesToAdd, tuckDir, options);
+  } finally {
+    await restoreRedactedLiveFiles(filesToAdd, tuckDir);
   }
-
-  const confirm = await prompts.confirm(
-    `Add ${filesToAdd.length} ${filesToAdd.length === 1 ? 'file' : 'files'}?`,
-    true
-  );
-
-  if (!confirm) {
-    prompts.cancel('Operation cancelled');
-    return;
-  }
-
-  await addFiles(filesToAdd, tuckDir, options);
 
   prompts.outro(`Added ${filesToAdd.length} ${filesToAdd.length === 1 ? 'file' : 'files'}`);
   logger.info("Run 'tuck sync' to commit changes");
@@ -250,6 +262,11 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
       repoKey: options.repoKey,
     });
 
+    // A plan never copies anything into the repo, but the interactive secret
+    // prompt above may have redacted live files — put the values back NOW or a
+    // dry run leaves the user's real config broken (issue #100).
+    await restoreRedactedLiveFiles(plannedFiles, tuckDir);
+
     const bundle = options.bundle ?? 'default';
     if (isJsonMode()) {
       emitJsonOk({
@@ -321,12 +338,18 @@ export const addCommand = new Command('add')
   .option('-n, --name <name>', 'Custom name for the file in manifest')
   .option('--symlink', 'Copy into tuck repo, then replace source path with a symlink')
   .option('--template', 'Mark as a template: rendered on apply (sync will not capture live edits)')
-  .option('--encrypt', 'Encrypt the file at rest in the repo (decrypted on apply; needs an encryption password)')
+  .option(
+    '--encrypt',
+    'Encrypt the file at rest in the repo (decrypted on apply; needs an encryption password)'
+  )
   .option(
     '--repo [dir]',
     'Track as repo-scoped (file lives in a git repo; auto-detects the root from the path when no dir is given)'
   )
-  .option('--repo-key <key>', 'Explicit stable repo identity (advanced; default derives from the remote)')
+  .option(
+    '--repo-key <key>',
+    'Explicit stable repo identity (advanced; default derives from the remote)'
+  )
   .option('-f, --force', 'Skip secret scanning (not recommended)')
   .option('-b, --bundle <name>', 'Bundle to assign the file to (defaults to "default")')
   .option('--json', 'Emit JSON envelope to stdout (non-interactive)')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -65,7 +65,7 @@ import { CATEGORIES } from '../constants.js';
 import { defaultConfig } from '../schemas/config.schema.js';
 import type { InitOptions } from '../types.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
-import { preparePathsForTracking } from '../lib/trackPipeline.js';
+import { preparePathsForTracking, restoreRedactedLiveFiles } from '../lib/trackPipeline.js';
 import { errorToMessage } from '../lib/validation.js';
 import { REPO_RUNTIME_GITIGNORE_PATTERNS, ensureRuntimeArtifactsGitignored } from '../lib/state.js';
 
@@ -120,6 +120,10 @@ const trackFilesWithProgressInit = async (
     showCategory: true,
     actionVerb: 'Tracking',
   });
+
+  // The redacted copies are in the repo now — put the original values back in
+  // the LIVE files so the user's actual config keeps working (issue #100).
+  await restoreRedactedLiveFiles(prepared, tuckDir);
 
   return result.succeeded;
 };

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -5,7 +5,7 @@ import { loadManifest, buildSourceIndex } from '../lib/manifest.js';
 import { detectDotfiles, DETECTION_CATEGORIES, DetectedFile } from '../lib/detect.js';
 import { NotInitializedError } from '../errors.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
-import { preparePathsForTracking } from '../lib/trackPipeline.js';
+import { preparePathsForTracking, restoreRedactedLiveFiles } from '../lib/trackPipeline.js';
 import { shouldExcludeFromBin } from '../lib/binary.js';
 import { loadTuckignore, isIgnoredInSet } from '../lib/tuckignore.js';
 import { setJsonMode, emitJsonOk, isJsonMode, addJsonWarning } from '../lib/jsonOutput.js';
@@ -252,6 +252,10 @@ const addFilesWithProgress = async (
     showCategory: true,
     actionVerb: 'Tracking',
   });
+
+  // The redacted copies are in the repo now — put the original values back in
+  // the LIVE files so the user's actual config keeps working (issue #100).
+  await restoreRedactedLiveFiles(prepared, tuckDir);
 
   return result.succeeded;
 };

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -56,7 +56,14 @@ import {
   restoreRedactedLivePaths,
   type PreparedTrackFile,
 } from '../lib/trackPipeline.js';
-import { scanForSecrets, isSecretScanningEnabled, shouldBlockOnSecrets, processSecretsForRedaction, redactFile, liveMatchesRestoredRepo } from '../lib/secrets/index.js';
+import {
+  scanForSecrets,
+  isSecretScanningEnabled,
+  shouldBlockOnSecrets,
+  processSecretsForRedaction,
+  redactFile,
+  liveMatchesRestoredRepo,
+} from '../lib/secrets/index.js';
 import { displayScanResults } from './secrets.js';
 import { logForceSecretBypass } from '../lib/audit.js';
 
@@ -81,7 +88,10 @@ interface SyncResult {
  */
 type TrackedFileChange = FileChange & { id?: string };
 
-const pathsResolveToSameLocation = async (sourcePath: string, destinationPath: string): Promise<boolean> => {
+const pathsResolveToSameLocation = async (
+  sourcePath: string,
+  destinationPath: string
+): Promise<boolean> => {
   try {
     const [resolvedSource, resolvedDestination] = await Promise.all([
       realpath(sourcePath),
@@ -223,9 +233,7 @@ const snapshotBeforePull = async (tuckDir: string, reason: string): Promise<void
     const tracked = await getAllTrackedFiles(tuckDir);
     // Resolve LIVE paths; drop unbound repo files (null) so we never snapshot a
     // bogus "key:rel" pseudo-path for a repo this machine hasn't linked.
-    const resolved = await Promise.all(
-      Object.values(tracked).map((f) => resolveLiveTarget(f))
-    );
+    const resolved = await Promise.all(Object.values(tracked).map((f) => resolveLiveTarget(f)));
     const sources = resolved.filter((p): p is string => p !== null);
     if (sources.length === 0) return;
     await createSnapshot(sources, reason);
@@ -325,8 +333,7 @@ const pullIfBehind = async (
         try {
           await abortRebase(tuckDir);
         } catch (abortError) {
-          const abortMsg =
-            abortError instanceof Error ? abortError.message : String(abortError);
+          const abortMsg = abortError instanceof Error ? abortError.message : String(abortError);
           logger.dim(`Could not abort in-progress rebase automatically: ${abortMsg}`);
         }
         // The dedicated exit code (3) + stable MERGE_CONFLICTS code + recovery
@@ -712,9 +719,7 @@ const scanAndHandleSecrets = async (
     // silently escaped both the .tuckignore write AND the filter and were
     // committed anyway. detectChanges keys .tuckignore on change.source, so that
     // is the correct value to record for BOTH scopes.
-    const secretLivePaths = new Set(
-      summary.results.filter((r) => r.hasSecrets).map((r) => r.path)
-    );
+    const secretLivePaths = new Set(summary.results.filter((r) => r.hasSecrets).map((r) => r.path));
     const sourcesToRemove = new Set<string>();
     for (const { change, live } of targets) {
       if (!secretLivePaths.has(live)) continue;
@@ -724,11 +729,7 @@ const scanAndHandleSecrets = async (
     }
     // Filter out ignored files from changes list
     // Note: This intentionally mutates the 'changes' array in place so callers see the filtered list
-    changes.splice(
-      0,
-      changes.length,
-      ...changes.filter((c) => !sourcesToRemove.has(c.source))
-    );
+    changes.splice(0, changes.length, ...changes.filter((c) => !sourcesToRemove.has(c.source)));
 
     if (changes.length === 0) {
       prompts.log.info('No remaining changes to sync');
@@ -783,284 +784,298 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
     redactedLivePaths = outcome.redactedLivePaths;
   }
 
-  // ========== STEP 3: Scan for new dotfiles (if enabled) ==========
-  let newFiles: DetectedFile[] = [];
-  if (options.scan !== false) {
-    const scanSpinner = prompts.spinner();
-    scanSpinner.start('Scanning for new dotfiles...');
-    newFiles = await detectNewDotfiles(tuckDir);
-    scanSpinner.stop(`Found ${newFiles.length} new dotfile${newFiles.length !== 1 ? 's' : ''}`);
-  }
-
-  // ========== STEP 4: Handle case where nothing to do ==========
-  if (changes.length === 0 && newFiles.length === 0) {
-    const gitStatus = await getStatus(tuckDir);
-    if (gitStatus.hasChanges) {
-      prompts.log.info('No dotfile changes, but repository has uncommitted changes');
-
-      const commitAnyway = await prompts.confirm('Commit repository changes?');
-      if (commitAnyway) {
-        const message = await prompts.text('Commit message:', {
-          defaultValue: 'Update dotfiles',
-        });
-
-        await stageAll(tuckDir);
-        const hash = await commit(tuckDir, message);
-        prompts.log.success(`Committed: ${hash.slice(0, 7)}`);
-
-        // Push if remote exists
-        if (options.push !== false && !(await checkLocalMode(tuckDir)) && (await hasRemote(tuckDir))) {
-          await pushWithSpinner(tuckDir, options);
-        }
-      }
-    } else {
-      prompts.log.success('Everything is up to date');
-    }
-    return;
-  }
-
-  // ========== STEP 5: Show changes to tracked files ==========
-  if (changes.length > 0) {
-    console.log();
-    console.log(c.bold('Changes to tracked files:'));
-    for (const change of changes) {
-      if (change.status === 'modified') {
-        console.log(c.yellow(`  ~ ${change.path}`));
-      } else if (change.status === 'deleted') {
-        console.log(c.red(`  - ${change.path}`));
-      }
-    }
-  }
-
-  // ========== STEP 6: Interactive selection for new files ==========
-  let filesToTrackCandidates: Array<{ path: string; category?: string }> = [];
-  let filesToTrack: FileToTrack[] = [];
-
-  if (newFiles.length > 0) {
-    console.log();
-    console.log(c.bold(`New dotfiles found (${newFiles.length}):`));
-
-    // Group by category for display
-    const grouped: Record<string, DetectedFile[]> = {};
-    for (const file of newFiles) {
-      if (!grouped[file.category]) grouped[file.category] = [];
-      grouped[file.category].push(file);
-    }
-
-    for (const [category, files] of Object.entries(grouped)) {
-      const categoryInfo = DETECTION_CATEGORIES[category] || { icon: '-', name: category };
-      console.log(
-        c.cyan(
-          `  ${categoryInfo.icon} ${categoryInfo.name}: ${files.length} file${files.length > 1 ? 's' : ''}`
-        )
-      );
-    }
-
-    console.log();
-    const trackNewFiles = await prompts.confirm(
-      'Would you like to track some of these new files?',
-      true
-    );
-
-    if (trackNewFiles) {
-      // Create multiselect options (pre-select non-sensitive files)
-      const selectOptions = newFiles.map((f) => ({
-        value: f.path,
-        label: `${collapsePath(expandPath(f.path))}${f.sensitive ? c.yellow(' [sensitive]') : ''}`,
-        hint: f.category,
-      }));
-
-      const nonSensitiveFiles = newFiles.filter((f) => !f.sensitive);
-      const initialValues = nonSensitiveFiles.map((f) => f.path);
-
-      const selected = await prompts.multiselect('Select files to track:', selectOptions, {
-        initialValues,
-      });
-
-      filesToTrackCandidates = (selected as string[]).map((path) => {
-        const matched = newFiles.find((file) => file.path === path);
-        return {
-          path,
-          category: matched?.category,
-        };
-      });
-    }
-  }
-
-  // ========== STEP 7: Handle large files in tracked changes ==========
-  const largeFiles: Array<{ path: string; size: string; sizeBytes: number }> = [];
-
-  for (const change of changes) {
-    if (change.status !== 'deleted') {
-      const expandedPath = expandPath(change.source);
-      const sizeCheck = await checkFileSizeThreshold(expandedPath);
-
-      if (sizeCheck.warn || sizeCheck.block) {
-        largeFiles.push({
-          path: change.path,
-          size: formatFileSize(sizeCheck.size),
-          sizeBytes: sizeCheck.size,
-        });
-      }
-    }
-  }
-
-  if (largeFiles.length > 0) {
-    console.log();
-    console.log(c.yellow('Large files detected:'));
-    for (const file of largeFiles) {
-      console.log(c.yellow(`  ${file.path} (${file.size})`));
-    }
-    console.log();
-    console.log(c.dim('GitHub has a 50MB warning and 100MB hard limit.'));
-    console.log();
-
-    const hasBlockers = largeFiles.some((f) => f.sizeBytes >= SIZE_BLOCK_THRESHOLD);
-
-    if (hasBlockers) {
-      const action = await prompts.select('Some files exceed 100MB. What would you like to do?', [
-        { value: 'ignore', label: 'Add large files to .tuckignore' },
-        { value: 'continue', label: 'Try to commit anyway (may fail)' },
-        { value: 'cancel', label: 'Cancel sync' },
-      ]);
-
-      if (action === 'ignore') {
-        for (const file of largeFiles) {
-          const fullPath = changes.find((c) => c.path === file.path)?.source;
-          if (fullPath) {
-            await addToTuckignore(tuckDir, fullPath);
-            const index = changes.findIndex((c) => c.path === file.path);
-            if (index > -1) changes.splice(index, 1);
-          }
-        }
-        prompts.log.success('Added large files to .tuckignore');
-
-        if (changes.length === 0 && filesToTrackCandidates.length === 0) {
-          prompts.log.info('No changes remaining to sync');
-          return;
-        }
-      } else if (action === 'cancel') {
-        prompts.cancel('Operation cancelled');
-        return;
-      }
-    } else {
-      const action = await prompts.select('Large files detected. What would you like to do?', [
-        { value: 'continue', label: 'Continue with sync' },
-        { value: 'ignore', label: 'Add to .tuckignore and skip' },
-        { value: 'cancel', label: 'Cancel sync' },
-      ]);
-
-      if (action === 'ignore') {
-        for (const file of largeFiles) {
-          const fullPath = changes.find((c) => c.path === file.path)?.source;
-          if (fullPath) {
-            await addToTuckignore(tuckDir, fullPath);
-            const index = changes.findIndex((c) => c.path === file.path);
-            if (index > -1) changes.splice(index, 1);
-          }
-        }
-        prompts.log.success('Added large files to .tuckignore');
-
-        if (changes.length === 0 && filesToTrackCandidates.length === 0) {
-          prompts.log.info('No changes remaining to sync');
-          return;
-        }
-      } else if (action === 'cancel') {
-        prompts.cancel('Operation cancelled');
-        return;
-      }
-    }
-  }
-
-  // ========== STEP 8: Track new files ==========
+  // Everything below can exit early (cancel prompts, large-file branches, "No
+  // changes remaining") or throw AFTER live files were redacted above / during
+  // new-file tracking. The finally at the bottom guarantees the original
+  // values always go back into the LIVE files (issue #100).
   let preparedNewFiles: PreparedTrackFile[] = [];
-  if (filesToTrackCandidates.length > 0) {
-    preparedNewFiles = await preparePathsForTracking(filesToTrackCandidates, tuckDir, {
-      secretHandling: 'interactive',
-    });
-    filesToTrack = preparedNewFiles.map((file) => ({
-      path: file.source,
-      category: file.category,
-    }));
-  }
+  try {
+    // ========== STEP 3: Scan for new dotfiles (if enabled) ==========
+    let newFiles: DetectedFile[] = [];
+    if (options.scan !== false) {
+      const scanSpinner = prompts.spinner();
+      scanSpinner.start('Scanning for new dotfiles...');
+      newFiles = await detectNewDotfiles(tuckDir);
+      scanSpinner.stop(`Found ${newFiles.length} new dotfile${newFiles.length !== 1 ? 's' : ''}`);
+    }
 
-  if (changes.length === 0 && filesToTrack.length === 0 && filesToTrackCandidates.length > 0) {
-    prompts.log.info('No changes remaining to sync');
-    return;
-  }
+    // ========== STEP 4: Handle case where nothing to do ==========
+    if (changes.length === 0 && newFiles.length === 0) {
+      const gitStatus = await getStatus(tuckDir);
+      if (gitStatus.hasChanges) {
+        prompts.log.info('No dotfile changes, but repository has uncommitted changes');
 
-  if (filesToTrack.length > 0) {
-    console.log();
-    await trackFilesWithProgress(filesToTrack, tuckDir, {
-      showCategory: true,
-      actionVerb: 'Tracking',
-    });
+        const commitAnyway = await prompts.confirm('Commit repository changes?');
+        if (commitAnyway) {
+          const message = await prompts.text('Commit message:', {
+            defaultValue: 'Update dotfiles',
+          });
 
-    // The redacted copies are in the repo now — put the original values back
-    // in the LIVE files so the user's actual config keeps working (issue #100).
-    await restoreRedactedLiveFiles(preparedNewFiles, tuckDir);
-  }
+          await stageAll(tuckDir);
+          const hash = await commit(tuckDir, message);
+          prompts.log.success(`Committed: ${hash.slice(0, 7)}`);
 
-  // ========== STEP 9: Sync changes to tracked files ==========
-  let result: SyncResult = { modified: [], deleted: [] };
+          // Push if remote exists
+          if (
+            options.push !== false &&
+            !(await checkLocalMode(tuckDir)) &&
+            (await hasRemote(tuckDir))
+          ) {
+            await pushWithSpinner(tuckDir, options);
+          }
+        }
+      } else {
+        prompts.log.success('Everything is up to date');
+      }
+      return;
+    }
 
-  if (changes.length > 0) {
-    // Generate commit message
-    const message =
-      options.message ||
-      generateCommitMessage({
-        modified: changes.filter((c) => c.status === 'modified').map((c) => c.path),
-        deleted: changes.filter((c) => c.status === 'deleted').map((c) => c.path),
+    // ========== STEP 5: Show changes to tracked files ==========
+    if (changes.length > 0) {
+      console.log();
+      console.log(c.bold('Changes to tracked files:'));
+      for (const change of changes) {
+        if (change.status === 'modified') {
+          console.log(c.yellow(`  ~ ${change.path}`));
+        } else if (change.status === 'deleted') {
+          console.log(c.red(`  - ${change.path}`));
+        }
+      }
+    }
+
+    // ========== STEP 6: Interactive selection for new files ==========
+    let filesToTrackCandidates: Array<{ path: string; category?: string }> = [];
+    let filesToTrack: FileToTrack[] = [];
+
+    if (newFiles.length > 0) {
+      console.log();
+      console.log(c.bold(`New dotfiles found (${newFiles.length}):`));
+
+      // Group by category for display
+      const grouped: Record<string, DetectedFile[]> = {};
+      for (const file of newFiles) {
+        if (!grouped[file.category]) grouped[file.category] = [];
+        grouped[file.category].push(file);
+      }
+
+      for (const [category, files] of Object.entries(grouped)) {
+        const categoryInfo = DETECTION_CATEGORIES[category] || { icon: '-', name: category };
+        console.log(
+          c.cyan(
+            `  ${categoryInfo.icon} ${categoryInfo.name}: ${files.length} file${files.length > 1 ? 's' : ''}`
+          )
+        );
+      }
+
+      console.log();
+      const trackNewFiles = await prompts.confirm(
+        'Would you like to track some of these new files?',
+        true
+      );
+
+      if (trackNewFiles) {
+        // Create multiselect options (pre-select non-sensitive files)
+        const selectOptions = newFiles.map((f) => ({
+          value: f.path,
+          label: `${collapsePath(expandPath(f.path))}${f.sensitive ? c.yellow(' [sensitive]') : ''}`,
+          hint: f.category,
+        }));
+
+        const nonSensitiveFiles = newFiles.filter((f) => !f.sensitive);
+        const initialValues = nonSensitiveFiles.map((f) => f.path);
+
+        const selected = await prompts.multiselect('Select files to track:', selectOptions, {
+          initialValues,
+        });
+
+        filesToTrackCandidates = (selected as string[]).map((path) => {
+          const matched = newFiles.find((file) => file.path === path);
+          return {
+            path,
+            category: matched?.category,
+          };
+        });
+      }
+    }
+
+    // ========== STEP 7: Handle large files in tracked changes ==========
+    const largeFiles: Array<{ path: string; size: string; sizeBytes: number }> = [];
+
+    for (const change of changes) {
+      if (change.status !== 'deleted') {
+        const expandedPath = expandPath(change.source);
+        const sizeCheck = await checkFileSizeThreshold(expandedPath);
+
+        if (sizeCheck.warn || sizeCheck.block) {
+          largeFiles.push({
+            path: change.path,
+            size: formatFileSize(sizeCheck.size),
+            sizeBytes: sizeCheck.size,
+          });
+        }
+      }
+    }
+
+    if (largeFiles.length > 0) {
+      console.log();
+      console.log(c.yellow('Large files detected:'));
+      for (const file of largeFiles) {
+        console.log(c.yellow(`  ${file.path} (${file.size})`));
+      }
+      console.log();
+      console.log(c.dim('GitHub has a 50MB warning and 100MB hard limit.'));
+      console.log();
+
+      const hasBlockers = largeFiles.some((f) => f.sizeBytes >= SIZE_BLOCK_THRESHOLD);
+
+      if (hasBlockers) {
+        const action = await prompts.select('Some files exceed 100MB. What would you like to do?', [
+          { value: 'ignore', label: 'Add large files to .tuckignore' },
+          { value: 'continue', label: 'Try to commit anyway (may fail)' },
+          { value: 'cancel', label: 'Cancel sync' },
+        ]);
+
+        if (action === 'ignore') {
+          for (const file of largeFiles) {
+            const fullPath = changes.find((c) => c.path === file.path)?.source;
+            if (fullPath) {
+              await addToTuckignore(tuckDir, fullPath);
+              const index = changes.findIndex((c) => c.path === file.path);
+              if (index > -1) changes.splice(index, 1);
+            }
+          }
+          prompts.log.success('Added large files to .tuckignore');
+
+          if (changes.length === 0 && filesToTrackCandidates.length === 0) {
+            prompts.log.info('No changes remaining to sync');
+            return;
+          }
+        } else if (action === 'cancel') {
+          prompts.cancel('Operation cancelled');
+          return;
+        }
+      } else {
+        const action = await prompts.select('Large files detected. What would you like to do?', [
+          { value: 'continue', label: 'Continue with sync' },
+          { value: 'ignore', label: 'Add to .tuckignore and skip' },
+          { value: 'cancel', label: 'Cancel sync' },
+        ]);
+
+        if (action === 'ignore') {
+          for (const file of largeFiles) {
+            const fullPath = changes.find((c) => c.path === file.path)?.source;
+            if (fullPath) {
+              await addToTuckignore(tuckDir, fullPath);
+              const index = changes.findIndex((c) => c.path === file.path);
+              if (index > -1) changes.splice(index, 1);
+            }
+          }
+          prompts.log.success('Added large files to .tuckignore');
+
+          if (changes.length === 0 && filesToTrackCandidates.length === 0) {
+            prompts.log.info('No changes remaining to sync');
+            return;
+          }
+        } else if (action === 'cancel') {
+          prompts.cancel('Operation cancelled');
+          return;
+        }
+      }
+    }
+
+    // ========== STEP 8: Track new files ==========
+    if (filesToTrackCandidates.length > 0) {
+      preparedNewFiles = await preparePathsForTracking(filesToTrackCandidates, tuckDir, {
+        secretHandling: 'interactive',
+      });
+      filesToTrack = preparedNewFiles.map((file) => ({
+        path: file.source,
+        category: file.category,
+      }));
+    }
+
+    if (changes.length === 0 && filesToTrack.length === 0 && filesToTrackCandidates.length > 0) {
+      prompts.log.info('No changes remaining to sync');
+      return;
+    }
+
+    if (filesToTrack.length > 0) {
+      console.log();
+      await trackFilesWithProgress(filesToTrack, tuckDir, {
+        showCategory: true,
+        actionVerb: 'Tracking',
       });
 
-    console.log();
-    console.log(c.dim('Commit message:'));
-    console.log(
-      c.cyan(
-        message
-          .split('\n')
-          .map((line) => `  ${line}`)
-          .join('\n')
-      )
-    );
-    console.log();
-
-    try {
-      result = await syncFiles(tuckDir, changes, { ...options, message });
-    } finally {
-      // The redacted content has been copied into the repo (or sync failed and
-      // will be retried) — either way, put the original values back in the
-      // LIVE files so the user's actual config keeps working (issue #100).
-      await restoreRedactedLivePaths(redactedLivePaths, tuckDir);
+      // The redacted copies are in the repo now — put the original values back
+      // in the LIVE files so the user's actual config keeps working (issue #100).
+      await restoreRedactedLiveFiles(preparedNewFiles, tuckDir);
     }
-  } else if (filesToTrack.length > 0) {
-    // Only new files were added, commit them
-    if (!options.noCommit) {
+
+    // ========== STEP 9: Sync changes to tracked files ==========
+    let result: SyncResult = { modified: [], deleted: [] };
+
+    if (changes.length > 0) {
+      // Generate commit message
       const message =
         options.message ||
-        `Add ${filesToTrack.length} new dotfile${filesToTrack.length > 1 ? 's' : ''}`;
-      await stageAll(tuckDir);
-      result.commitHash = await commit(tuckDir, message);
+        generateCommitMessage({
+          modified: changes.filter((c) => c.status === 'modified').map((c) => c.path),
+          deleted: changes.filter((c) => c.status === 'deleted').map((c) => c.path),
+        });
+
+      console.log();
+      console.log(c.dim('Commit message:'));
+      console.log(
+        c.cyan(
+          message
+            .split('\n')
+            .map((line) => `  ${line}`)
+            .join('\n')
+        )
+      );
+      console.log();
+
+      result = await syncFiles(tuckDir, changes, { ...options, message });
+    } else if (filesToTrack.length > 0) {
+      // Only new files were added, commit them
+      if (!options.noCommit) {
+        const message =
+          options.message ||
+          `Add ${filesToTrack.length} new dotfile${filesToTrack.length > 1 ? 's' : ''}`;
+        await stageAll(tuckDir);
+        result.commitHash = await commit(tuckDir, message);
+      }
     }
-  }
 
-  // ========== STEP 10: Push to remote ==========
-  console.log();
-  let pushFailed = false;
+    // ========== STEP 10: Push to remote ==========
+    console.log();
+    let pushFailed = false;
 
-  if (result.commitHash) {
-    prompts.log.success(`Committed: ${result.commitHash.slice(0, 7)}`);
+    if (result.commitHash) {
+      prompts.log.success(`Committed: ${result.commitHash.slice(0, 7)}`);
 
-    if (options.push !== false && !(await checkLocalMode(tuckDir)) && (await hasRemote(tuckDir))) {
-      pushFailed = !(await pushWithSpinner(tuckDir, options));
-    } else if (options.push === false) {
-      prompts.log.info("Run 'tuck push' when ready to upload");
+      if (
+        options.push !== false &&
+        !(await checkLocalMode(tuckDir)) &&
+        (await hasRemote(tuckDir))
+      ) {
+        pushFailed = !(await pushWithSpinner(tuckDir, options));
+      } else if (options.push === false) {
+        prompts.log.info("Run 'tuck push' when ready to upload");
+      }
     }
-  }
 
-  // Only show success if no push failure occurred
-  if (!pushFailed) {
-    prompts.outro('Synced successfully!');
+    // Only show success if no push failure occurred
+    if (!pushFailed) {
+      prompts.outro('Synced successfully!');
+    }
+  } finally {
+    // Redacted content is in the repo (or the run was cancelled/failed before
+    // it got there — then the repo simply keeps its old copy). Either way the
+    // LIVE files get their original values back. Both calls are no-ops when
+    // nothing was redacted or a restore already ran.
+    await restoreRedactedLivePaths(redactedLivePaths, tuckDir);
+    await restoreRedactedLiveFiles(preparedNewFiles, tuckDir);
   }
 };
 
@@ -1222,7 +1237,11 @@ export const runSyncCommand = async (
       await stageAll(tuckDir);
       const commitHash = await commit(tuckDir, messageArg || options.message || 'Update dotfiles');
       let pushError: string | undefined;
-      if (options.push !== false && !(await checkLocalMode(tuckDir)) && (await hasRemote(tuckDir))) {
+      if (
+        options.push !== false &&
+        !(await checkLocalMode(tuckDir)) &&
+        (await hasRemote(tuckDir))
+      ) {
         const config = await loadConfig(tuckDir);
         assertRemoteAvailable(config.remote, 'push');
         try {
@@ -1301,7 +1320,10 @@ export const runSyncCommand = async (
   }
 
   // Scan for secrets (non-interactive message path) — shared gate.
-  await scanChangesForSecretsOrThrow(tuckDir, changes, { force: options.force, json: options.json });
+  await scanChangesForSecretsOrThrow(tuckDir, changes, {
+    force: options.force,
+    json: options.json,
+  });
 
   // Show changes
   logger.heading('Changes detected:');

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -50,8 +50,13 @@ import { setJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import type { SyncOptions, FileChange } from '../types.js';
 import { detectDotfiles, DETECTION_CATEGORIES, type DetectedFile } from '../lib/detect.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
-import { preparePathsForTracking } from '../lib/trackPipeline.js';
-import { scanForSecrets, isSecretScanningEnabled, shouldBlockOnSecrets, processSecretsForRedaction, redactFile } from '../lib/secrets/index.js';
+import {
+  preparePathsForTracking,
+  restoreRedactedLiveFiles,
+  restoreRedactedLivePaths,
+  type PreparedTrackFile,
+} from '../lib/trackPipeline.js';
+import { scanForSecrets, isSecretScanningEnabled, shouldBlockOnSecrets, processSecretsForRedaction, redactFile, liveMatchesRestoredRepo } from '../lib/secrets/index.js';
 import { displayScanResults } from './secrets.js';
 import { logForceSecretBypass } from '../lib/audit.js';
 
@@ -149,6 +154,14 @@ const detectChanges = async (tuckDir: string): Promise<TrackedFileChange[]> => {
     try {
       const sourceChecksum = await getFileChecksum(sourcePath);
       if (sourceChecksum !== file.checksum) {
+        // Secret-redacted files: the repo copy holds `{{PLACEHOLDER}}` while
+        // the live file keeps the real values, so their checksums differ
+        // FOREVER. If the live file is exactly the repo copy with secrets
+        // restored, that is the correct state — not a modification (otherwise
+        // every sync would re-flag the same secrets, issue #100).
+        if (await liveMatchesRestoredRepo(sourcePath, join(tuckDir, file.destination), tuckDir)) {
+          continue;
+        }
         changes.push({
           path: file.source,
           status: 'modified',
@@ -578,14 +591,21 @@ const syncFiles = async (
 };
 
 /**
- * Scan modified files for secrets and handle user interaction
- * Returns true if sync should continue, false if aborted
+ * Scan modified files for secrets and handle user interaction.
+ * Returns whether sync should continue, plus the LIVE paths the redact action
+ * rewrote — the caller must restore those via restoreRedactedLivePaths once
+ * the redacted content has been copied into the repo (issue #100).
  */
+interface SecretScanOutcome {
+  proceed: boolean;
+  redactedLivePaths: string[];
+}
+
 const scanAndHandleSecrets = async (
   tuckDir: string,
   changes: FileChange[],
   options: SyncOptions
-): Promise<boolean> => {
+): Promise<SecretScanOutcome> => {
   // Skip if force flag is set (but require confirmation first)
   if (options.force) {
     const confirmed = await prompts.confirmDangerous(
@@ -595,18 +615,18 @@ const scanAndHandleSecrets = async (
     );
     if (!confirmed) {
       logger.info('Sync cancelled');
-      return false;
+      return { proceed: false, redactedLivePaths: [] };
     }
     logger.warning('Secret scanning bypassed with --force');
     // Audit log for security tracking
     await logForceSecretBypass('tuck sync --force', changes.length);
-    return true;
+    return { proceed: true, redactedLivePaths: [] };
   }
 
   // Check if scanning is enabled in config
   const scanningEnabled = await isSecretScanningEnabled(tuckDir);
   if (!scanningEnabled) {
-    return true;
+    return { proceed: true, redactedLivePaths: [] };
   }
 
   // Resolve modified changes to their LIVE paths (repo-scoped entries via the
@@ -615,7 +635,7 @@ const scanAndHandleSecrets = async (
   const targets = await resolveModifiedChangeTargets(tuckDir, changes);
 
   if (targets.length === 0) {
-    return true;
+    return { proceed: true, redactedLivePaths: [] };
   }
 
   const modifiedPaths = targets.map((t) => t.live);
@@ -627,7 +647,7 @@ const scanAndHandleSecrets = async (
   spinner.stop('Scan complete');
 
   if (summary.totalSecrets === 0) {
-    return true;
+    return { proceed: true, redactedLivePaths: [] };
   }
 
   // Display results
@@ -643,13 +663,14 @@ const scanAndHandleSecrets = async (
 
   if (action === 'abort') {
     prompts.cancel('Sync aborted - secrets detected');
-    return false;
+    return { proceed: false, redactedLivePaths: [] };
   }
 
   if (action === 'redact') {
     // Store secrets and replace them with placeholders in the source files
     const spinner = prompts.spinner();
     spinner.start('Redacting secrets...');
+    const redactedLivePaths: string[] = [];
 
     try {
       // Process secrets: store them and get placeholder mappings
@@ -662,6 +683,9 @@ const scanAndHandleSecrets = async (
         if (placeholderMap && placeholderMap.size > 0) {
           await redactFile(result.path, result.matches, placeholderMap);
           redactedCount++;
+          // The LIVE file was rewritten; the caller must restore it after the
+          // redacted content has been copied into the repo (issue #100).
+          redactedLivePaths.push(result.path);
         }
       }
 
@@ -671,10 +695,13 @@ const scanAndHandleSecrets = async (
     } catch (error) {
       spinner.stop('Redaction failed');
       prompts.log.error(error instanceof Error ? error.message : String(error));
-      return false;
+      // Restore whatever was already rewritten — aborting must not leave the
+      // user's live config broken.
+      await restoreRedactedLivePaths(redactedLivePaths, tuckDir);
+      return { proceed: false, redactedLivePaths: [] };
     }
 
-    return true;
+    return { proceed: true, redactedLivePaths };
   }
 
   if (action === 'ignore') {
@@ -705,14 +732,14 @@ const scanAndHandleSecrets = async (
 
     if (changes.length === 0) {
       prompts.log.info('No remaining changes to sync');
-      return false;
+      return { proceed: false, redactedLivePaths: [] };
     }
-    return true;
+    return { proceed: true, redactedLivePaths: [] };
   }
 
   // proceed - continue with warning
   prompts.log.warning('Proceeding with secrets - make sure your repo is private!');
-  return true;
+  return { proceed: true, redactedLivePaths: [] };
 };
 
 const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): Promise<void> => {
@@ -747,11 +774,13 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
   changeSpinner.stop(`Found ${changes.length} changed file${changes.length !== 1 ? 's' : ''}`);
 
   // ========== STEP 2.5: Scan modified files for secrets ==========
+  let redactedLivePaths: string[] = [];
   if (changes.length > 0) {
-    const shouldContinue = await scanAndHandleSecrets(tuckDir, changes, options);
-    if (!shouldContinue) {
+    const outcome = await scanAndHandleSecrets(tuckDir, changes, options);
+    if (!outcome.proceed) {
       return;
     }
+    redactedLivePaths = outcome.redactedLivePaths;
   }
 
   // ========== STEP 3: Scan for new dotfiles (if enabled) ==========
@@ -944,11 +973,12 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
   }
 
   // ========== STEP 8: Track new files ==========
+  let preparedNewFiles: PreparedTrackFile[] = [];
   if (filesToTrackCandidates.length > 0) {
-    const prepared = await preparePathsForTracking(filesToTrackCandidates, tuckDir, {
+    preparedNewFiles = await preparePathsForTracking(filesToTrackCandidates, tuckDir, {
       secretHandling: 'interactive',
     });
-    filesToTrack = prepared.map((file) => ({
+    filesToTrack = preparedNewFiles.map((file) => ({
       path: file.source,
       category: file.category,
     }));
@@ -965,6 +995,10 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
       showCategory: true,
       actionVerb: 'Tracking',
     });
+
+    // The redacted copies are in the repo now — put the original values back
+    // in the LIVE files so the user's actual config keeps working (issue #100).
+    await restoreRedactedLiveFiles(preparedNewFiles, tuckDir);
   }
 
   // ========== STEP 9: Sync changes to tracked files ==========
@@ -991,7 +1025,14 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
     );
     console.log();
 
-    result = await syncFiles(tuckDir, changes, { ...options, message });
+    try {
+      result = await syncFiles(tuckDir, changes, { ...options, message });
+    } finally {
+      // The redacted content has been copied into the repo (or sync failed and
+      // will be retried) — either way, put the original values back in the
+      // LIVE files so the user's actual config keeps working (issue #100).
+      await restoreRedactedLivePaths(redactedLivePaths, tuckDir);
+    }
   } else if (filesToTrack.length > 0) {
     // Only new files were added, commit them
     if (!options.noCommit) {

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -70,6 +70,8 @@ export {
   hasPlaceholders,
   countPlaceholders,
   restoreFiles,
+  restoreLiveFilesAfterRedaction,
+  liveMatchesRestoredRepo,
   previewRestoration,
   // Resolver-based functions (password manager integration)
   restoreFileWithResolver,

--- a/src/lib/secrets/patterns.ts
+++ b/src/lib/secrets/patterns.ts
@@ -525,8 +525,12 @@ export const GENERIC_PATTERNS: SecretPattern[] = [
   {
     id: 'password-url',
     name: 'Password in URL',
-    // Security: Upper bounds to prevent ReDoS
-    pattern: /:\/\/[^:]{1,100}:([^@]{8,200})@/g,
+    // Security: Upper bounds to prevent ReDoS.
+    // RFC 3986 userinfo cannot contain whitespace or '/'; excluding them keeps
+    // the match on a single line. `[^:]`/`[^@]` matched newlines, so URLs on
+    // consecutive comment lines were reported as one multi-line "password" and
+    // redaction spliced the lines together (issue #100).
+    pattern: /:\/\/[^:/\s]{1,100}:([^@/\s]{8,200})@/g,
     severity: 'critical',
     description: 'Password embedded in URL',
     placeholder: 'URL_PASSWORD',
@@ -536,7 +540,9 @@ export const GENERIC_PATTERNS: SecretPattern[] = [
   {
     id: 'api-key-assignment',
     name: 'API Key Assignment',
-    pattern: /(?:api[_-]?key|apikey)\s*[=:]\s*(?:['"]([A-Za-z0-9_-]{16,256})['"]|([A-Za-z0-9_-]{16,256}))/gi,
+    // '.' is allowed in the value: dotted keys (e.g. `part1.part2`) otherwise
+    // match only up to the dot, leaving the tail in cleartext (issue #100).
+    pattern: /(?:api[_-]?key|apikey)\s*[=:]\s*(?:['"]([A-Za-z0-9_.-]{16,256})['"]|([A-Za-z0-9_.-]{16,256}))/gi,
     severity: 'high',
     description: 'API key assigned in configuration',
     placeholder: 'API_KEY',
@@ -556,7 +562,8 @@ export const GENERIC_PATTERNS: SecretPattern[] = [
   {
     id: 'secret-assignment',
     name: 'Secret Assignment',
-    pattern: /(?:secret|client[_-]?secret|app[_-]?secret|secret[_-]?key)\s*[=:]\s*(?:['"]([A-Za-z0-9_-]{16,256})['"]|([A-Za-z0-9_-]{16,256}))/gi,
+    // '.' allowed in the value for the same reason as api-key-assignment.
+    pattern: /(?:secret|client[_-]?secret|app[_-]?secret|secret[_-]?key)\s*[=:]\s*(?:['"]([A-Za-z0-9_.-]{16,256})['"]|([A-Za-z0-9_.-]{16,256}))/gi,
     severity: 'high',
     description: 'Secret assigned in configuration',
     placeholder: 'SECRET',
@@ -583,11 +590,14 @@ export const GENERIC_PATTERNS: SecretPattern[] = [
   },
 
   // Database connection strings
-  // Security: All patterns have length limits to prevent ReDoS
+  // Security: All patterns have length limits to prevent ReDoS.
+  // User/password classes exclude whitespace so a URL on one line can never
+  // pair with an '@' on a later line (same newline-spanning defect as
+  // password-url, issue #100).
   {
     id: 'postgres-connection',
     name: 'PostgreSQL Connection String',
-    pattern: /postgres(?:ql)?:\/\/[^:]{1,100}:[^@]{1,200}@[^\s'"]{1,500}/gi,
+    pattern: /postgres(?:ql)?:\/\/[^:\s]{1,100}:[^@\s]{1,200}@[^\s'"]{1,500}/gi,
     severity: 'critical',
     description: 'PostgreSQL connection string with credentials',
     placeholder: 'DATABASE_URL',
@@ -595,7 +605,7 @@ export const GENERIC_PATTERNS: SecretPattern[] = [
   {
     id: 'mysql-connection',
     name: 'MySQL Connection String',
-    pattern: /mysql:\/\/[^:]{1,100}:[^@]{1,200}@[^\s'"]{1,500}/gi,
+    pattern: /mysql:\/\/[^:\s]{1,100}:[^@\s]{1,200}@[^\s'"]{1,500}/gi,
     severity: 'critical',
     description: 'MySQL connection string with credentials',
     placeholder: 'DATABASE_URL',
@@ -603,7 +613,7 @@ export const GENERIC_PATTERNS: SecretPattern[] = [
   {
     id: 'mongodb-connection',
     name: 'MongoDB Connection String',
-    pattern: /mongodb(?:\+srv)?:\/\/[^:]{1,100}:[^@]{1,200}@[^\s'"]{1,500}/gi,
+    pattern: /mongodb(?:\+srv)?:\/\/[^:\s]{1,100}:[^@\s]{1,200}@[^\s'"]{1,500}/gi,
     severity: 'critical',
     description: 'MongoDB connection string with credentials',
     placeholder: 'MONGODB_URI',
@@ -611,7 +621,7 @@ export const GENERIC_PATTERNS: SecretPattern[] = [
   {
     id: 'redis-connection',
     name: 'Redis Connection String',
-    pattern: /redis:\/\/[^:]{1,100}:[^@]{1,200}@[^\s'"]{1,500}/gi,
+    pattern: /redis:\/\/[^:\s]{1,100}:[^@\s]{1,200}@[^\s'"]{1,500}/gi,
     severity: 'critical',
     description: 'Redis connection string with credentials',
     placeholder: 'REDIS_URL',

--- a/src/lib/secrets/redactor.ts
+++ b/src/lib/secrets/redactor.ts
@@ -5,7 +5,7 @@
  * and restoring them from the local secrets store.
  */
 
-import { readFile, writeFile, rename, unlink, stat } from 'fs/promises';
+import { readFile, writeFile, rename, unlink, stat, lstat } from 'fs/promises';
 import { randomBytes } from 'crypto';
 import { dirname, basename, join } from 'path';
 import { expandPath, pathExists } from '../paths.js';
@@ -345,6 +345,94 @@ export const restoreFiles = async (
     filesModified,
     allUnresolved: [...allUnresolved],
   };
+};
+
+/**
+ * Restore LIVE files that were redacted in place so their tracked copy could be
+ * written with placeholders. A live rc/config file containing `{{PLACEHOLDER}}`
+ * is broken config (a shell reads it literally — see issue #100), so once the
+ * redacted copy is safely in the repo the live original must get its values
+ * back.
+ *
+ * Symlinks are skipped: a symlink-strategy live path points INTO the tuck
+ * repo, and restoring through it would write the secrets straight back into
+ * the git-tracked copy.
+ */
+export const restoreLiveFilesAfterRedaction = async (
+  filepaths: string[],
+  tuckDir: string
+): Promise<{ restoredFiles: number; skippedSymlinks: string[] }> => {
+  const secrets = await getAllSecrets(tuckDir);
+  let restoredFiles = 0;
+  const skippedSymlinks: string[] = [];
+
+  for (const filepath of filepaths) {
+    const expandedPath = expandPath(filepath);
+
+    let stats;
+    try {
+      stats = await lstat(expandedPath);
+    } catch {
+      continue; // Vanished since redaction — nothing to restore.
+    }
+
+    if (stats.isSymbolicLink()) {
+      skippedSymlinks.push(filepath);
+      continue;
+    }
+    if (stats.isDirectory()) {
+      continue;
+    }
+
+    const content = await readFile(expandedPath, 'utf-8');
+    const result = restoreContent(content, secrets);
+
+    if (result.restored > 0) {
+      // Security: Use atomic write to prevent data loss from race conditions
+      await atomicWriteFile(expandedPath, result.restoredContent);
+      restoredFiles++;
+    }
+  }
+
+  return { restoredFiles, skippedSymlinks };
+};
+
+/**
+ * Whether a LIVE file is exactly the repo copy with its secret placeholders
+ * restored — i.e. the correct post-redaction state, not real drift.
+ *
+ * After "Replace with placeholders" the repo copy holds `{{NAME}}` while the
+ * live file keeps the actual values (issue #100), so their checksums always
+ * differ. Change detection uses this to avoid reporting that as a perpetual
+ * "modified" (which would re-prompt about the same secrets on every sync).
+ * Analogous to how template/encrypted files compare live against
+ * materialize(repo) instead of the raw repo bytes.
+ */
+export const liveMatchesRestoredRepo = async (
+  livePath: string,
+  repoPath: string,
+  tuckDir: string
+): Promise<boolean> => {
+  try {
+    const expandedRepo = expandPath(repoPath);
+    const expandedLive = expandPath(livePath);
+
+    if ((await stat(expandedRepo)).isDirectory()) return false;
+    if ((await stat(expandedLive)).isDirectory()) return false;
+
+    const repoContent = await readFile(expandedRepo, 'utf-8');
+    if (!hasPlaceholders(repoContent)) return false;
+
+    const secrets = await getAllSecrets(tuckDir);
+    const result = restoreContent(repoContent, secrets);
+    if (result.restored === 0) return false;
+
+    const liveContent = await readFile(expandedLive, 'utf-8');
+    return liveContent === result.restoredContent;
+  } catch {
+    // Missing, binary, or unreadable on either side: treat as real drift.
+    return false;
+  }
 };
 
 /**

--- a/src/lib/secrets/scanner.ts
+++ b/src/lib/secrets/scanner.ts
@@ -261,8 +261,14 @@ export const scanContent = (content: string, options: ScanOptions = {}): SecretM
         break;
       }
 
-      // Extract the captured value (prefer capture group 1 if exists)
-      const value = match[1] || match[0];
+      // Extract the captured value: the FIRST DEFINED capture group, falling
+      // back to the whole match only for patterns with no groups. Several
+      // generic patterns put the secret in group 2 (the unquoted alternative);
+      // `match[1] || match[0]` fell back to the whole match there, so redaction
+      // replaced the `KEY=` context too — corrupting the file and orphaning the
+      // rest of the line (issue #100).
+      const captured = match.slice(1).find((group) => group !== undefined);
+      const value = captured ?? match[0];
 
       // Skip empty or very short matches
       if (!value || value.length < 4) {

--- a/src/lib/stateModel.ts
+++ b/src/lib/stateModel.ts
@@ -21,6 +21,7 @@ import { getFileChecksum } from './files.js';
 import { getAllTrackedFiles } from './manifest.js';
 import { resolveLiveTarget } from './repoScope.js';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from './materialize.js';
+import { liveMatchesRestoredRepo } from './secrets/redactor.js';
 import type { TemplateContext } from './template.js';
 import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
 
@@ -167,7 +168,17 @@ export const computeFileState = async (
   }
 
   const liveChecksum = await computeLiveChecksum(sourceAbs, file);
-  return entry(classifyFileState(liveChecksum, repoChecksum, file.checksum), liveChecksum, repoChecksum);
+  let state = classifyFileState(liveChecksum, repoChecksum, file.checksum);
+
+  // Secret-redacted files: the repo copy holds `{{PLACEHOLDER}}` while the live
+  // file keeps the real values, so their checksums differ FOREVER. Like the
+  // template/encrypted comparison above, the live form of a redacted file is
+  // restore(repo, secrets) — if the live file matches that, it is not drift.
+  if (state === 'drift-local' && (await liveMatchesRestoredRepo(sourceAbs, repoAbs, tuckDir))) {
+    state = repoChecksum !== file.checksum ? 'drift-repo' : 'ok';
+  }
+
+  return entry(state, liveChecksum, repoChecksum);
 };
 
 /** Compute the state of every tracked file in the manifest. */

--- a/src/lib/trackPipeline.ts
+++ b/src/lib/trackPipeline.ts
@@ -32,6 +32,7 @@ import {
   isSecretScanningEnabled,
   processSecretsForRedaction,
   redactFile,
+  restoreLiveFilesAfterRedaction,
   scanForSecrets,
   shouldBlockOnSecrets,
   type ScanSummary,
@@ -96,6 +97,13 @@ export interface PreparedTrackFile {
   remoteUrl?: string;
   /** Absolute live path to copy FROM (repo scope only). */
   liveSource?: string;
+  /**
+   * LIVE paths this candidate owns that were redacted in place so the repo
+   * copy gets placeholders. After tracking (i.e. after the copy), callers must
+   * restore these via restoreRedactedLiveFiles — a live rc/config file left
+   * with `{{PLACEHOLDER}}` in it is broken config (issue #100).
+   */
+  redactedLivePaths?: string[];
 }
 
 export interface PreparePathsForTrackingOptions {
@@ -315,6 +323,14 @@ const applySecretPolicy = async (
       if (placeholderMap && placeholderMap.size > 0) {
         const redactionResult = await redactFile(result.path, result.matches, placeholderMap);
         totalRedacted += redactionResult.replacements.length;
+
+        // Remember which LIVE path was rewritten (on its owning candidate —
+        // for a directory candidate the redacted path is an inner file) so the
+        // caller can restore it once the redacted copy is in the repo.
+        const owner = ownerByScanPath.get(result.path);
+        if (owner) {
+          (owner.redactedLivePaths ??= []).push(result.path);
+        }
       }
     }
 
@@ -366,6 +382,50 @@ const applySecretPolicy = async (
 
   logger.warning('Proceeding with secrets - be careful not to push to a public repository!');
   return files;
+};
+
+/**
+ * Restore the original secret values to LIVE paths that were redacted in
+ * place. Call this AFTER the (redacted) content has been copied into the
+ * repo: placeholders belong in the repo copy only — the live file must keep
+ * working config (issue #100: a `{{PLACEHOLDER}}` left in ~/.zshrc makes zsh
+ * abort sourcing it).
+ */
+export const restoreRedactedLivePaths = async (
+  paths: string[],
+  tuckDir: string
+): Promise<void> => {
+  if (paths.length === 0) {
+    return;
+  }
+
+  const { restoredFiles, skippedSymlinks } = await restoreLiveFilesAfterRedaction(paths, tuckDir);
+
+  if (restoredFiles > 0) {
+    logger.success(
+      `Restored original values to ${restoredFiles} live file(s) — placeholders remain only in the tuck repository`
+    );
+  }
+  for (const skipped of skippedSymlinks) {
+    logger.warning(
+      `${collapsePath(skipped)} is a symlink into the repository — original values NOT restored ` +
+        '(that would write the secrets back into git). The live file still contains placeholders.'
+    );
+  }
+};
+
+/**
+ * Convenience wrapper over restoreRedactedLivePaths for the prepared files
+ * returned by preparePathsForTracking.
+ */
+export const restoreRedactedLiveFiles = async (
+  files: PreparedTrackFile[],
+  tuckDir: string
+): Promise<void> => {
+  await restoreRedactedLivePaths(
+    files.flatMap((file) => file.redactedLivePaths ?? []),
+    tuckDir
+  );
 };
 
 export const preparePathsForTracking = async (

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -23,6 +23,9 @@ const isIgnoredMock = vi.fn();
 const shouldExcludeFromBinMock = vi.fn();
 const getDirectoryFileCountMock = vi.fn();
 const checkFileSizeThresholdMock = vi.fn();
+const processSecretsForRedactionMock = vi.fn();
+const redactFileMock = vi.fn();
+const restoreLiveFilesAfterRedactionMock = vi.fn();
 
 vi.mock('../../src/ui/index.js', () => ({
   prompts: {
@@ -50,6 +53,8 @@ vi.mock('../../src/ui/index.js', () => ({
     warning: vi.fn(),
     error: vi.fn(),
     dim: vi.fn(),
+    heading: vi.fn(),
+    file: vi.fn(),
   },
   colors: {
     error: (x: string) => x,
@@ -90,9 +95,11 @@ vi.mock('../../src/lib/secrets/index.js', () => ({
   scanForSecrets: scanForSecretsMock,
   shouldBlockOnSecrets: shouldBlockOnSecretsMock,
   isSecretScanningEnabled: isSecretScanningEnabledMock,
-  processSecretsForRedaction: vi.fn(),
-  redactFile: vi.fn(),
-  getSecretsPath: vi.fn(),
+  processSecretsForRedaction: processSecretsForRedactionMock,
+  redactFile: redactFileMock,
+  restoreLiveFilesAfterRedaction: restoreLiveFilesAfterRedactionMock,
+  liveMatchesRestoredRepo: vi.fn().mockResolvedValue(false),
+  getSecretsPath: vi.fn(() => '/test-home/.tuck/secrets.local.json'),
 }));
 
 vi.mock('../../src/lib/tuckignore.js', () => ({
@@ -328,5 +335,84 @@ describe('add command behavior', () => {
         strategy: undefined,
       })
     );
+  });
+  describe('live-file restoration on early exits (issue #100)', () => {
+    const SECRET_SUMMARY = {
+      totalSecrets: 1,
+      filesWithSecrets: 1,
+      results: [
+        {
+          path: '/test-home/.zshrc',
+          collapsedPath: '~/.zshrc',
+          hasSecrets: true,
+          matches: [
+            {
+              patternId: 'api-key-assignment',
+              patternName: 'API Key Assignment',
+              severity: 'high',
+              value: 'secret_0123456789abcdef0123456789abcdef',
+              redactedValue: '[REDACTED SECRET]',
+              line: 1,
+              column: 1,
+              context: 'export MY_API_KEY=[REDACTED]',
+              placeholder: 'API_KEY',
+            },
+          ],
+        },
+      ],
+    };
+
+    const armRedaction = () => {
+      scanForSecretsMock.mockResolvedValue(SECRET_SUMMARY);
+      processSecretsForRedactionMock.mockResolvedValue(
+        new Map([
+          ['/test-home/.zshrc', new Map([['secret_0123456789abcdef0123456789abcdef', 'API_KEY']])],
+        ])
+      );
+      redactFileMock.mockResolvedValue({
+        originalContent: '',
+        redactedContent: '',
+        replacements: [{ placeholder: 'API_KEY', originalValue: 'x', line: 1 }],
+      });
+      restoreLiveFilesAfterRedactionMock.mockResolvedValue({ restoredFiles: 1, skippedSymlinks: [] });
+    };
+
+    it('restores redacted live files when the user declines the final interactive confirm', async () => {
+      armRedaction();
+      const { prompts } = await import('../../src/ui/index.js');
+      (prompts.text as ReturnType<typeof vi.fn>).mockResolvedValue('~/.zshrc');
+      // 1st select: secret action -> redact; 2nd select: category
+      (prompts.select as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce('redact')
+        .mockResolvedValueOnce('shell');
+      // Final "Add 1 file?" confirm -> user cancels AFTER redaction already ran
+      (prompts.confirm as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+      const { addCommand } = await import('../../src/commands/add.js');
+      await addCommand.parseAsync(['node', 'tuck']);
+
+      expect(redactFileMock).toHaveBeenCalledTimes(1);
+      expect(trackFilesWithProgressMock).not.toHaveBeenCalled();
+      expect(restoreLiveFilesAfterRedactionMock).toHaveBeenCalledWith(
+        ['/test-home/.zshrc'],
+        '/test-home/.tuck'
+      );
+    });
+
+    it('restores redacted live files immediately in --plan mode (nothing is tracked)', async () => {
+      armRedaction();
+      const { prompts } = await import('../../src/ui/index.js');
+      (prompts.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce('redact');
+
+      const { addCommand } = await import('../../src/commands/add.js');
+      await addCommand.parseAsync(['node', 'tuck', '~/.zshrc', '--plan']);
+
+      expect(redactFileMock).toHaveBeenCalledTimes(1);
+      expect(trackFilesWithProgressMock).not.toHaveBeenCalled();
+      expect(restoreLiveFilesAfterRedactionMock).toHaveBeenCalledWith(
+        ['/test-home/.zshrc'],
+        '/test-home/.tuck'
+      );
+    });
   });
 });

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -93,6 +93,7 @@ vi.mock('../../src/lib/fileTracking.js', () => ({
 
 vi.mock('../../src/lib/trackPipeline.js', () => ({
   preparePathsForTracking: preparePathsForTrackingMock,
+  restoreRedactedLiveFiles: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('scan command behavior', () => {

--- a/tests/lib/redactor-live-restore.test.ts
+++ b/tests/lib/redactor-live-restore.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for restoreLiveFilesAfterRedaction (issue #100).
+ *
+ * After "Replace with placeholders", the LIVE dotfile must get its original
+ * values back once the redacted copy is safely in the repo — a live rc file
+ * containing `{{PLACEHOLDER}}` is broken config (zsh aborts sourcing on it).
+ * Symlinked live paths are skipped: writing through a symlink that points into
+ * the tuck repo would put the secrets straight back into git.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_HOME, TEST_TUCK_DIR, initTestTuck } from '../utils/testHelpers.js';
+import { scanFile } from '../../src/lib/secrets/scanner.js';
+import {
+  redactFile,
+  restoreLiveFilesAfterRedaction,
+  liveMatchesRestoredRepo,
+} from '../../src/lib/secrets/redactor.js';
+import { processSecretsForRedaction } from '../../src/lib/secrets/index.js';
+import { setSecret } from '../../src/lib/secrets/store.js';
+
+const ORIGINAL = 'export MY_API_KEY=secret_0123456789abcdef0123456789abcdef\n';
+
+const redactLiveFile = async (filepath: string): Promise<void> => {
+  const result = await scanFile(filepath);
+  expect(result.hasSecrets).toBe(true);
+  const maps = await processSecretsForRedaction([result], TEST_TUCK_DIR);
+  const placeholderMap = maps.get(result.path);
+  expect(placeholderMap).toBeDefined();
+  await redactFile(filepath, result.matches, placeholderMap!);
+};
+
+describe('restoreLiveFilesAfterRedaction', () => {
+  beforeEach(async () => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    await initTestTuck();
+  });
+
+  it('restores the original content of a redacted live file', async () => {
+    const file = join(TEST_HOME, '.testrc');
+    vol.writeFileSync(file, ORIGINAL);
+
+    await redactLiveFile(file);
+    expect(vol.readFileSync(file, 'utf-8')).not.toBe(ORIGINAL);
+
+    const result = await restoreLiveFilesAfterRedaction([file], TEST_TUCK_DIR);
+
+    expect(result.restoredFiles).toBe(1);
+    expect(vol.readFileSync(file, 'utf-8')).toBe(ORIGINAL);
+  });
+
+  it('skips symlinks so secrets cannot be written through into the repo copy', async () => {
+    const repoCopy = join(TEST_TUCK_DIR, 'files', 'shell', '.testrc');
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files', 'shell'), { recursive: true });
+    vol.writeFileSync(repoCopy, 'export MY_API_KEY={{API_KEY}}\n');
+
+    const live = join(TEST_HOME, '.testrc');
+    vol.symlinkSync(repoCopy, live);
+
+    const result = await restoreLiveFilesAfterRedaction([live], TEST_TUCK_DIR);
+
+    expect(result.restoredFiles).toBe(0);
+    expect(result.skippedSymlinks).toEqual([live]);
+    expect(vol.readFileSync(repoCopy, 'utf-8')).toBe('export MY_API_KEY={{API_KEY}}\n');
+  });
+
+  it('ignores paths that no longer exist', async () => {
+    const result = await restoreLiveFilesAfterRedaction(
+      [join(TEST_HOME, '.does-not-exist')],
+      TEST_TUCK_DIR
+    );
+    expect(result.restoredFiles).toBe(0);
+  });
+});
+
+describe('liveMatchesRestoredRepo', () => {
+  const REPO_COPY = join(TEST_TUCK_DIR, 'files', 'shell', '.testrc');
+  const LIVE = join(TEST_HOME, '.testrc');
+
+  beforeEach(async () => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    await initTestTuck();
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files', 'shell'), { recursive: true });
+  });
+
+  it('returns true when the live file equals the repo copy with placeholders restored', async () => {
+    await setSecret(TEST_TUCK_DIR, 'API_KEY', 'secret_0123456789abcdef0123456789abcdef');
+    vol.writeFileSync(REPO_COPY, 'export MY_API_KEY={{API_KEY}}\n');
+    vol.writeFileSync(LIVE, ORIGINAL);
+
+    expect(await liveMatchesRestoredRepo(LIVE, REPO_COPY, TEST_TUCK_DIR)).toBe(true);
+  });
+
+  it('returns false when the live file was genuinely edited', async () => {
+    await setSecret(TEST_TUCK_DIR, 'API_KEY', 'secret_0123456789abcdef0123456789abcdef');
+    vol.writeFileSync(REPO_COPY, 'export MY_API_KEY={{API_KEY}}\n');
+    vol.writeFileSync(LIVE, ORIGINAL + 'alias new="thing"\n');
+
+    expect(await liveMatchesRestoredRepo(LIVE, REPO_COPY, TEST_TUCK_DIR)).toBe(false);
+  });
+
+  it('returns false when the repo copy has no placeholders', async () => {
+    vol.writeFileSync(REPO_COPY, 'plain content\n');
+    vol.writeFileSync(LIVE, 'different content\n');
+
+    expect(await liveMatchesRestoredRepo(LIVE, REPO_COPY, TEST_TUCK_DIR)).toBe(false);
+  });
+
+  it('returns false when the placeholder has no stored value', async () => {
+    vol.writeFileSync(REPO_COPY, 'export MY_API_KEY={{UNKNOWN_KEY}}\n');
+    vol.writeFileSync(LIVE, ORIGINAL);
+
+    expect(await liveMatchesRestoredRepo(LIVE, REPO_COPY, TEST_TUCK_DIR)).toBe(false);
+  });
+});

--- a/tests/lib/scanner-redaction-incident.test.ts
+++ b/tests/lib/scanner-redaction-incident.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression tests for issue #100 — secret redaction corrupting dotfiles.
+ *
+ * Covers three scanner/pattern defects that combined to rewrite a live ~/.zshrc
+ * into invalid shell and leave half a credential committed in cleartext:
+ *   1. scanContent used `match[1] || match[0]`: patterns whose secret lands in
+ *      capture group 2 (the UNQUOTED alternative of the generic assignment
+ *      patterns) fell back to the whole match — so redaction swallowed the
+ *      `API_KEY=` context and broke the variable name.
+ *   2. The unquoted value class excluded '.', so dotted keys were matched only
+ *      up to the dot: the tail stayed in cleartext AND got committed.
+ *   3. `password-url`'s character classes matched newlines, so URLs on
+ *      consecutive comment lines (stock ~/.p10k.zsh) were reported as one
+ *      multi-line "critical" password and redaction spliced the lines together.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { scanContent } from '../../src/lib/secrets/scanner.js';
+import { redactContent } from '../../src/lib/secrets/redactor.js';
+
+const HEX32 = '0123456789abcdef0123456789abcdef';
+
+describe('scanner value extraction (issue #100)', () => {
+  it('extracts only the secret for an unquoted api key assignment (capture group 2)', () => {
+    const secret = `secret_${HEX32}`;
+    const content = `export LAMBDA_API_KEY=${secret}`;
+    const matches = scanContent(content);
+
+    const match = matches.find((m) => m.patternId === 'api-key-assignment');
+    expect(match).toBeDefined();
+    expect(match!.value).toBe(secret);
+  });
+
+  it('extracts only the secret for an unquoted token assignment (capture group 2)', () => {
+    const secret = `tok_${HEX32}${HEX32}`;
+    const content = `export MY_ACCESS_TOKEN=${secret}`;
+    const matches = scanContent(content);
+
+    const match = matches.find((m) => m.patternId === 'token-assignment');
+    expect(match).toBeDefined();
+    expect(match!.value).toBe(secret);
+  });
+
+  it('captures a dotted unquoted api key fully instead of stopping at the dot', () => {
+    const secret = `secret_${HEX32}.SecondHalf${HEX32}`;
+    const content = `export LAMBDA_API_KEY=${secret}`;
+    const matches = scanContent(content);
+
+    const match = matches.find((m) => m.patternId === 'api-key-assignment');
+    expect(match).toBeDefined();
+    expect(match!.value).toBe(secret);
+  });
+
+  it('redacts an unquoted dotted assignment without corrupting the variable name or leaking a tail', () => {
+    const secret = `secret_${HEX32}.SecondHalf${HEX32}`;
+    const content = `export LAMBDA_API_KEY=${secret}\n`;
+    const matches = scanContent(content);
+    expect(matches.length).toBeGreaterThan(0);
+
+    const placeholderMap = new Map(matches.map((m) => [m.value, 'API_KEY']));
+    const result = redactContent(content, matches, placeholderMap);
+
+    expect(result.redactedContent).toBe('export LAMBDA_API_KEY={{API_KEY}}\n');
+  });
+});
+
+describe('password-url multiline false positive (issue #100)', () => {
+  it('does not flag URLs spread across consecutive comment lines as a password in a URL', () => {
+    // Verbatim shape of stock ~/.p10k.zsh comments: several URLs, then a later
+    // line containing '@'. The buggy pattern matched from one URL across four
+    // lines to the '@' in 'name@version'.
+    const p10kComments = [
+      '    # dotnet_version        # .NET version (https://dotnet.microsoft.com)',
+      '    # php_version           # php version (https://www.php.net/)',
+      '    # laravel_version       # laravel php framework version (https://laravel.com/)',
+      '    # java_version          # java version (https://www.java.com/)',
+      '    # package               # name@version from package.json (https://docs.npmjs.com/files/package.json)',
+    ].join('\n');
+
+    const matches = scanContent(p10kComments);
+    expect(matches.filter((m) => m.patternId === 'password-url')).toHaveLength(0);
+  });
+
+  it('still detects a real password embedded in a single-line URL', () => {
+    const content = 'backup_target=https://admin:hunter2secret@db.example.com/prod';
+    const matches = scanContent(content);
+
+    const match = matches.find((m) => m.patternId === 'password-url');
+    expect(match).toBeDefined();
+    expect(match!.value).toBe('hunter2secret');
+  });
+
+  it('does not let database connection string patterns span lines', () => {
+    const content = [
+      '# see postgres://wiki for details',
+      'unrelated: value@host',
+    ].join('\n');
+    const matches = scanContent(content);
+    expect(matches.filter((m) => m.patternId === 'postgres-connection')).toHaveLength(0);
+  });
+});

--- a/tests/lib/stateModel.test.ts
+++ b/tests/lib/stateModel.test.ts
@@ -111,6 +111,43 @@ describe('computeStateModel', () => {
     expect(model[0].state).toBe('ok');
   });
 
+  it('reports ok for a secret-redacted repo copy whose live file holds the restored values (issue #100)', async () => {
+    // Live keeps the real secret; the repo copy holds the placeholder. That is
+    // the CORRECT post-redaction state, not drift.
+    const { setSecret } = await import('../../src/lib/secrets/store.js');
+    await setSecret(TUCK, 'API_KEY', 'secret_0123456789abcdef0123456789abcdef');
+    vol.writeFileSync('/test-home/.zshrc', 'export MY_API_KEY=secret_0123456789abcdef0123456789abcdef\n');
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'export MY_API_KEY={{API_KEY}}\n');
+    const { getFileChecksum } = await import('../../src/lib/files.js');
+    const repoChecksum = await getFileChecksum(`${TUCK}/files/shell/zshrc`);
+    writeManifest({
+      source: '~/.zshrc', destination: 'files/shell/zshrc', category: 'shell',
+      strategy: 'copy', checksum: repoChecksum, added: ts, modified: ts,
+    });
+
+    const model = await computeStateModel(TUCK);
+    expect(model[0].state).toBe('ok');
+  });
+
+  it('reports drift-local when a secret-redacted live file was genuinely edited', async () => {
+    const { setSecret } = await import('../../src/lib/secrets/store.js');
+    await setSecret(TUCK, 'API_KEY', 'secret_0123456789abcdef0123456789abcdef');
+    vol.writeFileSync(
+      '/test-home/.zshrc',
+      'export MY_API_KEY=secret_0123456789abcdef0123456789abcdef\nalias new="thing"\n'
+    );
+    vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'export MY_API_KEY={{API_KEY}}\n');
+    const { getFileChecksum } = await import('../../src/lib/files.js');
+    const repoChecksum = await getFileChecksum(`${TUCK}/files/shell/zshrc`);
+    writeManifest({
+      source: '~/.zshrc', destination: 'files/shell/zshrc', category: 'shell',
+      strategy: 'copy', checksum: repoChecksum, added: ts, modified: ts,
+    });
+
+    const model = await computeStateModel(TUCK);
+    expect(model[0].state).toBe('drift-local');
+  });
+
   it('reports drift-local for a hand-edited template live file (needs apply)', async () => {
     vol.writeFileSync('/test-home/.zshrc', 'HAND EDITED');
     vol.writeFileSync(`${TUCK}/files/shell/zshrc`, 'os={{os}}');

--- a/tests/lib/trackPipeline-secrets.test.ts
+++ b/tests/lib/trackPipeline-secrets.test.ts
@@ -69,6 +69,37 @@ describe('track pipeline secret gate', () => {
     ).rejects.toBeInstanceOf(SecretsDetectedError);
   });
 
+  it('redact action records the redacted live paths and restores them after tracking (issue #100)', async () => {
+    selectMock.mockResolvedValue('redact');
+    await initTestTuck();
+
+    const file = join(TEST_HOME, '.testrc');
+    const original = 'export MY_API_KEY=secret_0123456789abcdef0123456789abcdef\n';
+    vol.writeFileSync(file, original);
+
+    const { preparePathsForTracking, restoreRedactedLiveFiles } = await import(
+      '../../src/lib/trackPipeline.js'
+    );
+
+    const prepared = await preparePathsForTracking([{ path: file }], TEST_TUCK_DIR, {
+      secretHandling: 'interactive',
+    });
+    expect(prepared).toHaveLength(1);
+
+    // The live file is redacted for the upcoming copy into the repo — but the
+    // variable name must survive (only the VALUE is a secret), and the pipeline
+    // must remember which live paths it rewrote.
+    const redacted = vol.readFileSync(file, 'utf-8') as string;
+    expect(redacted).toContain('MY_API_KEY={{');
+    expect(redacted).not.toContain('secret_0123456789');
+    expect(prepared[0].redactedLivePaths).toEqual([file]);
+
+    // After the repo copy exists, the caller restores the live file so the
+    // user's actual config keeps working.
+    await restoreRedactedLiveFiles(prepared, TEST_TUCK_DIR);
+    expect(vol.readFileSync(file, 'utf-8')).toBe(original);
+  });
+
   it('excludes a repo-scoped file from tracking when the user chooses the .tuckignore action', async () => {
     selectMock.mockResolvedValue('ignore');
     await initTestTuck();


### PR DESCRIPTION
Fixes #100.

## What this fixes

Choosing **"Replace with placeholders"** during `tuck add`/`tuck scan`/`tuck sync` could:

1. rewrite a live `~/.zshrc` into invalid shell (`export LAMBDA_{{API_KEY}}...`) — zsh aborts sourcing at that line, killing p10k, aliases, and PATH for every new terminal;
2. leave the second half of a dotted credential in cleartext **committed to the repo**;
3. flag stock `~/.p10k.zsh` comments as multi-line "critical" passwords and splice four comment lines into one;
4. leave the live file permanently redacted with no restore path.

## Changes

**`scanner.ts` — use the first *defined* capture group.**
`match[1] || match[0]` fell back to the whole match for the generic assignment patterns, whose unquoted alternative captures in group 2. The stored/replaced "secret" then included the `API_KEY=` context, so redaction ate the tail of the variable name.

**`patterns.ts` — allow `.` in assignment values.**
`api-key-assignment`/`secret-assignment` stopped matching at a dot, so `secret_xxx.yyy` was only half-captured — and after redaction the other half stayed in cleartext in the committed copy (`token-assignment` already allowed dots).

**`patterns.ts` — keep URL credential patterns on one line.**
`password-url`'s `[^:]`/`[^@]` classes matched newlines, so a URL in one comment line paired with an `@` four lines later (RFC 3986 userinfo can't contain whitespace or `/`). Same whitespace exclusion applied to the postgres/mysql/mongodb/redis connection-string patterns.

**`trackPipeline.ts` / `redactor.ts` — restore live files after tracking.**
The redact action records which live paths it rewrote (`PreparedTrackFile.redactedLivePaths`); after `trackFilesWithProgress` copies the redacted content into the repo, `restoreRedactedLiveFiles` puts the original values back into the live files. Placeholders now exist **only** in the repo copy. Symlinked live paths are skipped (restoring through them would write the secrets back into git) with a warning. Wired into `add`, `scan`, `init`, and both `sync` flows (new-file tracking, and modified-change redaction via a `finally` around `syncFiles` so an aborted sync also restores).

**`stateModel.ts` / `sync.ts` `detectChanges` — placeholder-aware drift.**
With the live file keeping real values and the repo copy keeping placeholders, their checksums differ forever — every future sync would re-flag the same secrets (or `SecretsDetectedError` in non-interactive mode). A live file that equals `restore(repoCopy, secrets)` is now classified as unchanged, mirroring how template/encrypted files compare live against `materialize(repo)`. Genuine edits still surface as `drift-local`/modified.

## Verification

- 1529 tests pass (16 new: scanner extraction, multiline false positive, live restore incl. symlink guard, pipeline round-trip, state-model drift semantics), `tsc --noEmit` and `eslint` clean.
- Exercised end-to-end against the built CLI in a sandbox `$HOME` with the exact incident inputs (dotted `LAMBDA_API_KEY`, p10k-style comment block), driving the interactive prompts through a pty:
  - live `.testrc` byte-identical after add; repo copy is `export LAMBDA_API_KEY={{API_KEY}}` (valid zsh, `zsh -n` clean, no cleartext tail); `secrets.local.json` holds the full dotted value with no `API_KEY=` context.
  - `tuck sync --plan` empty after restore; a genuine edit is detected; reverting is clean; `tuck status` reports up to date.
  - p10k-style file tracks with **no** security warning and a byte-identical repo copy.

## Not addressed (follow-ups)

- Placeholder naming still prefers whichever pattern matches first, so a GitHub fine-grained PAT on a `..._TOKEN=` line is stored as generic `TOKEN` rather than `GITHUB_FINE_GRAINED_TOKEN` — cosmetic, dedup is by value.
- If the process dies between redaction and restore, the live file stays redacted (values remain recoverable in `secrets.local.json`). Window is small; a crash-safe journal felt out of scope.
- Directory-tracked entries whose inner files were redacted still compare by directory checksum in `detectChanges` (single files — the incident case — are placeholder-aware).
