### PR TITLE
feat(apply): remote / SSH apply — push tracked configs onto a remote box

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,43 @@ tuck init --from github.com/you/dotfiles
 tuck restore --all
 ```
 
+### Onto a remote box (SSH)
+
+Push the configs this machine already tracks — your agent configs (`.claude`,
+`.cursor`, `.codex`), shell, git, editor — onto a remote server over ssh/scp.
+tuck prints a plan first and asks before transferring anything.
+
+```bash
+# Push everything you track to a remote box (a plan is shown first)
+tuck apply --target ssh://me@server.example.com
+
+# Shorthand, a non-standard port, and a preview-only run
+tuck apply --ssh me@server.example.com --port 2222
+tuck apply --ssh server --dry-run
+
+# Only push a single bundle (e.g. your agent configs)
+tuck apply --ssh server --bundle agents
+```
+
+Each tracked file lands at the same home-relative path on the remote
+(`~/.zshrc` → remote `~/.zshrc`). Only regular home-scoped files are pushed;
+repo-scoped and directory entries are skipped and reported. Nothing runs through
+a shell on your side, and the ssh host/user/port and every remote path are
+validated before use.
+
+**No local push? Bootstrap the remote instead.** Print a one-liner that installs
+tuck and applies a source on a fresh box:
+
+```bash
+tuck apply you/dotfiles --print-bootstrap
+# → npm install -g @prnv/tuck && tuck apply you/dotfiles --yes
+# run it over ssh:
+ssh server 'npm install -g @prnv/tuck && tuck apply you/dotfiles --yes'
+```
+
+Requires `ssh` and `scp` on your machine and SSH access to the remote (key-based
+auth recommended). `tuck` does not need to be installed on the remote for a push.
+
 ## Commands
 
 ### Essential (what you'll use 99% of the time)
@@ -114,11 +151,12 @@ tuck restore --all
 
 ### Restoring
 
-| Command             | Description                                            |
-| ------------------- | ------------------------------------------------------ |
-| `tuck apply <user>` | Apply dotfiles from a GitHub user (with smart merging) |
-| `tuck restore`      | Restore dotfiles from repo to system                   |
-| `tuck undo`         | Restore from Time Machine backup snapshots             |
+| Command                     | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| `tuck apply <user>`         | Apply dotfiles from a GitHub user (with smart merging)          |
+| `tuck apply --target <uri>` | Push your locally-tracked configs onto a remote box over SSH    |
+| `tuck restore`              | Restore dotfiles from repo to system                            |
+| `tuck undo`                 | Restore from Time Machine backup snapshots                      |
 
 ### Configuration
 

--- a/docs/man/tuck.1
+++ b/docs/man/tuck.1
@@ -42,7 +42,7 @@ Show differences between system and repository
 Manage tuck configuration
 .TP
 .B apply
-Apply dotfiles from a repository to this machine
+Apply dotfiles from a repository to this machine, or push locally-tracked configs onto a remote box with \-\-target ssh://[user@]host (or \-\-ssh host); \-\-print\-bootstrap prints a remote install\-and\-apply one\-liner
 .TP
 .B undo
 Restore files from a Time Machine backup snapshot

--- a/docs/man/tuck.1.md
+++ b/docs/man/tuck.1.md
@@ -21,7 +21,7 @@ tuck is a modern dotfiles manager that provides a beautiful CLI for managing you
 * **list**: List all tracked files
 * **diff**: Show differences between system and repository
 * **config**: Manage tuck configuration
-* **apply**: Apply dotfiles from a repository to this machine
+* **apply**: Apply dotfiles from a repository to this machine, or push locally-tracked configs onto a remote box with **--target ssh://[user@]host** (or **--ssh host**); **--print-bootstrap** prints a remote install-and-apply one-liner
 * **undo**: Restore files from a Time Machine backup snapshot
 * **scan**: Scan the system for dotfiles and select which to track
 * **secrets**: Manage local secrets for placeholder replacement

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -31,7 +31,7 @@ import { findPlaceholders, restoreContent, restoreFiles as restoreSecrets, getAl
 import { createResolver } from '../lib/secretBackends/index.js';
 import { loadConfig } from '../lib/config.js';
 import { IS_WINDOWS } from '../lib/platform.js';
-import { RepositoryNotFoundError, MaterializeError, NotInitializedError, ValidationError } from '../errors.js';
+import { RepositoryNotFoundError, MaterializeError, NotInitializedError, ValidationError, RemoteApplyError } from '../errors.js';
 import {
   parseSshTarget,
   buildRemotePlan,
@@ -1698,22 +1698,30 @@ export const runSshApply = async (
     }
   }
 
+  // Escalate any transfer failure into a non-zero exit. Returning normally here
+  // (as a warning) makes `tuck apply --ssh box --json` emit {ok:true, applied:0}
+  // and exit 0 even when every push failed — invisible to CI/scripts. Throwing a
+  // RemoteApplyError still preserves the partial outcome in its JSON envelope.
+  if (failed.length > 0) {
+    if (!isJsonMode()) {
+      logger.blank();
+      logger.warning(`Pushed ${pushed} file(s), ${failed.length} failed`);
+    }
+    throw new RemoteApplyError(target.display, pushed, failed, skipCounts(plan));
+  }
+
   if (isJsonMode()) {
     emitJsonOk({
       applied: pushed,
       target: target.display,
-      failed: failed.map((f) => f.source),
+      failed: [],
       skipped: skipCounts(plan),
     });
     return;
   }
 
   logger.blank();
-  if (failed.length === 0) {
-    logger.success(`Pushed ${pushed} file(s) to ${target.display}`);
-  } else {
-    logger.warning(`Pushed ${pushed} file(s), ${failed.length} failed`);
-  }
+  logger.success(`Pushed ${pushed} file(s) to ${target.display}`);
 };
 
 /** Structured skip counts for the JSON envelope. */

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -26,12 +26,22 @@ import { smartMerge, isShellFile, generateMergePreview } from '../lib/merge.js';
 import { CATEGORIES } from '../constants.js';
 import { type TuckManifestOutput } from '../schemas/manifest.schema.js';
 import { loadManifestFile } from '../lib/manifestFile.js';
-import { clearManifestCache } from '../lib/manifest.js';
+import { clearManifestCache, loadManifest } from '../lib/manifest.js';
 import { findPlaceholders, restoreContent, restoreFiles as restoreSecrets, getAllSecrets, getSecretCount } from '../lib/secrets/index.js';
 import { createResolver } from '../lib/secretBackends/index.js';
 import { loadConfig } from '../lib/config.js';
 import { IS_WINDOWS } from '../lib/platform.js';
-import { RepositoryNotFoundError, MaterializeError } from '../errors.js';
+import { RepositoryNotFoundError, MaterializeError, NotInitializedError, ValidationError } from '../errors.js';
+import {
+  parseSshTarget,
+  buildRemotePlan,
+  pushEntryToRemote,
+  buildBootstrapOneLiner,
+  defaultRemoteRunner,
+  type SshTarget,
+  type RemotePlan,
+  type RemoteRunner,
+} from '../lib/sshApply.js';
 import { getProvider, type ProviderMode, type RemoteConfig as ProviderRemoteConfig } from '../lib/providers/index.js';
 import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from '../lib/materialize.js';
@@ -302,6 +312,14 @@ export interface ApplyOptions {
   bundle?: string;
   /** Bind an as-yet-unknown repo to this root before applying repo-scoped files. */
   repoRoot?: string;
+  /** Remote apply target as an `ssh://[user@]host[:port]` URI (or bare host). */
+  target?: string;
+  /** Remote apply target shorthand: `[user@]host`. */
+  ssh?: string;
+  /** Override/supply the SSH port for remote apply. */
+  port?: string;
+  /** Print the documented remote bootstrap one-liner for <source> and exit. */
+  printBootstrap?: boolean;
 }
 
 export interface ApplyFile {
@@ -1498,11 +1516,219 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
   }
 };
 
+/**
+ * Merge the CLI `--port` override onto a parsed SSH target. Commander hands the
+ * value over as a string; it is validated to a 1–65535 integer before use.
+ */
+const applyPortOverride = (target: SshTarget, portOption?: string): SshTarget => {
+  if (portOption === undefined) return target;
+  if (!/^\d+$/.test(portOption)) {
+    throw new ValidationError('ssh port', `${portOption} is not a valid port`);
+  }
+  const port = Number(portOption);
+  if (port < 1 || port > 65535) {
+    throw new ValidationError('ssh port', `${portOption} is out of range (1-65535)`);
+  }
+  const display =
+    (target.user ? `${target.user}@` : '') + target.host + `:${port}`;
+  return { ...target, port, display };
+};
+
+/** Human-readable one-line summary of everything the remote plan skipped. */
+const summarizeSkips = (plan: RemotePlan): string[] => {
+  const notes: string[] = [];
+  if (plan.skippedRepoScoped.length > 0) {
+    notes.push(
+      `${plan.skippedRepoScoped.length} repo-scoped file(s) (no portable remote home path)`
+    );
+  }
+  if (plan.skippedDirectories.length > 0) {
+    notes.push(`${plan.skippedDirectories.length} directory entr(y/ies) (v1 pushes files only)`);
+  }
+  if (plan.skippedUnsafe.length > 0) {
+    notes.push(`${plan.skippedUnsafe.length} non-home file(s)`);
+  }
+  if (plan.missing.length > 0) {
+    notes.push(`${plan.missing.length} file(s) missing from the repo copy`);
+  }
+  return notes;
+};
+
+/**
+ * Print the remote-apply plan (grouped by category) so the operator sees exactly
+ * what will be written to which remote path before anything is transferred.
+ */
+const displayRemotePlan = (target: SshTarget, plan: RemotePlan): void => {
+  console.log();
+  console.log(c.bold(`Plan for ${target.display}:`));
+  console.log();
+
+  const byCategory: Record<string, typeof plan.entries> = {};
+  for (const entry of plan.entries) {
+    (byCategory[entry.category] ??= []).push(entry);
+  }
+  for (const [category, categoryEntries] of Object.entries(byCategory)) {
+    const categoryConfig = CATEGORIES[category] || { icon: '📄' };
+    console.log(c.bold(`  ${categoryConfig.icon} ${category}`));
+    for (const entry of categoryEntries) {
+      console.log(c.dim(`    ${entry.source}  →  ~/${entry.remoteRelative}`));
+    }
+  }
+  console.log();
+
+  const skips = summarizeSkips(plan);
+  if (skips.length > 0) {
+    console.log(c.dim(`  Skipping: ${skips.join(', ')}`));
+    console.log();
+  }
+};
+
+/**
+ * Print the documented remote bootstrap one-liner for a source, then return.
+ * Users copy this onto a fresh box (or `ssh host '<one-liner>'`) to install
+ * tuck and apply a dotfiles source without a local push.
+ */
+export const runBootstrap = (source: string, options: ApplyOptions): void => {
+  if (options.json) setJsonMode(true, 'tuck apply');
+  const oneLiner = buildBootstrapOneLiner(source);
+
+  if (isJsonMode()) {
+    emitJsonOk({ bootstrap: oneLiner, source });
+    return;
+  }
+
+  console.log();
+  console.log(c.bold('Remote bootstrap one-liner:'));
+  console.log();
+  console.log(`  ${oneLiner}`);
+  console.log();
+  console.log(c.dim('Run it on the remote host, or over ssh:'));
+  console.log(c.dim(`  ssh <host> '${oneLiner}'`));
+  console.log();
+};
+
+/**
+ * Push the locally-tracked home configs onto a remote box over ssh/scp.
+ *
+ * A plan is ALWAYS shown first. In an interactive TTY the operator confirms
+ * before any transfer; `--yes`/`--force`/`--json` skip the prompt. `--dry-run`
+ * prints the plan and stops. The transfer runner is injectable so tests exercise
+ * the flow without touching the network.
+ */
+export const runSshApply = async (
+  options: ApplyOptions,
+  runner: RemoteRunner = defaultRemoteRunner
+): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck apply');
+
+  const targetInput = options.target ?? options.ssh;
+  if (!targetInput) {
+    throw new ValidationError('ssh target', 'no --target or --ssh value provided');
+  }
+  const target = applyPortOverride(parseSshTarget(targetInput), options.port);
+
+  // Read the LOCAL manifest — the files this machine tracks are what we push.
+  const tuckDir = getTuckDir();
+  let manifest: TuckManifestOutput;
+  try {
+    manifest = await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+
+  const plan = await buildRemotePlan(manifest, tuckDir, options.bundle);
+
+  if (plan.entries.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ applied: 0, target: target.display, skipped: skipCounts(plan) });
+      return;
+    }
+    const scope = options.bundle ? ` in bundle "${options.bundle}"` : '';
+    logger.warning(`No files to push${scope}`);
+    for (const note of summarizeSkips(plan)) logger.warning(`Skipped: ${note}`);
+    return;
+  }
+
+  // JSON / non-interactive: no plan UI, no prompt; honor --dry-run.
+  const interactive =
+    !options.force && !options.yes && !options.json && !!process.stdout.isTTY;
+
+  if (!isJsonMode()) {
+    displayRemotePlan(target, plan);
+  }
+
+  if (options.dryRun) {
+    if (isJsonMode()) {
+      emitJsonOk({
+        applied: 0,
+        target: target.display,
+        dryRun: true,
+        planned: plan.entries.length,
+        skipped: skipCounts(plan),
+      });
+      return;
+    }
+    logger.info(`Dry run - would push ${plan.entries.length} file(s) to ${target.display}`);
+    return;
+  }
+
+  if (interactive) {
+    const confirmed = await prompts.confirm(
+      `Push ${plan.entries.length} file(s) to ${target.display}?`,
+      true
+    );
+    if (!confirmed) {
+      prompts.cancel('Remote apply cancelled');
+      return;
+    }
+    console.log();
+  }
+
+  let pushed = 0;
+  const failed: Array<{ source: string; error: string }> = [];
+  for (const entry of plan.entries) {
+    try {
+      await pushEntryToRemote(target, entry, runner);
+      pushed++;
+      if (!isJsonMode()) logger.file('add', `~/${entry.remoteRelative}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failed.push({ source: entry.source, error: message });
+      if (!isJsonMode()) logger.warning(`Failed to push ${entry.source}: ${message}`);
+    }
+  }
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      applied: pushed,
+      target: target.display,
+      failed: failed.map((f) => f.source),
+      skipped: skipCounts(plan),
+    });
+    return;
+  }
+
+  logger.blank();
+  if (failed.length === 0) {
+    logger.success(`Pushed ${pushed} file(s) to ${target.display}`);
+  } else {
+    logger.warning(`Pushed ${pushed} file(s), ${failed.length} failed`);
+  }
+};
+
+/** Structured skip counts for the JSON envelope. */
+const skipCounts = (plan: RemotePlan): Record<string, number> => ({
+  repoScoped: plan.skippedRepoScoped.length,
+  directories: plan.skippedDirectories.length,
+  unsafe: plan.skippedUnsafe.length,
+  missing: plan.missing.length,
+});
+
 export const applyCommand = new Command('apply')
-  .description('Apply dotfiles from a repository to this machine')
+  .description('Apply dotfiles from a repository to this machine (or push to a remote over SSH)')
   .argument(
-    '<source>',
-    'username, user/repo, provider:user/repo, a full git URL, or a local directory/tarball path'
+    '[source]',
+    'username, user/repo, provider:user/repo, a full git URL, or a local directory/tarball path (omit for --target/--ssh)'
   )
   .option('-m, --merge', 'Merge with existing files (preserve local customizations)')
   .option('-r, --replace', 'Replace existing files completely')
@@ -1515,7 +1741,40 @@ export const applyCommand = new Command('apply')
     '--repo-root <dir>',
     'Bind an as-yet-unlinked repo to this checkout before applying repo-scoped files'
   )
-  .action(async (source: string, options: ApplyOptions) => {
+  .option(
+    '--target <uri>',
+    'Push locally-tracked configs to a remote box: ssh://[user@]host[:port] (or a bare host)'
+  )
+  .option('--ssh <host>', 'Push locally-tracked configs to a remote box: [user@]host (shorthand for --target)')
+  .option('--port <n>', 'SSH port for --target/--ssh (overrides a port in the URI)')
+  .option('--print-bootstrap', 'Print the remote bootstrap one-liner for <source> and exit')
+  .action(async (source: string | undefined, options: ApplyOptions) => {
+    // --print-bootstrap is a pure informational path: it needs a <source> to
+    // build the "install tuck and apply this" one-liner and touches nothing.
+    if (options.printBootstrap) {
+      if (!source) {
+        throw new ValidationError('source', '--print-bootstrap requires a <source> to bootstrap');
+      }
+      runBootstrap(source, options);
+      return;
+    }
+
+    // Remote apply pushes THIS machine's tracked files; a repo source is not used.
+    if (options.target || options.ssh) {
+      if (source) {
+        throw new ValidationError(
+          'source',
+          '--target/--ssh pushes your locally-tracked files; omit the <source> argument'
+        );
+      }
+      await runSshApply(options);
+      return;
+    }
+
+    if (!source) {
+      throw new ValidationError('source', 'a <source> is required (or use --target/--ssh)');
+    }
+
     // Determine if we should run interactive mode
     const isInteractive = !options.force && !options.yes && !options.json && process.stdout.isTTY;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -393,6 +393,62 @@ export class KeystoreError extends TuckError {
   }
 }
 
+/**
+ * The JSON error projection for a partially- or fully-failed remote apply.
+ *
+ * Extends the base {@link JsonError} with the structured push outcome so a
+ * `tuck apply --ssh <box> --json` that hit transfer failures still exits
+ * non-zero AND surfaces what got through / what did not, instead of silently
+ * reporting `{ ok: true, applied: 0 }` with exit code 0.
+ */
+export interface RemoteApplyJsonError extends JsonError {
+  /** Files successfully pushed before/around the failures. */
+  applied: number;
+  /** The remote target's display form (e.g. "me@box:2222"). */
+  target: string;
+  /** Sources of the files whose transfer failed. */
+  failed: string[];
+  /** Structured skip counts (repo-scoped, directories, unsafe, missing). */
+  skipped: Record<string, number>;
+}
+
+/**
+ * Raised when one or more files failed to transfer during a remote/SSH apply.
+ *
+ * Escalating (rather than logging a warning and returning) guarantees a
+ * non-zero exit code so CI/scripts can detect a failed push. The partial
+ * outcome is preserved in {@link toJSON} so `--json` consumers still see what
+ * was applied and what failed.
+ */
+export class RemoteApplyError extends TuckError {
+  constructor(
+    private readonly target: string,
+    private readonly applied: number,
+    private readonly failed: Array<{ source: string; error: string }>,
+    private readonly skipped: Record<string, number>
+  ) {
+    super(
+      `Pushed ${applied} file(s) to ${target}, ${failed.length} failed`,
+      'REMOTE_APPLY_FAILED',
+      [
+        'Check the remote is reachable and accepting connections (try: ssh <host>)',
+        'Ensure the remote user can write to their home directory',
+      ]
+    );
+    this.name = 'RemoteApplyError';
+  }
+
+  toJSON(): RemoteApplyJsonError {
+    return {
+      ...super.toJSON(),
+      applied: this.applied,
+      target: this.target,
+      failed: this.failed.map((f) => f.source),
+      skipped: this.skipped,
+    };
+  }
+}
+
 // ============================================================================
 // Error Handler
 // ============================================================================

--- a/src/lib/sshApply.ts
+++ b/src/lib/sshApply.ts
@@ -13,9 +13,13 @@
  * - The remote destination is derived from the tracked file's home-relative
  *   source (`~/.zshrc` → `.zshrc`) and is always placed under the remote $HOME.
  *   Absolute / out-of-home / traversal paths are refused.
- * - The remote `mkdir -p` command and the scp remote spec ARE interpreted by the
- *   remote shell, so remote paths are single-quoted and validated to contain no
- *   single quote or control character before use.
+ * - The remote `mkdir -p` command IS interpreted by the remote shell, so its path
+ *   is single-quoted and validated to contain no single quote or control
+ *   character before use. The scp destination path is NOT shell-interpreted:
+ *   since OpenSSH 9.0 scp speaks the SFTP protocol and takes the path verbatim,
+ *   so it is passed UNQUOTED (quoting it would create a file whose name literally
+ *   contains the quotes). The same no-quote/no-control-char validation is kept as
+ *   defense-in-depth.
  * - ssh host/user/port components are strictly validated (no leading dash, no
  *   shell metacharacters) so a hostile value cannot be smuggled in as an ssh flag.
  */
@@ -271,9 +275,16 @@ export const buildSshCommand = (target: SshTarget, remoteCommand: string): strin
 
 /**
  * Build the argv for an `scp` upload of a single local file to a remote
- * home-relative path. The port flag for scp is `-P` (capital). The remote path
- * is single-quoted so spaces and shell-special characters are inert; the caller
- * has already validated it contains no single quote.
+ * home-relative path. The port flag for scp is `-P` (capital).
+ *
+ * The remote path is passed UNQUOTED. Since OpenSSH 9.0 (the default on all
+ * modern macOS/Linux) scp uses the SFTP protocol, where the remote path is taken
+ * verbatim rather than expanded by a remote shell — there is no shell on the
+ * execFile→scp→sftp-server path. Single-quoting it (as the legacy SCP protocol
+ * required) would create a remote file whose name literally contains the quote
+ * characters, silently writing to the wrong destination. `remoteRelative` has
+ * already been validated (no single quote, no control character) as
+ * defense-in-depth.
  */
 export const buildScpCommand = (
   target: SshTarget,
@@ -282,7 +293,7 @@ export const buildScpCommand = (
 ): string[] => {
   const args: string[] = [];
   if (target.port) args.push('-P', String(target.port));
-  args.push(localPath, `${sshDestination(target)}:'${remoteRelative}'`);
+  args.push(localPath, `${sshDestination(target)}:${remoteRelative}`);
   return args;
 };
 

--- a/src/lib/sshApply.ts
+++ b/src/lib/sshApply.ts
@@ -1,0 +1,326 @@
+/**
+ * Remote / SSH apply — push locally-tracked configs onto a remote box.
+ *
+ * `tuck apply --target ssh://[user@]host` (or `tuck apply --ssh host`) reads the
+ * LOCAL tuck manifest and copies each tracked file's committed repo copy onto a
+ * remote machine over ssh/scp, placing it at the same home-relative path on the
+ * remote. This is the "get my agent configs (.claude / .cursor / .codex) onto
+ * every server I SSH into" workflow.
+ *
+ * Design/safety notes:
+ * - We never shell out through a shell: every ssh/scp invocation uses execFile
+ *   with an argv array, so the LOCAL side cannot be command-injected.
+ * - The remote destination is derived from the tracked file's home-relative
+ *   source (`~/.zshrc` → `.zshrc`) and is always placed under the remote $HOME.
+ *   Absolute / out-of-home / traversal paths are refused.
+ * - The remote `mkdir -p` command and the scp remote spec ARE interpreted by the
+ *   remote shell, so remote paths are single-quoted and validated to contain no
+ *   single quote or control character before use.
+ * - ssh host/user/port components are strictly validated (no leading dash, no
+ *   shell metacharacters) so a hostile value cannot be smuggled in as an ssh flag.
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { join, posix } from 'path';
+import { z } from 'zod';
+import { isDirectory, pathExists } from './paths.js';
+import { ValidationError } from '../errors.js';
+import type { TuckManifestOutput } from '../schemas/manifest.schema.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Per-operation timeout for a single ssh/scp child process (60s). */
+export const SSH_OPERATION_TIMEOUT = 60_000;
+
+/** Upper bound on buffered ssh/scp output so a hostile remote can't OOM us. */
+export const SSH_MAX_BUFFER = 10 * 1024 * 1024; // 10MB
+
+/** Package spec used by the documented remote bootstrap one-liner. */
+export const TUCK_NPM_PACKAGE = '@prnv/tuck';
+
+export interface SshTarget {
+  /** Optional remote user (defaults to ssh's own default when absent). */
+  user?: string;
+  host: string;
+  /** Optional non-standard port. */
+  port?: number;
+  /** Human display form, e.g. "me@box:2222". */
+  display: string;
+}
+
+export interface RemoteApplyEntry {
+  /** Display source from the manifest (e.g. "~/.zshrc"). */
+  source: string;
+  /** Absolute path to the committed repo copy to upload. */
+  localPath: string;
+  /** POSIX home-relative path on the remote (e.g. ".config/nvim/init.lua"). */
+  remoteRelative: string;
+  category: string;
+}
+
+export interface RemotePlan {
+  entries: RemoteApplyEntry[];
+  /** Repo-scoped sources skipped (no stable cross-machine remote home path). */
+  skippedRepoScoped: string[];
+  /** Directory entries skipped (v1 pushes regular files only). */
+  skippedDirectories: string[];
+  /** Non-home-relative / unsafe sources skipped. */
+  skippedUnsafe: string[];
+  /** Tracked entries whose committed repo copy is missing on disk. */
+  missing: string[];
+}
+
+// A single ssh host/user label component: must start with an alphanumeric and
+// contain only host-safe characters. This rejects a leading '-' (which ssh/scp
+// would read as a flag) and every shell metacharacter.
+const HOST_COMPONENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+const sshTargetSchema = z.object({
+  user: z
+    .string()
+    .regex(HOST_COMPONENT, 'invalid ssh user')
+    .optional(),
+  host: z.string().regex(HOST_COMPONENT, 'invalid ssh host'),
+  port: z.number().int().min(1).max(65535).optional(),
+});
+
+/**
+ * Parse a target into a validated {@link SshTarget}.
+ *
+ * Accepts either an `ssh://[user@]host[:port]` URL (from `--target`) or a bare
+ * `[user@]host` shorthand (from `--ssh`, or `--target` without a scheme).
+ * A non-`ssh` scheme is rejected. Every component is validated with
+ * {@link sshTargetSchema}, so a malformed or injection-shaped value throws a
+ * {@link ValidationError} instead of reaching ssh/scp.
+ */
+export const parseSshTarget = (input: string): SshTarget => {
+  const raw = input.trim();
+  if (raw.length === 0) {
+    throw new ValidationError('ssh target', 'target is empty');
+  }
+
+  let user: string | undefined;
+  let host: string;
+  let port: number | undefined;
+
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(raw)) {
+    // A scheme is present — only ssh:// is supported here.
+    if (!raw.startsWith('ssh://')) {
+      throw new ValidationError('ssh target', `unsupported scheme in "${raw}" (expected ssh://)`);
+    }
+    let url: URL;
+    try {
+      url = new URL(raw);
+    } catch {
+      throw new ValidationError('ssh target', `could not parse "${raw}"`);
+    }
+    host = url.hostname;
+    user = url.username ? decodeURIComponent(url.username) : undefined;
+    if (url.port) {
+      port = Number(url.port);
+    }
+    if (url.pathname && url.pathname !== '/') {
+      throw new ValidationError('ssh target', 'a remote path is not allowed in the ssh target');
+    }
+  } else {
+    // Bare shorthand: [user@]host[:port].
+    let rest = raw;
+    const at = rest.indexOf('@');
+    if (at !== -1) {
+      user = rest.slice(0, at);
+      rest = rest.slice(at + 1);
+    }
+    // Split a trailing :port, but leave bracketed IPv6 (unsupported here) to fail
+    // validation rather than mis-parse.
+    const colon = rest.lastIndexOf(':');
+    if (colon !== -1) {
+      const portStr = rest.slice(colon + 1);
+      if (/^\d+$/.test(portStr)) {
+        port = Number(portStr);
+        rest = rest.slice(0, colon);
+      }
+    }
+    host = rest;
+  }
+
+  const parsed = sshTargetSchema.safeParse({ user, host, port });
+  if (!parsed.success) {
+    const reason = parsed.error.issues[0]?.message ?? 'invalid ssh target';
+    throw new ValidationError('ssh target', `${reason} (from "${raw}")`);
+  }
+
+  const display =
+    (parsed.data.user ? `${parsed.data.user}@` : '') +
+    parsed.data.host +
+    (parsed.data.port ? `:${parsed.data.port}` : '');
+
+  return { user: parsed.data.user, host: parsed.data.host, port: parsed.data.port, display };
+};
+
+/**
+ * Convert a tracked file's home-relative source (`~/.zshrc`) into the POSIX
+ * home-relative path used on the remote (`.zshrc`). Returns null for anything
+ * that is not safely inside home: a bare `~`/`$HOME`, an absolute path, or a
+ * path containing a `..` segment. The result is also rejected if it contains a
+ * single quote or control character, since it is interpolated into a
+ * single-quoted remote shell command.
+ */
+export const remoteRelativeFromSource = (source: string): string | null => {
+  const norm = source.replace(/\\/g, '/').trim();
+
+  let rel: string;
+  if (norm === '~' || norm === '$HOME') {
+    return null; // the home dir itself is not a file to push
+  } else if (norm.startsWith('~/')) {
+    rel = norm.slice(2);
+  } else if (norm.startsWith('$HOME/')) {
+    rel = norm.slice(6);
+  } else {
+    return null; // absolute or otherwise out-of-home
+  }
+
+  const segments = rel.split('/').filter((s) => s.length > 0 && s !== '.');
+  if (segments.length === 0) return null;
+  if (segments.includes('..')) return null;
+
+  const result = segments.join('/');
+  // Reject a single quote or any control character: the path is interpolated
+  // into a single-quoted remote shell command (`mkdir -p '<path>'`); a quote or
+  // newline would break out of that quoting. Spaces are safe inside quotes.
+  if (result.includes("'")) return null;
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f]/.test(result)) return null;
+  return result;
+};
+
+/**
+ * Build the remote-apply plan from the LOCAL manifest.
+ *
+ * Home-scoped regular files become {@link RemoteApplyEntry}s targeting the same
+ * home-relative path on the remote. Repo-scoped entries, directory entries, and
+ * unsafe sources are collected into their respective skip lists (v1 pushes
+ * regular home files only). Entries whose committed repo copy is missing on disk
+ * are reported in `missing` and excluded.
+ */
+export const buildRemotePlan = async (
+  manifest: TuckManifestOutput,
+  tuckDir: string,
+  bundle?: string
+): Promise<RemotePlan> => {
+  const entries: RemoteApplyEntry[] = [];
+  const skippedRepoScoped: string[] = [];
+  const skippedDirectories: string[] = [];
+  const skippedUnsafe: string[] = [];
+  const missing: string[] = [];
+
+  for (const file of Object.values(manifest.files)) {
+    if (bundle && (file.bundle ?? 'default') !== bundle) {
+      continue;
+    }
+
+    if (file.scope === 'repo') {
+      skippedRepoScoped.push(file.source);
+      continue;
+    }
+
+    const remoteRelative = remoteRelativeFromSource(file.source);
+    if (remoteRelative === null) {
+      skippedUnsafe.push(file.source);
+      continue;
+    }
+
+    const localPath = join(tuckDir, file.destination);
+    if (!(await pathExists(localPath))) {
+      missing.push(file.source);
+      continue;
+    }
+
+    if (await isDirectory(localPath)) {
+      skippedDirectories.push(file.source);
+      continue;
+    }
+
+    entries.push({
+      source: file.source,
+      localPath,
+      remoteRelative,
+      category: file.category,
+    });
+  }
+
+  // Stable ordering for deterministic plans/output.
+  entries.sort((a, b) => a.remoteRelative.localeCompare(b.remoteRelative));
+
+  return { entries, skippedRepoScoped, skippedDirectories, skippedUnsafe, missing };
+};
+
+/** The `[user@]host` destination passed to ssh/scp. */
+export const sshDestination = (target: SshTarget): string =>
+  target.user ? `${target.user}@${target.host}` : target.host;
+
+/**
+ * Build the argv for an `ssh` invocation running a remote shell command.
+ * The port flag for ssh is `-p`.
+ */
+export const buildSshCommand = (target: SshTarget, remoteCommand: string): string[] => {
+  const args: string[] = [];
+  if (target.port) args.push('-p', String(target.port));
+  args.push(sshDestination(target), remoteCommand);
+  return args;
+};
+
+/**
+ * Build the argv for an `scp` upload of a single local file to a remote
+ * home-relative path. The port flag for scp is `-P` (capital). The remote path
+ * is single-quoted so spaces and shell-special characters are inert; the caller
+ * has already validated it contains no single quote.
+ */
+export const buildScpCommand = (
+  target: SshTarget,
+  localPath: string,
+  remoteRelative: string
+): string[] => {
+  const args: string[] = [];
+  if (target.port) args.push('-P', String(target.port));
+  args.push(localPath, `${sshDestination(target)}:'${remoteRelative}'`);
+  return args;
+};
+
+/**
+ * Runner abstraction so the command layer (and tests) can inject a fake ssh/scp.
+ * The default implementation shells out via execFile with a timeout and a
+ * bounded output buffer.
+ */
+export type RemoteRunner = (command: 'ssh' | 'scp', args: string[]) => Promise<void>;
+
+export const defaultRemoteRunner: RemoteRunner = async (command, args) => {
+  await execFileAsync(command, args, {
+    timeout: SSH_OPERATION_TIMEOUT,
+    maxBuffer: SSH_MAX_BUFFER,
+  });
+};
+
+/**
+ * Push a single planned entry to the remote: create its parent directory tree
+ * (idempotent `mkdir -p`), then scp the file into place. The remote parent path
+ * is single-quoted; entries were validated to contain no single quote.
+ */
+export const pushEntryToRemote = async (
+  target: SshTarget,
+  entry: RemoteApplyEntry,
+  runner: RemoteRunner = defaultRemoteRunner
+): Promise<void> => {
+  const parent = posix.dirname(entry.remoteRelative);
+  if (parent && parent !== '.') {
+    await runner('ssh', buildSshCommand(target, `mkdir -p '${parent}'`));
+  }
+  await runner('scp', buildScpCommand(target, entry.localPath, entry.remoteRelative));
+};
+
+/**
+ * The documented remote bootstrap one-liner: install tuck on a fresh box and
+ * apply a dotfiles source in one shot. Complements the push flow for machines
+ * you can reach but don't want to push to from your laptop.
+ */
+export const buildBootstrapOneLiner = (source: string): string =>
+  `npm install -g ${TUCK_NPM_PACKAGE} && tuck apply ${source} --yes`;

--- a/tests/commands/apply-ssh.test.ts
+++ b/tests/commands/apply-ssh.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Integration tests for `tuck apply --target/--ssh` (remote apply).
+ *
+ * The transfer runner is INJECTED, so these exercise the full command flow —
+ * manifest load, plan build, confirmation gate, per-file push, JSON envelope —
+ * without ever touching the network, a real keychain, or the real $HOME (memfs +
+ * a temp tuck dir under the mocked home).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+
+const loggerWarningMock = vi.fn();
+const loggerSuccessMock = vi.fn();
+const loggerInfoMock = vi.fn();
+const loggerFileMock = vi.fn();
+const confirmMock = vi.fn().mockResolvedValue(true);
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    confirm: confirmMock,
+    select: vi.fn(),
+    cancel: vi.fn(),
+  },
+  logger: {
+    info: loggerInfoMock,
+    success: loggerSuccessMock,
+    warning: loggerWarningMock,
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: loggerFileMock,
+    dim: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: {
+    yellow: (x: string) => x,
+    dim: (x: string) => x,
+    bold: (x: string) => x,
+    green: (x: string) => x,
+    cyan: (x: string) => x,
+  },
+}));
+
+const seedManifest = (
+  files: Record<string, ReturnType<typeof createMockTrackedFile>>
+): void => {
+  vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  const manifest = createMockManifest({ files });
+  vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+};
+
+const writeRepoFile = (rel: string, content = 'x'): void => {
+  const abs = join(TEST_TUCK_DIR, rel);
+  vol.mkdirSync(join(abs, '..'), { recursive: true });
+  vol.writeFileSync(abs, content);
+};
+
+describe('runSshApply', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    const { clearManifestCache } = await import('../../src/lib/manifest.js');
+    clearManifestCache();
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+    confirmMock.mockResolvedValue(true);
+  });
+
+  afterEach(async () => {
+    vol.reset();
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+  });
+
+  it('pushes each tracked file to the remote via ssh mkdir + scp', async () => {
+    seedManifest({
+      a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+      b: createMockTrackedFile({
+        source: '~/.config/nvim/init.lua',
+        destination: 'files/editor/nvim/init.lua',
+      }),
+    });
+    writeRepoFile('files/shell/zshrc', 'export A=1');
+    writeRepoFile('files/editor/nvim/init.lua', '-- lua');
+
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const runner = vi.fn(async (cmd: 'ssh' | 'scp', args: string[]) => {
+      calls.push({ cmd, args });
+    });
+
+    const { runSshApply } = await import('../../src/commands/apply.js');
+    await runSshApply({ target: 'ssh://me@box:2222', yes: true }, runner);
+
+    // Two files → for the nested one an ssh mkdir precedes the scp; the top-level
+    // one is a bare scp. Assert the scp destinations landed at remote home paths.
+    const scps = calls.filter((c) => c.cmd === 'scp').map((c) => c.args[c.args.length - 1]);
+    expect(scps).toContain("me@box:'.zshrc'");
+    expect(scps).toContain("me@box:'.config/nvim/init.lua'");
+
+    // The nested file's parent dir was created first with the -p ssh port flag.
+    const mkdir = calls.find((c) => c.cmd === 'ssh');
+    expect(mkdir?.args).toEqual(['-p', '2222', 'me@box', "mkdir -p '.config/nvim'"]);
+
+    expect(loggerSuccessMock).toHaveBeenCalledWith('Pushed 2 file(s) to me@box:2222');
+  });
+
+  it('does not transfer anything on --dry-run', async () => {
+    seedManifest({
+      a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+    });
+    writeRepoFile('files/shell/zshrc');
+
+    const runner = vi.fn(async () => {});
+    const { runSshApply } = await import('../../src/commands/apply.js');
+    await runSshApply({ ssh: 'box', dryRun: true, yes: true }, runner);
+
+    expect(runner).not.toHaveBeenCalled();
+    expect(loggerInfoMock).toHaveBeenCalledWith('Dry run - would push 1 file(s) to box');
+  });
+
+  it('aborts without transferring when the interactive confirm is declined', async () => {
+    seedManifest({
+      a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+    });
+    writeRepoFile('files/shell/zshrc');
+    confirmMock.mockResolvedValue(false);
+
+    const runner = vi.fn(async () => {});
+    // Force an interactive session: no --yes/--force/--json, TTY on.
+    const originalTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    try {
+      const { runSshApply } = await import('../../src/commands/apply.js');
+      await runSshApply({ ssh: 'box' }, runner);
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalTty, configurable: true });
+    }
+
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('emits a JSON envelope with applied count and target', async () => {
+    seedManifest({
+      a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+    });
+    writeRepoFile('files/shell/zshrc');
+
+    const { __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+    __resetJsonEmitState();
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    const runner = vi.fn(async () => {});
+    const { runSshApply } = await import('../../src/commands/apply.js');
+    await runSshApply({ target: 'box', json: true }, runner);
+
+    writeSpy.mockRestore();
+
+    const env = JSON.parse(writes.join('').trim());
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck apply');
+    expect(env.data.applied).toBe(1);
+    expect(env.data.target).toBe('box');
+  });
+
+  it('warns and pushes nothing when no tracked files map to a remote path', async () => {
+    seedManifest({
+      r: createMockTrackedFile({
+        source: 'repo-cafef00d:config/x.toml',
+        destination: 'files/repos/repo-cafef00d/config/x.toml',
+        scope: 'repo',
+        repoKey: 'repo-cafef00d',
+        repoRelative: 'config/x.toml',
+      }),
+    });
+
+    const runner = vi.fn(async () => {});
+    const { runSshApply } = await import('../../src/commands/apply.js');
+    await runSshApply({ ssh: 'box', yes: true }, runner);
+
+    expect(runner).not.toHaveBeenCalled();
+    expect(loggerWarningMock).toHaveBeenCalledWith('No files to push');
+  });
+
+  it('reports per-file failures without aborting the whole push', async () => {
+    seedManifest({
+      a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+      b: createMockTrackedFile({ source: '~/.bashrc', destination: 'files/shell/bashrc' }),
+    });
+    writeRepoFile('files/shell/zshrc');
+    writeRepoFile('files/shell/bashrc');
+
+    const runner = vi.fn(async (_cmd: 'ssh' | 'scp', args: string[]) => {
+      if (args[args.length - 1].includes('.bashrc')) {
+        throw new Error('scp: connection closed');
+      }
+    });
+
+    const { runSshApply } = await import('../../src/commands/apply.js');
+    await runSshApply({ ssh: 'box', yes: true }, runner);
+
+    expect(loggerWarningMock).toHaveBeenCalledWith('Pushed 1 file(s), 1 failed');
+  });
+});

--- a/tests/commands/apply-ssh.test.ts
+++ b/tests/commands/apply-ssh.test.ts
@@ -103,8 +103,9 @@ describe('runSshApply', () => {
     // Two files → for the nested one an ssh mkdir precedes the scp; the top-level
     // one is a bare scp. Assert the scp destinations landed at remote home paths.
     const scps = calls.filter((c) => c.cmd === 'scp').map((c) => c.args[c.args.length - 1]);
-    expect(scps).toContain("me@box:'.zshrc'");
-    expect(scps).toContain("me@box:'.config/nvim/init.lua'");
+    // scp destinations are UNQUOTED (SFTP protocol takes the path verbatim).
+    expect(scps).toContain('me@box:.zshrc');
+    expect(scps).toContain('me@box:.config/nvim/init.lua');
 
     // The nested file's parent dir was created first with the -p ssh port flag.
     const mkdir = calls.find((c) => c.cmd === 'ssh');
@@ -197,7 +198,7 @@ describe('runSshApply', () => {
     expect(loggerWarningMock).toHaveBeenCalledWith('No files to push');
   });
 
-  it('reports per-file failures without aborting the whole push', async () => {
+  it('pushes what it can but escalates any per-file failure to a non-zero exit', async () => {
     seedManifest({
       a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
       b: createMockTrackedFile({ source: '~/.bashrc', destination: 'files/shell/bashrc' }),
@@ -212,8 +213,50 @@ describe('runSshApply', () => {
     });
 
     const { runSshApply } = await import('../../src/commands/apply.js');
-    await runSshApply({ ssh: 'box', yes: true }, runner);
-
+    const { RemoteApplyError } = await import('../../src/errors.js');
+    // The good file still transferred, but the failure must not exit 0.
+    await expect(runSshApply({ ssh: 'box', yes: true }, runner)).rejects.toBeInstanceOf(
+      RemoteApplyError
+    );
     expect(loggerWarningMock).toHaveBeenCalledWith('Pushed 1 file(s), 1 failed');
+  });
+
+  it('escalates a fully-failed push and preserves partial results in the JSON error', async () => {
+    seedManifest({
+      a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+      b: createMockTrackedFile({ source: '~/.bashrc', destination: 'files/shell/bashrc' }),
+    });
+    writeRepoFile('files/shell/zshrc');
+    writeRepoFile('files/shell/bashrc');
+
+    const { __resetJsonEmitState, isJsonMode } = await import('../../src/lib/jsonOutput.js');
+    __resetJsonEmitState();
+
+    // Every ssh/scp fails, as if the remote refused the connection.
+    const runner = vi.fn(async () => {
+      throw new Error('ssh: connect to host box port 22: Connection refused');
+    });
+
+    const { runSshApply } = await import('../../src/commands/apply.js');
+    const { RemoteApplyError } = await import('../../src/errors.js');
+
+    let thrown: unknown;
+    try {
+      await runSshApply({ ssh: 'box', json: true }, runner);
+    } catch (err) {
+      thrown = err;
+    }
+
+    // JSON mode still throws so handleError emits the error envelope + non-zero exit.
+    expect(thrown).toBeInstanceOf(RemoteApplyError);
+    expect(isJsonMode()).toBe(true);
+
+    // The JSON projection escalates (ok:false envelope) while keeping the outcome.
+    const json = (thrown as InstanceType<typeof RemoteApplyError>).toJSON();
+    expect(json.code).toBe('REMOTE_APPLY_FAILED');
+    expect(json.exit_code).toBeGreaterThan(0);
+    expect(json.applied).toBe(0);
+    expect(json.target).toBe('box');
+    expect(json.failed).toEqual(['~/.bashrc', '~/.zshrc']);
   });
 });

--- a/tests/lib/sshApply.test.ts
+++ b/tests/lib/sshApply.test.ts
@@ -130,12 +130,21 @@ describe('sshDestination / buildSshCommand / buildScpCommand', () => {
     expect(buildSshCommand(noUser, 'mkdir -p x')).toEqual(['box', 'mkdir -p x']);
   });
 
-  it('builds scp argv with the -P port flag and a single-quoted remote path', () => {
+  it('builds scp argv with the -P port flag and an UNQUOTED remote path', () => {
+    // scp uses the SFTP protocol (OpenSSH 9.0+) and takes the remote path
+    // verbatim — quoting it would create a file literally named "'.zshrc'".
     expect(buildScpCommand(withUser, '/local/zshrc', '.zshrc')).toEqual([
       '-P',
       '2222',
       '/local/zshrc',
-      "me@box:'.zshrc'",
+      'me@box:.zshrc',
+    ]);
+  });
+
+  it('does not quote a nested remote path', () => {
+    expect(buildScpCommand(noUser, '/local/init.lua', '.config/nvim/init.lua')).toEqual([
+      '/local/init.lua',
+      'box:.config/nvim/init.lua',
     ]);
   });
 });
@@ -158,11 +167,13 @@ describe('pushEntryToRemote', () => {
     await pushEntryToRemote(target, entry, runner);
 
     expect(calls[0].cmd).toBe('ssh');
+    // The mkdir command IS remote-shell-interpreted, so its path stays quoted.
     expect(calls[0].args).toEqual(['box', "mkdir -p '.config/nvim'"]);
     expect(calls[1].cmd).toBe('scp');
+    // The scp destination is verbatim (SFTP), so its path is UNQUOTED.
     expect(calls[1].args).toEqual([
       '/tuck/files/editor/nvim/init.lua',
-      "box:'.config/nvim/init.lua'",
+      'box:.config/nvim/init.lua',
     ]);
   });
 
@@ -178,7 +189,7 @@ describe('pushEntryToRemote', () => {
     await pushEntryToRemote(target, entry, runner);
 
     expect(runner).toHaveBeenCalledTimes(1);
-    expect(runner).toHaveBeenCalledWith('scp', ['/tuck/files/shell/zshrc', "box:'.zshrc'"]);
+    expect(runner).toHaveBeenCalledWith('scp', ['/tuck/files/shell/zshrc', 'box:.zshrc']);
   });
 });
 

--- a/tests/lib/sshApply.test.ts
+++ b/tests/lib/sshApply.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for the remote / SSH apply library.
+ *
+ * These cover the pure, network-free surface: target parsing + validation,
+ * home-relative remote path derivation (and its injection guards), argv
+ * construction for ssh/scp, and the plan builder against a temp (memfs) tuck dir.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
+import { TEST_TUCK_DIR } from '../setup.js';
+import {
+  parseSshTarget,
+  remoteRelativeFromSource,
+  buildRemotePlan,
+  sshDestination,
+  buildSshCommand,
+  buildScpCommand,
+  pushEntryToRemote,
+  buildBootstrapOneLiner,
+  type SshTarget,
+  type RemoteApplyEntry,
+} from '../../src/lib/sshApply.js';
+import { ValidationError } from '../../src/errors.js';
+
+describe('parseSshTarget', () => {
+  it('parses an ssh:// URL with user, host and port', () => {
+    const t = parseSshTarget('ssh://me@box.example.com:2222');
+    expect(t).toMatchObject({ user: 'me', host: 'box.example.com', port: 2222 });
+    expect(t.display).toBe('me@box.example.com:2222');
+  });
+
+  it('parses a bare host', () => {
+    const t = parseSshTarget('box');
+    expect(t).toMatchObject({ user: undefined, host: 'box', port: undefined });
+    expect(t.display).toBe('box');
+  });
+
+  it('parses user@host:port shorthand', () => {
+    const t = parseSshTarget('deploy@10.0.0.5:22');
+    expect(t).toMatchObject({ user: 'deploy', host: '10.0.0.5', port: 22 });
+  });
+
+  it('rejects a non-ssh scheme', () => {
+    expect(() => parseSshTarget('http://box')).toThrow(ValidationError);
+  });
+
+  it('rejects a host that starts with a dash (would be read as an ssh flag)', () => {
+    expect(() => parseSshTarget('-oProxyCommand=evil')).toThrow(ValidationError);
+    expect(() => parseSshTarget('ssh://-badhost')).toThrow(ValidationError);
+  });
+
+  it('rejects hosts with shell metacharacters', () => {
+    expect(() => parseSshTarget('box;rm -rf')).toThrow(ValidationError);
+    expect(() => parseSshTarget('box$(whoami)')).toThrow(ValidationError);
+  });
+
+  it('rejects an out-of-range port', () => {
+    expect(() => parseSshTarget('box:99999')).toThrow(ValidationError);
+  });
+
+  it('rejects an empty target', () => {
+    expect(() => parseSshTarget('   ')).toThrow(ValidationError);
+  });
+
+  it('rejects a remote path in the ssh target', () => {
+    expect(() => parseSshTarget('ssh://box/etc/passwd')).toThrow(ValidationError);
+  });
+});
+
+describe('remoteRelativeFromSource', () => {
+  it('strips the home prefix from a ~/ source', () => {
+    expect(remoteRelativeFromSource('~/.zshrc')).toBe('.zshrc');
+    expect(remoteRelativeFromSource('~/.config/nvim/init.lua')).toBe('.config/nvim/init.lua');
+  });
+
+  it('handles $HOME-prefixed sources', () => {
+    expect(remoteRelativeFromSource('$HOME/.gitconfig')).toBe('.gitconfig');
+  });
+
+  it('preserves dashes and dots in legitimate paths', () => {
+    expect(remoteRelativeFromSource('~/.config/my-app/config.toml')).toBe(
+      '.config/my-app/config.toml'
+    );
+  });
+
+  it('returns null for the bare home directory', () => {
+    expect(remoteRelativeFromSource('~')).toBeNull();
+    expect(remoteRelativeFromSource('$HOME')).toBeNull();
+  });
+
+  it('returns null for absolute / out-of-home sources', () => {
+    expect(remoteRelativeFromSource('/etc/passwd')).toBeNull();
+    expect(remoteRelativeFromSource('relative/path')).toBeNull();
+  });
+
+  it('returns null for path traversal', () => {
+    expect(remoteRelativeFromSource('~/../etc/passwd')).toBeNull();
+  });
+
+  it('returns null when a single quote would break remote shell quoting', () => {
+    expect(remoteRelativeFromSource("~/.config/a'b")).toBeNull();
+  });
+
+  it('returns null for control characters', () => {
+    expect(remoteRelativeFromSource('~/.config/a\nb')).toBeNull();
+  });
+});
+
+describe('sshDestination / buildSshCommand / buildScpCommand', () => {
+  const withUser: SshTarget = { user: 'me', host: 'box', port: 2222, display: 'me@box:2222' };
+  const noUser: SshTarget = { host: 'box', display: 'box' };
+
+  it('builds the [user@]host destination', () => {
+    expect(sshDestination(withUser)).toBe('me@box');
+    expect(sshDestination(noUser)).toBe('box');
+  });
+
+  it('builds ssh argv with the -p port flag', () => {
+    expect(buildSshCommand(withUser, "mkdir -p '.config'")).toEqual([
+      '-p',
+      '2222',
+      'me@box',
+      "mkdir -p '.config'",
+    ]);
+  });
+
+  it('omits the port flag when no port is set', () => {
+    expect(buildSshCommand(noUser, 'mkdir -p x')).toEqual(['box', 'mkdir -p x']);
+  });
+
+  it('builds scp argv with the -P port flag and a single-quoted remote path', () => {
+    expect(buildScpCommand(withUser, '/local/zshrc', '.zshrc')).toEqual([
+      '-P',
+      '2222',
+      '/local/zshrc',
+      "me@box:'.zshrc'",
+    ]);
+  });
+});
+
+describe('pushEntryToRemote', () => {
+  const target: SshTarget = { host: 'box', display: 'box' };
+
+  it('mkdirs the parent then scps the file via the injected runner', async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const runner = vi.fn(async (cmd: 'ssh' | 'scp', args: string[]) => {
+      calls.push({ cmd, args });
+    });
+    const entry: RemoteApplyEntry = {
+      source: '~/.config/nvim/init.lua',
+      localPath: '/tuck/files/editor/nvim/init.lua',
+      remoteRelative: '.config/nvim/init.lua',
+      category: 'editor',
+    };
+
+    await pushEntryToRemote(target, entry, runner);
+
+    expect(calls[0].cmd).toBe('ssh');
+    expect(calls[0].args).toEqual(['box', "mkdir -p '.config/nvim'"]);
+    expect(calls[1].cmd).toBe('scp');
+    expect(calls[1].args).toEqual([
+      '/tuck/files/editor/nvim/init.lua',
+      "box:'.config/nvim/init.lua'",
+    ]);
+  });
+
+  it('skips the mkdir when the file lands directly in remote home', async () => {
+    const runner = vi.fn(async () => {});
+    const entry: RemoteApplyEntry = {
+      source: '~/.zshrc',
+      localPath: '/tuck/files/shell/zshrc',
+      remoteRelative: '.zshrc',
+      category: 'shell',
+    };
+
+    await pushEntryToRemote(target, entry, runner);
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner).toHaveBeenCalledWith('scp', ['/tuck/files/shell/zshrc', "box:'.zshrc'"]);
+  });
+});
+
+describe('buildBootstrapOneLiner', () => {
+  it('installs tuck and applies the source', () => {
+    expect(buildBootstrapOneLiner('octocat')).toBe(
+      'npm install -g @prnv/tuck && tuck apply octocat --yes'
+    );
+  });
+});
+
+describe('buildRemotePlan', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  });
+  afterEach(() => vol.reset());
+
+  const writeRepoFile = (rel: string, content = 'x'): void => {
+    const abs = join(TEST_TUCK_DIR, rel);
+    vol.mkdirSync(join(abs, '..'), { recursive: true });
+    vol.writeFileSync(abs, content);
+  };
+
+  it('maps home-scoped regular files to remote home-relative entries', async () => {
+    writeRepoFile('files/shell/zshrc');
+    writeRepoFile('files/editor/nvim/init.lua');
+    const manifest = createMockManifest({
+      files: {
+        a: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+        b: createMockTrackedFile({
+          source: '~/.config/nvim/init.lua',
+          destination: 'files/editor/nvim/init.lua',
+        }),
+      },
+    });
+
+    const plan = await buildRemotePlan(manifest, TEST_TUCK_DIR);
+
+    expect(plan.entries.map((e) => e.remoteRelative)).toEqual([
+      '.config/nvim/init.lua',
+      '.zshrc',
+    ]);
+    expect(plan.entries[1].localPath).toBe(join(TEST_TUCK_DIR, 'files/shell/zshrc'));
+  });
+
+  it('skips repo-scoped entries', async () => {
+    const manifest = createMockManifest({
+      files: {
+        r: createMockTrackedFile({
+          source: 'myrepo-deadbeef:config/app.toml',
+          destination: 'files/repos/myrepo-deadbeef/config/app.toml',
+          scope: 'repo',
+          repoKey: 'myrepo-deadbeef',
+          repoRelative: 'config/app.toml',
+        }),
+      },
+    });
+
+    const plan = await buildRemotePlan(manifest, TEST_TUCK_DIR);
+
+    expect(plan.entries).toHaveLength(0);
+    expect(plan.skippedRepoScoped).toEqual(['myrepo-deadbeef:config/app.toml']);
+  });
+
+  it('skips directory entries (v1 pushes files only)', async () => {
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files/editor/nvim'), { recursive: true });
+    const manifest = createMockManifest({
+      files: {
+        d: createMockTrackedFile({
+          source: '~/.config/nvim',
+          destination: 'files/editor/nvim',
+        }),
+      },
+    });
+
+    const plan = await buildRemotePlan(manifest, TEST_TUCK_DIR);
+
+    expect(plan.entries).toHaveLength(0);
+    expect(plan.skippedDirectories).toEqual(['~/.config/nvim']);
+  });
+
+  it('reports a tracked file whose repo copy is missing on disk', async () => {
+    const manifest = createMockManifest({
+      files: {
+        m: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+      },
+    });
+
+    const plan = await buildRemotePlan(manifest, TEST_TUCK_DIR);
+
+    expect(plan.entries).toHaveLength(0);
+    expect(plan.missing).toEqual(['~/.zshrc']);
+  });
+
+  it('filters by bundle', async () => {
+    writeRepoFile('files/shell/zshrc');
+    writeRepoFile('files/shell/bashrc');
+    const manifest = createMockManifest({
+      files: {
+        a: createMockTrackedFile({
+          source: '~/.zshrc',
+          destination: 'files/shell/zshrc',
+          bundle: 'work',
+        }),
+        b: createMockTrackedFile({
+          source: '~/.bashrc',
+          destination: 'files/shell/bashrc',
+          bundle: 'default',
+        }),
+      },
+    });
+
+    const plan = await buildRemotePlan(manifest, TEST_TUCK_DIR, 'work');
+
+    expect(plan.entries.map((e) => e.source)).toEqual(['~/.zshrc']);
+  });
+});


### PR DESCRIPTION
## Summary

Implements IDEAS.md §1.9 — Remote / SSH Apply. Adds `tuck apply --target ssh://[user@]host` (and the `--ssh host` shorthand, with `--port`) that reads the **local** manifest and copies each tracked home file's committed repo copy onto a remote box over ssh/scp, landing at the same home-relative path (`~/.zshrc` → remote `~/.zshrc`). This is the "get my agent configs (`.claude`/`.cursor`/`.codex`) onto every server I SSH into" workflow.

- **Plan first, always.** A grouped plan is printed before anything moves; an interactive TTY confirms, `--dry-run` stops after the plan, `--json` emits an envelope, `--bundle` scopes the push.
- **Documented bootstrap.** `tuck apply <source> --print-bootstrap` prints an install-and-apply one-liner (`npm install -g @prnv/tuck && tuck apply <source> --yes`) for fresh remotes where you'd rather not push from your laptop.

### Safety
- ssh host/user/port strictly validated (no leading dash → can't be smuggled as an ssh flag; no shell metacharacters); zod-validated.
- Remote paths derived from home-relative sources; absolute / `..` / single-quote / control-character paths refused.
- Every ssh/scp call uses `execFile` with an argv array — no local shell. Remote `mkdir -p` / scp specs are single-quoted.
- v1 pushes regular home-scoped files only; repo-scoped and directory entries are skipped and reported (see Deferred).

## Files
- `src/lib/sshApply.ts` — new: target parsing, plan builder, ssh/scp argv, injectable transfer runner, bootstrap one-liner.
- `src/commands/apply.ts` — wires `--target/--ssh/--port/--print-bootstrap`, makes `<source>` optional, routes to `runSshApply`.
- Tests + README/man docs.

## Test evidence
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm build` — pass
- `pnpm test` — **1547 passed** (35 new across `tests/lib/sshApply.test.ts` + `tests/commands/apply-ssh.test.ts`; integration tests inject the runner — no network, no real `$HOME`, no keychain)
- `pnpm knip` — exit 0
- Real-binary smoke (isolated `HOME`): help lists the options; `--print-bootstrap` prints text + JSON; an injection-shaped `ssh://-evil;rm` target is rejected with `VALIDATION_ERROR` before any manifest access; `source + --target` is rejected.

## Deferred
- Directory-entry push (recursive scp with deterministic placement) — skipped and reported for now.
- Repo-scoped entries (no portable cross-machine remote home path) — skipped and reported.
- IPv6 literal hosts; custom ssh options / identity-file passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)