### PR TITLE
feat: AI agent config presets and cross-agent instructions translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,14 @@ tuck restore --all
 
 ### Managing Files
 
-| Command               | Description                        |
-| --------------------- | ---------------------------------- |
-| `tuck add <paths>`    | Manually track specific files      |
-| `tuck remove <paths>` | Stop tracking files                |
-| `tuck scan`           | Discover dotfiles without syncing  |
-| `tuck list`           | List all tracked files by category |
-| `tuck diff [file]`    | Show what's changed                |
+| Command                     | Description                                           |
+| --------------------------- | ----------------------------------------------------- |
+| `tuck add <paths>`          | Manually track specific files                         |
+| `tuck add --preset <agent>` | Track an AI agent's safe config allowlist (see below) |
+| `tuck remove <paths>`       | Stop tracking files                                   |
+| `tuck scan`                 | Discover dotfiles without syncing                     |
+| `tuck list`                 | List all tracked files by category                    |
+| `tuck diff [file]`          | Show what's changed                                   |
 
 ### Syncing
 
@@ -122,35 +123,36 @@ tuck restore --all
 
 ### Configuration
 
-| Command              | Description                                  |
-| -------------------- | -------------------------------------------- |
-| `tuck config`        | Interactive config menu (includes a setup wizard option) |
-| `tuck config remote` | Configure git provider (GitHub/GitLab/local) |
-| `tuck config get/set/list/edit/reset` | Read or change individual settings |
+| Command                               | Description                                              |
+| ------------------------------------- | -------------------------------------------------------- |
+| `tuck config`                         | Interactive config menu (includes a setup wizard option) |
+| `tuck config remote`                  | Configure git provider (GitHub/GitLab/local)             |
+| `tuck config get/set/list/edit/reset` | Read or change individual settings                       |
 
 ### Diagnostics & Verification
 
-| Command         | Description                                          |
-| --------------- | ---------------------------------------------------- |
-| `tuck doctor`   | Run repository health and safety diagnostics         |
-| `tuck verify`   | Verify the live system, repo, and manifest agree (add `--exit-code` as a CI gate) |
+| Command       | Description                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| `tuck doctor` | Run repository health and safety diagnostics                                      |
+| `tuck verify` | Verify the live system, repo, and manifest agree (add `--exit-code` as a CI gate) |
 
 `tuck doctor` flags:
+
 - `--json`: Machine-readable output for CI
 - `--strict`: Treat warnings as non-zero exit
 - `-c, --category <env|repo|manifest|security|hooks|sandboxing>`: Run one check group
 
 ### Advanced
 
-| Command             | Description                                                       |
-| ------------------- | ---------------------------------------------------------------- |
-| `tuck bundle`       | Manage bundles — logical groups of tracked files                 |
-| `tuck encryption`   | Manage at-rest backup encryption (AES-256-GCM, password-based)   |
-| `tuck secrets`      | Manage local secrets / placeholder replacement                   |
-| `tuck context`      | Track AI agent configs across home and per-repo scopes           |
-| `tuck preset`       | Apply or publish curated bundles of dotfiles & agent configs     |
-| `tuck repo`         | Manage machine-local repo bindings (for repo-scoped tracking)    |
-| `tuck mcp`          | Run the Model Context Protocol server (expose tuck to AI agents) |
+| Command           | Description                                                      |
+| ----------------- | ---------------------------------------------------------------- |
+| `tuck bundle`     | Manage bundles — logical groups of tracked files                 |
+| `tuck encryption` | Manage at-rest backup encryption (AES-256-GCM, password-based)   |
+| `tuck secrets`    | Manage local secrets / placeholder replacement                   |
+| `tuck context`    | Track AI agent configs across home and per-repo scopes           |
+| `tuck preset`     | Apply or publish curated bundles of dotfiles & agent configs     |
+| `tuck repo`       | Manage machine-local repo bindings (for repo-scoped tracking)    |
+| `tuck mcp`        | Run the Model Context Protocol server (expose tuck to AI agents) |
 
 ## How It Works
 
@@ -179,16 +181,57 @@ tuck stores your dotfiles in `~/.tuck`, organized by category:
 
 Run `tuck sync` anytime to detect changes and push. On a new machine, run `tuck apply username` to grab anyone's dotfiles.
 
+## AI Agent Configs
+
+tuck knows exactly which files under each AI agent's home directory are safe to
+version-control — and which are credentials, history, or session state that must
+never leave your machine. One command tracks the safe set:
+
+```bash
+tuck add --preset claude-code   # CLAUDE.md, settings.json, commands/, skills/, agents/, hooks/, rules/
+tuck add --preset cursor        # user settings, keybindings, snippets, ~/.cursor rules
+tuck add --preset codex         # AGENTS.md, config.toml, prompts/
+tuck add --preset gemini        # GEMINI.md, settings.json, commands/
+tuck add --preset copilot       # GitHub Copilot CLI config (non-credential)
+```
+
+Each preset **hard-excludes** local/credential/history/session files
+(`settings.local.json`, `.credentials.json`, `sessions/`, `projects/`, …). Files
+that are found but deliberately skipped are reported so you know they were left
+alone, and tuck's secret scanner still runs on everything actually tracked.
+
+Preview without tracking anything:
+
+```bash
+tuck add --preset claude-code --plan --json
+```
+
+### Cross-agent translation
+
+Keep one canonical instructions file and materialize it for every agent you use.
+`tuck preset translate` writes the same source into each agent's global
+instruction path (default: Claude Code's `~/.claude/CLAUDE.md` and Codex's
+`~/.codex/AGENTS.md`):
+
+```bash
+tuck preset translate ~/dotfiles/AGENTS.md          # copy into Claude + Codex
+tuck preset translate ~/dotfiles/AGENTS.md --link   # symlink instead of copy
+tuck preset translate ~/dotfiles/AGENTS.md --to claude-code,codex,gemini
+```
+
+Existing files are snapshotted before being overwritten (`tuck undo` rolls it
+back), and translation refuses to clobber non-interactively without `--yes`.
+
 ## Git Providers
 
 tuck supports multiple git hosting providers, detected automatically during setup:
 
-| Provider | CLI Required | Features |
-|----------|--------------|----------|
-| **GitHub** | `gh` | Auto-create repos, full integration |
-| **GitLab** | `glab` | Auto-create repos, self-hosted support |
-| **Local** | None | No remote sync, local git only |
-| **Custom** | None | Any git URL (Bitbucket, Gitea, etc.) |
+| Provider   | CLI Required | Features                               |
+| ---------- | ------------ | -------------------------------------- |
+| **GitHub** | `gh`         | Auto-create repos, full integration    |
+| **GitLab** | `glab`       | Auto-create repos, self-hosted support |
+| **Local**  | None         | No remote sync, local git only         |
+| **Custom** | None         | Any git URL (Bitbucket, Gitea, etc.)   |
 
 ### Switching Providers
 
@@ -244,14 +287,14 @@ tuck fully supports Windows with platform-specific handling:
 
 ### Detected Windows Dotfiles
 
-| Category | Files |
-|----------|-------|
-| **Shell** | PowerShell profiles (`Microsoft.PowerShell_profile.ps1`) |
-| **Terminal** | Windows Terminal settings, ConEmu/Cmder configs |
-| **Editors** | VS Code, Cursor, Neovim (in `%LOCALAPPDATA%`) |
-| **Git** | `.gitconfig`, `.gitignore_global` |
-| **SSH** | SSH config in `%USERPROFILE%\.ssh` |
-| **Misc** | WSL config (`.wslconfig`), Docker, Kubernetes |
+| Category     | Files                                                    |
+| ------------ | -------------------------------------------------------- |
+| **Shell**    | PowerShell profiles (`Microsoft.PowerShell_profile.ps1`) |
+| **Terminal** | Windows Terminal settings, ConEmu/Cmder configs          |
+| **Editors**  | VS Code, Cursor, Neovim (in `%LOCALAPPDATA%`)            |
+| **Git**      | `.gitconfig`, `.gitignore_global`                        |
+| **SSH**      | SSH config in `%USERPROFILE%\.ssh`                       |
+| **Misc**     | WSL config (`.wslconfig`), Docker, Kubernetes            |
 
 ### Windows-Specific Behavior
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -6,38 +6,40 @@ This document lists all error codes used by tuck for programmatic error handling
 
 ## Error Code Table
 
-| Code | Error Class | Description | Common Causes | Suggestions |
-|------|-------------|-------------|---------------|-------------|
-| `NOT_INITIALIZED` | `NotInitializedError` | Tuck is not initialized | Running commands before `tuck init` | Run `tuck init` to get started |
-| `ALREADY_INITIALIZED` | `AlreadyInitializedError` | Tuck already exists at path | Running `tuck init` twice | Use `tuck status` to see current state |
-| `FILE_NOT_FOUND` | `FileNotFoundError` | Specified file doesn't exist | Wrong path, deleted file | Check path, use absolute paths |
-| `FILE_NOT_TRACKED` | `FileNotTrackedError` | File isn't being tracked | File not added with `tuck add` | Run `tuck add <path>` first |
-| `FILE_ALREADY_TRACKED` | `FileAlreadyTrackedError` | File is already tracked | Adding same file twice | Use `tuck sync` to update |
-| `GIT_ERROR` | `GitError` | Git operation failed | Auth issues, network, conflicts | Check git credentials and network |
-| `MERGE_CONFLICTS` | `MergeConflictsError` | Merge left unresolved conflicts (**exit code 3**, distinct for agent branching) | Overlapping local/remote edits | Resolve conflicts, then re-run the operation |
-| `CONFIG_ERROR` | `ConfigError` | Configuration problem | Corrupted config, invalid values | Run `tuck config reset` |
-| `MANIFEST_ERROR` | `ManifestError` | Manifest file issue | Corrupted JSON, schema mismatch | Restore from remote with `tuck init --from` |
-| `PERMISSION_ERROR` | `PermissionError` | Cannot read/write file | Wrong permissions, locked file | Check file permissions |
-| `GITHUB_CLI_ERROR` | `GitHubCliError` | GitHub CLI issue | Not installed, not authenticated | Install `gh` and run `gh auth login` |
-| `BACKUP_ERROR` | `BackupError` | Backup operation failed | Disk full, permissions | Check disk space and permissions |
-| `ENCRYPTION_ERROR` | `EncryptionError` | Encryption failed | Wrong password, key issues | Check encryption password |
-| `DECRYPTION_ERROR` | `DecryptionError` | Decryption failed | Wrong password, corrupted data | Verify correct password is used |
-| `SECRETS_DETECTED` | `SecretsDetectedError` | Secrets found in files | API keys, passwords in dotfiles | Review and remove secrets, or use `--force` |
-| `SECRET_BACKEND_ERROR` | `SecretBackendError` | Password manager issue | Not installed, not authenticated | Check CLI installation and auth |
-| `SECRET_NOT_FOUND` | `SecretNotFoundError` | Secret not in backend | Missing mapping, deleted secret | Check secrets.mappings.json |
-| `BACKEND_NOT_AVAILABLE` | `BackendNotAvailableError` | Backend CLI missing | 1Password/Bitwarden not installed | Install the backend CLI |
-| `BACKEND_AUTH_ERROR` | `BackendAuthenticationError` | Backend not authenticated | Session expired | Re-authenticate with backend |
-| `UNRESOLVED_SECRETS` | `UnresolvedSecretsError` | Could not resolve secrets | Missing in backend | Ensure secrets are configured |
-| `MATERIALIZE_FAILED` | `MaterializeError` | Could not materialize a template/encrypted file on apply | Bad template, decryption failure | Check the source file and encryption password |
-| `OPERATION_CANCELLED` | `OperationCancelledError` | Operation was cancelled | User aborted, or a prompt required in a non-TTY context | Re-run interactively, or pass `-y/--yes` |
-| `PRIVATE_KEY_ERROR` | `PrivateKeyError` | Refused to track a private key | Attempting to add an SSH/GPG private key | Store keys in a secret manager, not dotfiles |
-| `REPOSITORY_NOT_FOUND` | `RepositoryNotFoundError` | No dotfiles repository found for the source | Bad user/repo, missing remote | Check the source argument and remote access |
-| `INVALID_MANIFEST` | `InvalidManifestError` | Manifest failed schema validation | Hand-edited or corrupted manifest | Restore from remote with `tuck init --from` |
-| `PATH_TRAVERSAL_ERROR` | `PathTraversalError` | Path escaped the allowed root | `..` segments or absolute escape in a path | Use a path within the tuck/target root |
-| `SECRETS_STORE_ERROR` | `SecretsStoreError` | Local secrets store operation failed | Corrupted store, permissions | Check the secrets store file and permissions |
-| `SCAN_LIMIT_ERROR` | `ScanLimitError` | Too many files to scan | Directory exceeds the scan limit | Narrow the scan scope or raise the limit |
-| `VALIDATION_ERROR` | `ValidationError` | Input failed validation | Invalid flag/field value | Correct the input per the message |
-| `KEYSTORE_ERROR` | `KeystoreError` | OS keystore operation failed | Keychain/secret-service unavailable | Check the OS keystore or use the fallback |
+| Code                         | Error Class                  | Description                                                                     | Common Causes                                           | Suggestions                                             |
+| ---------------------------- | ---------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------- |
+| `NOT_INITIALIZED`            | `NotInitializedError`        | Tuck is not initialized                                                         | Running commands before `tuck init`                     | Run `tuck init` to get started                          |
+| `ALREADY_INITIALIZED`        | `AlreadyInitializedError`    | Tuck already exists at path                                                     | Running `tuck init` twice                               | Use `tuck status` to see current state                  |
+| `FILE_NOT_FOUND`             | `FileNotFoundError`          | Specified file doesn't exist                                                    | Wrong path, deleted file                                | Check path, use absolute paths                          |
+| `FILE_NOT_TRACKED`           | `FileNotTrackedError`        | File isn't being tracked                                                        | File not added with `tuck add`                          | Run `tuck add <path>` first                             |
+| `FILE_ALREADY_TRACKED`       | `FileAlreadyTrackedError`    | File is already tracked                                                         | Adding same file twice                                  | Use `tuck sync` to update                               |
+| `GIT_ERROR`                  | `GitError`                   | Git operation failed                                                            | Auth issues, network, conflicts                         | Check git credentials and network                       |
+| `MERGE_CONFLICTS`            | `MergeConflictsError`        | Merge left unresolved conflicts (**exit code 3**, distinct for agent branching) | Overlapping local/remote edits                          | Resolve conflicts, then re-run the operation            |
+| `CONFIG_ERROR`               | `ConfigError`                | Configuration problem                                                           | Corrupted config, invalid values                        | Run `tuck config reset`                                 |
+| `MANIFEST_ERROR`             | `ManifestError`              | Manifest file issue                                                             | Corrupted JSON, schema mismatch                         | Restore from remote with `tuck init --from`             |
+| `PERMISSION_ERROR`           | `PermissionError`            | Cannot read/write file                                                          | Wrong permissions, locked file                          | Check file permissions                                  |
+| `GITHUB_CLI_ERROR`           | `GitHubCliError`             | GitHub CLI issue                                                                | Not installed, not authenticated                        | Install `gh` and run `gh auth login`                    |
+| `BACKUP_ERROR`               | `BackupError`                | Backup operation failed                                                         | Disk full, permissions                                  | Check disk space and permissions                        |
+| `ENCRYPTION_ERROR`           | `EncryptionError`            | Encryption failed                                                               | Wrong password, key issues                              | Check encryption password                               |
+| `DECRYPTION_ERROR`           | `DecryptionError`            | Decryption failed                                                               | Wrong password, corrupted data                          | Verify correct password is used                         |
+| `SECRETS_DETECTED`           | `SecretsDetectedError`       | Secrets found in files                                                          | API keys, passwords in dotfiles                         | Review and remove secrets, or use `--force`             |
+| `SECRET_BACKEND_ERROR`       | `SecretBackendError`         | Password manager issue                                                          | Not installed, not authenticated                        | Check CLI installation and auth                         |
+| `SECRET_NOT_FOUND`           | `SecretNotFoundError`        | Secret not in backend                                                           | Missing mapping, deleted secret                         | Check secrets.mappings.json                             |
+| `BACKEND_NOT_AVAILABLE`      | `BackendNotAvailableError`   | Backend CLI missing                                                             | 1Password/Bitwarden not installed                       | Install the backend CLI                                 |
+| `BACKEND_AUTH_ERROR`         | `BackendAuthenticationError` | Backend not authenticated                                                       | Session expired                                         | Re-authenticate with backend                            |
+| `UNRESOLVED_SECRETS`         | `UnresolvedSecretsError`     | Could not resolve secrets                                                       | Missing in backend                                      | Ensure secrets are configured                           |
+| `MATERIALIZE_FAILED`         | `MaterializeError`           | Could not materialize a template/encrypted file on apply                        | Bad template, decryption failure                        | Check the source file and encryption password           |
+| `OPERATION_CANCELLED`        | `OperationCancelledError`    | Operation was cancelled                                                         | User aborted, or a prompt required in a non-TTY context | Re-run interactively, or pass `-y/--yes`                |
+| `PRIVATE_KEY_ERROR`          | `PrivateKeyError`            | Refused to track a private key                                                  | Attempting to add an SSH/GPG private key                | Store keys in a secret manager, not dotfiles            |
+| `REPOSITORY_NOT_FOUND`       | `RepositoryNotFoundError`    | No dotfiles repository found for the source                                     | Bad user/repo, missing remote                           | Check the source argument and remote access             |
+| `INVALID_MANIFEST`           | `InvalidManifestError`       | Manifest failed schema validation                                               | Hand-edited or corrupted manifest                       | Restore from remote with `tuck init --from`             |
+| `PATH_TRAVERSAL_ERROR`       | `PathTraversalError`         | Path escaped the allowed root                                                   | `..` segments or absolute escape in a path              | Use a path within the tuck/target root                  |
+| `SECRETS_STORE_ERROR`        | `SecretsStoreError`          | Local secrets store operation failed                                            | Corrupted store, permissions                            | Check the secrets store file and permissions            |
+| `SCAN_LIMIT_ERROR`           | `ScanLimitError`             | Too many files to scan                                                          | Directory exceeds the scan limit                        | Narrow the scan scope or raise the limit                |
+| `VALIDATION_ERROR`           | `ValidationError`            | Input failed validation                                                         | Invalid flag/field value                                | Correct the input per the message                       |
+| `KEYSTORE_ERROR`             | `KeystoreError`              | OS keystore operation failed                                                    | Keychain/secret-service unavailable                     | Check the OS keystore or use the fallback               |
+| `UNKNOWN_AGENT_PRESET`       | `TuckError`                  | `tuck add --preset` was given an unknown agent                                  | Typo or unsupported agent id                            | Use one of: claude-code, cursor, codex, gemini, copilot |
+| `UNKNOWN_TRANSLATION_TARGET` | `TuckError`                  | `tuck preset translate --to` named an unknown agent                             | Typo in the `--to` list                                 | Use claude-code, codex, or gemini                       |
 
 ---
 
@@ -47,8 +49,8 @@ All tuck errors extend the base `TuckError` class and include:
 
 ```typescript
 interface TuckError {
-  message: string;      // Human-readable error message
-  code: string;         // Error code (from table above)
+  message: string; // Human-readable error message
+  code: string; // Error code (from table above)
   suggestions?: string[]; // Helpful suggestions to resolve
 }
 ```
@@ -89,17 +91,20 @@ execFile('tuck', ['status'], (error, stdout, stderr) => {
 This error occurs when tuck's secret scanner finds potential secrets in files you're trying to track.
 
 **What triggers it:**
+
 - API keys (AWS, GitHub, etc.)
 - Passwords in config files
 - Private keys
 - OAuth tokens
 
 **Resolution options:**
+
 1. Remove the secrets from the file
 2. Use a password manager integration
 3. Use `--force` to bypass (not recommended)
 
 **Example:**
+
 ```
 ✖ Found 2 potential secret(s) in: ~/.aws/credentials
 
@@ -136,6 +141,7 @@ DEBUG=1 tuck status
 ```
 
 This shows:
+
 - Full stack traces
 - Internal error messages
 - Additional diagnostic information
@@ -185,6 +191,7 @@ If you encounter an unexpected error:
 3. Open an issue at https://github.com/Pranav-Karra-3301/tuck/issues
 
 Include:
+
 - The full error message
 - What command you ran
 - Your OS and Node.js version

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,12 +1,13 @@
 import { Command } from 'commander';
 import { prompts, logger } from '../ui/index.js';
 import { getTuckDir } from '../lib/paths.js';
-import { loadManifest, ensureBundle } from '../lib/manifest.js';
+import { loadManifest, ensureBundle, isFileTracked } from '../lib/manifest.js';
 import { trackFilesWithProgress, type FileToTrack } from '../lib/fileTracking.js';
-import { NotInitializedError } from '../errors.js';
+import { NotInitializedError, TuckError } from '../errors.js';
 import { CATEGORIES } from '../constants.js';
 import type { AddOptions } from '../types.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { resolveAgentPreset } from '../lib/agentPresets.js';
 import {
   preparePathsForTracking,
   type PreparedTrackFile,
@@ -201,7 +202,154 @@ export const addFilesFromPaths = async (
   return filesToAdd.length;
 };
 
+/**
+ * Track a curated AI-agent config preset (`tuck add --preset <agent>`).
+ *
+ * Enumerates the agent's safe-to-track allowlist, drops anything already
+ * tracked (so re-runs are idempotent), and hands the survivors to the normal
+ * tracking pipeline — which still runs the secret scan on every file as the
+ * final backstop. Sensitive files (credentials/history/sessions) are never
+ * candidates and are reported as intentionally skipped.
+ */
+const runAddPreset = async (presetId: string, options: AddOptions): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck add');
+  const tuckDir = getTuckDir();
+
+  try {
+    await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+
+  if (options.repo !== undefined && options.repo !== false) {
+    throw new TuckError('--preset cannot be combined with --repo', 'VALIDATION_ERROR', [
+      'Agent presets track home-scoped config; drop --repo.',
+    ]);
+  }
+
+  const { preset, tracked, missing, skippedSensitive } = await resolveAgentPreset(presetId);
+
+  // Skip entries already in the manifest so re-running the preset is a no-op
+  // rather than a FileAlreadyTrackedError abort.
+  const fresh: typeof tracked = [];
+  const alreadyTracked: string[] = [];
+  for (const t of tracked) {
+    if (await isFileTracked(tuckDir, t.collapsed)) {
+      alreadyTracked.push(t.collapsed);
+    } else {
+      fresh.push(t);
+    }
+  }
+
+  if (options.plan || options.dryRun) {
+    if (isJsonMode()) {
+      emitJsonOk({
+        preset: preset.id,
+        plan: fresh.map((t) => ({ source: t.collapsed, category: t.category, isDir: t.isDir })),
+        alreadyTracked,
+        skipped: skippedSensitive,
+        missing,
+      });
+    } else {
+      logger.heading(`Plan — tuck add --preset ${preset.id}:`);
+      if (fresh.length === 0) logger.dim('  (nothing new to track)');
+      for (const t of fresh)
+        logger.file('add', `${t.collapsed}${t.isDir ? '/' : ''} [${t.category}]`);
+      if (skippedSensitive.length > 0) {
+        logger.blank();
+        logger.warning(`Excluded ${skippedSensitive.length} sensitive file(s):`);
+        for (const s of skippedSensitive) logger.dim(`  ${s}`);
+      }
+    }
+    return;
+  }
+
+  if (fresh.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({
+        added: 0,
+        files: [],
+        preset: preset.id,
+        alreadyTracked,
+        skipped: skippedSensitive,
+      });
+    } else if (alreadyTracked.length > 0) {
+      logger.info(`All ${preset.label} config files are already tracked.`);
+    } else {
+      logger.info(`No ${preset.label} config files found to track.`);
+    }
+    return;
+  }
+
+  const nonInteractive = isJsonMode() || options.yes || !process.stdout.isTTY;
+  if (!nonInteractive) {
+    prompts.intro(`tuck add --preset ${preset.id}`);
+    for (const t of fresh) prompts.log.step(`${t.collapsed}${t.isDir ? '/' : ''} [${t.category}]`);
+    if (skippedSensitive.length > 0) {
+      prompts.log.warning(
+        `Skipping ${skippedSensitive.length} sensitive file(s): ${skippedSensitive.join(', ')}`
+      );
+    }
+    const ok = await prompts.confirm(`Track ${fresh.length} ${preset.label} file(s)?`, true);
+    if (!ok) {
+      prompts.cancel('Operation cancelled');
+      return;
+    }
+  }
+
+  const candidates: TrackPathCandidate[] = fresh.map((t) => ({
+    path: t.collapsed,
+    category: t.category,
+  }));
+
+  const filesToAdd = await preparePathsForTracking(candidates, tuckDir, {
+    force: options.force,
+    secretHandling: isJsonMode() || options.yes ? 'strict' : 'interactive',
+    forceBypassCommand: 'tuck add --force',
+  });
+
+  if (filesToAdd.length === 0) {
+    if (isJsonMode())
+      emitJsonOk({ added: 0, files: [], preset: preset.id, skipped: skippedSensitive });
+    else logger.info('No files to add');
+    return;
+  }
+
+  await addFiles(filesToAdd, tuckDir, options);
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      added: filesToAdd.length,
+      files: filesToAdd.map((f) => ({ source: f.source, category: f.category })),
+      preset: preset.id,
+      skipped: skippedSensitive,
+      bundle: options.bundle ?? 'default',
+    });
+    return;
+  }
+
+  logger.success(
+    `Tracked ${filesToAdd.length} ${preset.label} file${filesToAdd.length === 1 ? '' : 's'}`
+  );
+  if (skippedSensitive.length > 0) {
+    logger.dim(
+      `Skipped ${skippedSensitive.length} sensitive file(s) (credentials/history/sessions)`
+    );
+  }
+  logger.info("Run 'tuck sync' when you're ready to commit changes");
+};
+
 const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
+  if (options.preset) {
+    if (paths.length > 0) {
+      throw new TuckError('--preset does not take path arguments', 'VALIDATION_ERROR', [
+        `Run: tuck add --preset ${options.preset}`,
+      ]);
+    }
+    await runAddPreset(options.preset, options);
+    return;
+  }
+
   if (options.json) setJsonMode(true, 'tuck add');
   const tuckDir = getTuckDir();
 
@@ -312,16 +460,26 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
 export const addCommand = new Command('add')
   .description('Track new dotfiles')
   .argument('[paths...]', 'Paths to dotfiles to track')
+  .option(
+    '--preset <agent>',
+    'Track a curated AI-agent config preset (claude-code, cursor, codex, gemini, copilot)'
+  )
   .option('-c, --category <name>', 'Category to organize under')
   .option('-n, --name <name>', 'Custom name for the file in manifest')
   .option('--symlink', 'Copy into tuck repo, then replace source path with a symlink')
   .option('--template', 'Mark as a template: rendered on apply (sync will not capture live edits)')
-  .option('--encrypt', 'Encrypt the file at rest in the repo (decrypted on apply; needs an encryption password)')
+  .option(
+    '--encrypt',
+    'Encrypt the file at rest in the repo (decrypted on apply; needs an encryption password)'
+  )
   .option(
     '--repo [dir]',
     'Track as repo-scoped (file lives in a git repo; auto-detects the root from the path when no dir is given)'
   )
-  .option('--repo-key <key>', 'Explicit stable repo identity (advanced; default derives from the remote)')
+  .option(
+    '--repo-key <key>',
+    'Explicit stable repo identity (advanced; default derives from the remote)'
+  )
   .option('-f, --force', 'Skip secret scanning (not recommended)')
   .option('-b, --bundle <name>', 'Bundle to assign the file to (defaults to "default")')
   .option('--json', 'Emit JSON envelope to stdout (non-interactive)')

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -25,7 +25,7 @@
  */
 
 import { Command } from 'commander';
-import { readFile, writeFile, mkdir, readdir, stat, symlink, rm } from 'fs/promises';
+import { readFile, writeFile, mkdir, readdir, stat, symlink, rm, realpath } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, isAbsolute, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -384,6 +384,27 @@ const resolveTranslationSource = async (source?: string): Promise<string> => {
   ]);
 };
 
+/**
+ * True when `a` and `b` resolve — through any symlinks — to the same real file
+ * on disk. Returns false when either path cannot be resolved (e.g. the target
+ * does not exist yet, or is a broken symlink), since a missing target cannot be
+ * clobbered.
+ *
+ * A lexical `resolve()` compare is not enough for the translation self-target
+ * guard: if a target is a symlink pointing at the source (e.g. the user ran
+ * `ln -s ~/.codex/AGENTS.md ~/.claude/CLAUDE.md`), the two paths differ
+ * lexically but reference one file. Translating with `--link` would then `rm`
+ * the real source and create a circular symlink, leaving both instruction files
+ * unreadable (ELOOP) while reporting success — a silent data-loss bug.
+ */
+const sameRealFile = async (a: string, b: string): Promise<boolean> => {
+  try {
+    return resolve(await realpath(a)) === resolve(await realpath(b));
+  } catch {
+    return false;
+  }
+};
+
 interface TranslateEntry {
   agent: string;
   label: string;
@@ -432,6 +453,10 @@ export const translateAction = async (
     const resolved = resolveWriteTarget(target.path);
     // Never translate a file onto itself (source may already be one target).
     if (resolve(resolved) === resolve(sourcePath)) continue;
+    // Also skip when the target resolves to the source *through symlinks* — a
+    // lexical compare misses `~/.claude/CLAUDE.md -> ~/.codex/AGENTS.md`, and
+    // `--link` would otherwise rm the real source and create a circular symlink.
+    if (await sameRealFile(resolved, sourcePath)) continue;
     entries.push({ agent: target.agent, label: target.label, target: resolved });
   }
 

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -25,12 +25,12 @@
  */
 
 import { Command } from 'commander';
-import { readFile, writeFile, mkdir, readdir, stat } from 'fs/promises';
+import { readFile, writeFile, mkdir, readdir, stat, symlink, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, isAbsolute, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
-import { collapsePath, pathExists, validateSafeDestinationPath } from '../lib/paths.js';
+import { expandPath, collapsePath, pathExists, validateSafeDestinationPath } from '../lib/paths.js';
 import { resolveWriteTarget, allowedRoots } from '../lib/writeContext.js';
 import { copyFileOrDir, setFilePermissions } from '../lib/files.js';
 import { logger, prompts, colors as c } from '../ui/index.js';
@@ -38,6 +38,11 @@ import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 import { TuckError } from '../errors.js';
 import { renderTemplate } from '../lib/template.js';
 import { createPreApplySnapshot } from '../lib/timemachine.js';
+import {
+  listInstructionTargets,
+  getInstructionTarget,
+  DEFAULT_TRANSLATION_AGENTS,
+} from '../lib/agentPresets.js';
 
 interface PresetFile {
   source: string;
@@ -93,11 +98,9 @@ const loadPresetFile = async (path: string): Promise<Preset> => {
   // require presets to ship as JSON. YAML is supported only via conversion at
   // publish time (preset publish converts YAML→JSON). See open question in
   // implementation-notes.html.
-  throw new TuckError(
-    `Unsupported preset format: ${path}`,
-    'PRESET_FORMAT',
-    ['Presets must be JSON in v1. Convert YAML to JSON with a tool of your choice.']
-  );
+  throw new TuckError(`Unsupported preset format: ${path}`, 'PRESET_FORMAT', [
+    'Presets must be JSON in v1. Convert YAML to JSON with a tool of your choice.',
+  ]);
 };
 
 const resolvePreset = async (nameOrPath: string): Promise<{ path: string; preset: Preset }> => {
@@ -116,11 +119,10 @@ const resolvePreset = async (nameOrPath: string): Promise<{ path: string; preset
   if (await pathExists(manifest)) {
     return { path: manifest, preset: await loadPresetFile(manifest) };
   }
-  throw new TuckError(
-    `Preset not found: ${nameOrPath}`,
-    'PRESET_NOT_FOUND',
-    ['Run `tuck preset list` to see available presets', 'Or pass a path to a preset.json']
-  );
+  throw new TuckError(`Preset not found: ${nameOrPath}`, 'PRESET_NOT_FOUND', [
+    'Run `tuck preset list` to see available presets',
+    'Or pass a path to a preset.json',
+  ]);
 };
 
 const renderIfTemplate = async (
@@ -352,6 +354,175 @@ const publishAction = async (
   logger.dim(`Pack with: tar -czf ${out} -C ${dir} .`);
 };
 
+/**
+ * Resolve the canonical instructions file for `preset translate`. An explicit
+ * source wins; otherwise fall back to the first existing known instruction
+ * file (Claude Code's CLAUDE.md, then Codex's AGENTS.md, then Gemini's).
+ */
+const resolveTranslationSource = async (source?: string): Promise<string> => {
+  if (source) {
+    const abs = expandPath(source);
+    if (!(await pathExists(abs))) {
+      throw new TuckError(`Source not found: ${collapsePath(abs)}`, 'PRESET_SOURCE_MISSING', [
+        'Pass a readable canonical instructions file.',
+      ]);
+    }
+    if ((await stat(abs)).isDirectory()) {
+      throw new TuckError(
+        `Source must be a file, not a directory: ${collapsePath(abs)}`,
+        'VALIDATION_ERROR'
+      );
+    }
+    return abs;
+  }
+  for (const t of listInstructionTargets()) {
+    const abs = expandPath(t.path);
+    if (await pathExists(abs)) return abs;
+  }
+  throw new TuckError('No canonical instructions file found', 'PRESET_SOURCE_MISSING', [
+    'Pass a source path, e.g. tuck preset translate ~/.claude/CLAUDE.md',
+  ]);
+};
+
+interface TranslateEntry {
+  agent: string;
+  label: string;
+  target: string;
+}
+
+/**
+ * Cross-agent instructions translation (IDEAS 1.8 v1). Materialize one
+ * canonical instructions file into each target agent's global instruction path
+ * (default: Claude Code's CLAUDE.md and Codex's AGENTS.md). Copies by default;
+ * `--link` symlinks each target at the source instead. Reuses the same safety
+ * machinery as `preset apply`: home-confined targets, snapshot-before-overwrite,
+ * and a non-interactive overwrite refusal.
+ */
+export const translateAction = async (
+  source: string | undefined,
+  opts: {
+    json?: boolean;
+    yes?: boolean;
+    plan?: boolean;
+    dryRun?: boolean;
+    to?: string;
+    link?: boolean;
+  }
+): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck preset translate');
+
+  const sourcePath = await resolveTranslationSource(source);
+
+  const agentIds = (opts.to ?? DEFAULT_TRANSLATION_AGENTS.join(','))
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const entries: TranslateEntry[] = [];
+  for (const agent of agentIds) {
+    const target = getInstructionTarget(agent);
+    if (!target) {
+      throw new TuckError(`Unknown translation target: ${agent}`, 'UNKNOWN_TRANSLATION_TARGET', [
+        `Valid targets: ${listInstructionTargets()
+          .map((t) => t.agent)
+          .join(', ')}`,
+      ]);
+    }
+    // Confine + redirect under --root (no-op when not sandboxed).
+    const resolved = resolveWriteTarget(target.path);
+    // Never translate a file onto itself (source may already be one target).
+    if (resolve(resolved) === resolve(sourcePath)) continue;
+    entries.push({ agent: target.agent, label: target.label, target: resolved });
+  }
+
+  if (entries.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ source: collapsePath(sourcePath), translated: 0, targets: [] });
+      return;
+    }
+    logger.info('Nothing to translate — the source is the only requested target.');
+    return;
+  }
+
+  if (opts.plan || opts.dryRun) {
+    if (isJsonMode()) {
+      emitJsonOk({
+        source: collapsePath(sourcePath),
+        mode: opts.link ? 'symlink' : 'copy',
+        plan: entries.map((e) => ({ agent: e.agent, target: e.target })),
+      });
+      return;
+    }
+    console.log(
+      c.bold(`Translate ${collapsePath(sourcePath)} → (${opts.link ? 'symlink' : 'copy'}):`)
+    );
+    for (const e of entries) console.log(`  ${e.label}: ${collapsePath(e.target)}`);
+    return;
+  }
+
+  // Safety gate 1: refuse to write anywhere outside $HOME before any mkdir/write.
+  assertPresetTargetsSafe(entries);
+
+  // Safety gate 2: never silently clobber. Snapshot + consent.
+  const existing: string[] = [];
+  for (const e of entries) {
+    if (await pathExists(e.target)) existing.push(e.target);
+  }
+  const nonInteractive = isJsonMode() || !process.stdout.isTTY;
+  const decision = decidePresetOverwrite(existing.length, { yes: opts.yes, nonInteractive });
+
+  if (decision === 'refuse') {
+    throw new TuckError(
+      `Translating would overwrite ${existing.length} existing file(s). Re-run with --yes to confirm.`,
+      'PRESET_OVERWRITE_REFUSED',
+      ['Pass --yes to overwrite (a snapshot is taken first so you can `tuck undo`).']
+    );
+  }
+  if (decision === 'confirm') {
+    logger.warning(`This will overwrite ${existing.length} existing file(s):`);
+    for (const t of existing) logger.dim(`  ${collapsePath(t)}`);
+    const confirmed = await prompts.confirm(
+      `Translate ${collapsePath(sourcePath)} into these files?`,
+      false
+    );
+    if (!confirmed) {
+      logger.info('Aborted — no files changed.');
+      return;
+    }
+  }
+
+  if (existing.length > 0) {
+    await createPreApplySnapshot(existing, 'preset:translate');
+  }
+
+  const content = await readFile(sourcePath);
+  for (const e of entries) {
+    await mkdir(dirname(e.target), { recursive: true });
+    if (opts.link) {
+      // Replace any existing target with a symlink to the canonical source.
+      if (await pathExists(e.target)) await rm(e.target, { force: true });
+      await symlink(sourcePath, e.target);
+    } else {
+      await writeFile(e.target, content);
+    }
+  }
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      source: collapsePath(sourcePath),
+      mode: opts.link ? 'symlink' : 'copy',
+      translated: entries.length,
+      targets: entries.map((e) => ({ agent: e.agent, target: e.target })),
+    });
+    return;
+  }
+  logger.success(
+    `Translated ${collapsePath(sourcePath)} into ${entries.length} agent file(s)` +
+      `${opts.link ? ' (symlinked)' : ''}`
+  );
+  for (const e of entries) logger.dim(`  ${e.label}: ${collapsePath(e.target)}`);
+};
+
 export const presetCommand = new Command('preset')
   .description('Apply or publish curated bundles of dotfiles & agent configs')
   .addCommand(
@@ -362,7 +533,7 @@ export const presetCommand = new Command('preset')
   )
   .addCommand(
     new Command('show')
-      .description('Show a preset\'s contents')
+      .description("Show a preset's contents")
       .argument('<name>', 'Preset name or path')
       .option('--json', 'Emit JSON envelope')
       .action(showAction)
@@ -384,4 +555,23 @@ export const presetCommand = new Command('preset')
       .option('--json', 'Emit JSON envelope')
       .option('-o, --out <path>', 'Output archive path')
       .action(publishAction)
+  )
+  .addCommand(
+    new Command('translate')
+      .description('Materialize one canonical instructions file for multiple agents')
+      .argument(
+        '[source]',
+        'Canonical instructions file (defaults to an existing CLAUDE.md/AGENTS.md)'
+      )
+      .option(
+        '--to <agents>',
+        'Comma-separated target agents',
+        DEFAULT_TRANSLATION_AGENTS.join(',')
+      )
+      .option('--link', 'Symlink each target to the source instead of copying')
+      .option('--json', 'Emit JSON envelope')
+      .option('-y, --yes', 'Auto-confirm prompts')
+      .option('--plan', 'Print the operation plan and exit')
+      .option('--dry-run', 'Print the operation as text and exit (no JSON)')
+      .action(translateAction)
   );

--- a/src/lib/agentPresets.ts
+++ b/src/lib/agentPresets.ts
@@ -1,0 +1,309 @@
+/**
+ * Agent config presets — the curated allowlists that power
+ * `tuck add --preset <agent>` (IDEAS 1.2) and the canonical instruction-file
+ * targets that power `tuck preset translate` (IDEAS 1.8).
+ *
+ * Each preset encodes two things the community keeps hand-rolling:
+ *   1. `allow` — the exact files/dirs under an agent's home config that are
+ *      SAFE to version-control (instructions, settings, commands, skills…).
+ *   2. `exclude` — the local/credential/history/session files that must NEVER
+ *      be tracked (settings.local.json, credentials, sessions/, projects/…).
+ *
+ * The two sets are disjoint by construction (asserted in tests). `exclude`
+ * additionally serves as a runtime guard and as user-facing reassurance: after
+ * a preset add we report which sensitive files were found and deliberately
+ * skipped. tuck's secret scanner remains the final backstop on every tracked
+ * file, so even an over-broad allowlist entry can never smuggle a credential
+ * into the repo silently.
+ */
+import { basename } from 'path';
+import { z } from 'zod';
+import { IS_MACOS, IS_WINDOWS } from './platform.js';
+import { expandPath, collapsePath, pathExists, isDirectory } from './paths.js';
+
+/** A single safe-to-track entry. Directory entries end with a trailing `/`. */
+export interface AgentPresetEntry {
+  /** Home-relative path (always `~/…`, forward slashes). Dirs end with `/`. */
+  path: string;
+  /** Manifest category the tracked entry is filed under. */
+  category: string;
+}
+
+/** A curated allowlist/excludelist for one AI agent's home configuration. */
+export interface AgentPreset {
+  /** Stable id used on the CLI, e.g. `claude-code`. */
+  id: string;
+  /** Human-facing label, e.g. `Claude Code`. */
+  label: string;
+  /** One-line description for `--help` / listings. */
+  description: string;
+  /** Config roots this agent uses (for messaging). */
+  configDirs: string[];
+  /** Safe-to-track allowlist. */
+  allow: AgentPresetEntry[];
+  /**
+   * Hard-exclude paths (home-relative). These are never tracked and are
+   * surfaced to the user as "found but intentionally skipped".
+   */
+  exclude: string[];
+}
+
+const entrySchema = z.object({
+  path: z.string().min(1),
+  category: z.string().min(1),
+});
+
+const presetSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().min(1),
+  configDirs: z.array(z.string().min(1)).min(1),
+  allow: z.array(entrySchema).min(1),
+  exclude: z.array(z.string().min(1)),
+});
+
+/** Agent config category — one logical grouping for all agent files. */
+const AGENTS = 'agents';
+
+/**
+ * Cursor stores its user settings under a platform-specific Application Support
+ * path. Always emit `~/`-prefixed, forward-slash paths so {@link expandPath}
+ * resolves them identically on every platform.
+ */
+const cursorUserDir = (): string => {
+  if (IS_MACOS) return '~/Library/Application Support/Cursor/User';
+  if (IS_WINDOWS) return '~/AppData/Roaming/Cursor/User';
+  return '~/.config/Cursor/User';
+};
+
+/** GitHub Copilot CLI config root (per platform). */
+const copilotDir = (): string => {
+  if (IS_WINDOWS) return '~/AppData/Local/github-copilot';
+  return '~/.config/github-copilot';
+};
+
+const buildPresets = (): AgentPreset[] => {
+  const cursor = cursorUserDir();
+  const copilot = copilotDir();
+
+  return [
+    {
+      id: 'claude-code',
+      label: 'Claude Code',
+      description: 'CLAUDE.md, settings.json, commands/, skills/, agents/, hooks/, rules/',
+      configDirs: ['~/.claude'],
+      allow: [
+        { path: '~/.claude/CLAUDE.md', category: AGENTS },
+        { path: '~/.claude/settings.json', category: AGENTS },
+        { path: '~/.claude/commands/', category: AGENTS },
+        { path: '~/.claude/skills/', category: AGENTS },
+        { path: '~/.claude/agents/', category: AGENTS },
+        { path: '~/.claude/hooks/', category: AGENTS },
+        { path: '~/.claude/rules/', category: AGENTS },
+        { path: '~/.claude/output-styles/', category: AGENTS },
+      ],
+      exclude: [
+        '~/.claude/settings.local.json',
+        '~/.claude/CLAUDE.local.md',
+        '~/.claude/.credentials.json',
+        '~/.claude/credentials',
+        '~/.claude/history.jsonl',
+        '~/.claude/history',
+        '~/.claude/sessions/',
+        '~/.claude/projects/',
+        '~/.claude/todos/',
+        '~/.claude/statsig/',
+        '~/.claude/shell-snapshots/',
+        '~/.claude/ide/',
+        '~/.claude.json',
+      ],
+    },
+    {
+      id: 'cursor',
+      label: 'Cursor',
+      description: 'User settings, keybindings, snippets/, and ~/.cursor rules',
+      configDirs: [cursor, '~/.cursor'],
+      allow: [
+        { path: `${cursor}/settings.json`, category: AGENTS },
+        { path: `${cursor}/keybindings.json`, category: AGENTS },
+        { path: `${cursor}/snippets/`, category: AGENTS },
+        { path: '~/.cursor/rules/', category: AGENTS },
+      ],
+      exclude: [
+        `${cursor}/globalStorage/`,
+        `${cursor}/workspaceStorage/`,
+        `${cursor}/History/`,
+        '~/.cursor/mcp.json',
+        '~/.cursor/logs/',
+        '~/.cursor/sessions/',
+      ],
+    },
+    {
+      id: 'codex',
+      label: 'Codex',
+      description: 'AGENTS.md, config.toml, prompts/',
+      configDirs: ['~/.codex'],
+      allow: [
+        { path: '~/.codex/AGENTS.md', category: AGENTS },
+        { path: '~/.codex/config.toml', category: AGENTS },
+        { path: '~/.codex/prompts/', category: AGENTS },
+      ],
+      exclude: [
+        '~/.codex/auth.json',
+        '~/.codex/.credentials.json',
+        '~/.codex/sessions/',
+        '~/.codex/history.jsonl',
+        '~/.codex/log/',
+      ],
+    },
+    {
+      id: 'gemini',
+      label: 'Gemini CLI',
+      description: 'GEMINI.md, settings.json, commands/',
+      configDirs: ['~/.gemini'],
+      allow: [
+        { path: '~/.gemini/GEMINI.md', category: AGENTS },
+        { path: '~/.gemini/settings.json', category: AGENTS },
+        { path: '~/.gemini/commands/', category: AGENTS },
+      ],
+      exclude: [
+        '~/.gemini/oauth_creds.json',
+        '~/.gemini/google_accounts.json',
+        '~/.gemini/access_tokens.json',
+        '~/.gemini/tmp/',
+        '~/.gemini/sessions/',
+      ],
+    },
+    {
+      id: 'copilot',
+      label: 'GitHub Copilot',
+      description: 'GitHub Copilot CLI config (non-credential)',
+      configDirs: [copilot],
+      allow: [{ path: `${copilot}/config.json`, category: AGENTS }],
+      exclude: [`${copilot}/hosts.json`, `${copilot}/apps.json`, `${copilot}/versions.json`],
+    },
+  ];
+};
+
+// Validate the registry at module load so a typo (bad category, empty path)
+// fails fast in tests/CI rather than at a user's terminal.
+const REGISTRY: AgentPreset[] = buildPresets().map((p) => presetSchema.parse(p));
+
+/** All agent presets, in stable display order. */
+export const listAgentPresets = (): AgentPreset[] => REGISTRY;
+
+/** Valid preset ids (for help text and error suggestions). */
+export const agentPresetIds = (): string[] => REGISTRY.map((p) => p.id);
+
+/** Look up a preset by id, or `undefined` if unknown. */
+export const getAgentPreset = (id: string): AgentPreset | undefined =>
+  REGISTRY.find((p) => p.id === id);
+
+const stripTrailingSlash = (p: string): string => p.replace(/\/+$/, '');
+
+/**
+ * Whether a home-relative `path` is covered by any `exclude` entry. Covered
+ * means: exact match, the path lives inside an excluded directory, or a bare
+ * (slash-free) exclude name matches the path's basename. Pure function — used
+ * both as a defense-in-depth runtime filter and as the disjointness invariant
+ * asserted in tests.
+ */
+export const isPathExcluded = (path: string, excludes: string[]): boolean => {
+  const p = stripTrailingSlash(path);
+  return excludes.some((raw) => {
+    const e = stripTrailingSlash(raw);
+    if (p === e) return true;
+    if (p.startsWith(`${e}/`)) return true;
+    if (!e.includes('/') && basename(p) === e) return true;
+    return false;
+  });
+};
+
+/** The outcome of resolving a preset against the current filesystem. */
+export interface AgentPresetResolution {
+  preset: AgentPreset;
+  /** Allowlisted entries that exist on disk and are safe to track. */
+  tracked: Array<{
+    /** Absolute, expanded path. */
+    path: string;
+    /** `~/…` collapsed path for display and as a track candidate. */
+    collapsed: string;
+    category: string;
+    isDir: boolean;
+  }>;
+  /** Allowlisted entries not present on disk (informational). */
+  missing: string[];
+  /** Excluded paths that DO exist on disk (found → intentionally skipped). */
+  skippedSensitive: string[];
+}
+
+/**
+ * Resolve a preset id against the real filesystem: enumerate the allowlist,
+ * keep the entries that exist and are not excluded, and separately report the
+ * sensitive files that were found and skipped. Throws when `id` is unknown.
+ */
+export const resolveAgentPreset = async (id: string): Promise<AgentPresetResolution> => {
+  const preset = getAgentPreset(id);
+  if (!preset) {
+    const { TuckError } = await import('../errors.js');
+    throw new TuckError(`Unknown agent preset: ${id}`, 'UNKNOWN_AGENT_PRESET', [
+      `Valid presets: ${agentPresetIds().join(', ')}`,
+    ]);
+  }
+
+  const tracked: AgentPresetResolution['tracked'] = [];
+  const missing: string[] = [];
+
+  for (const entry of preset.allow) {
+    // Defense in depth: never track an allow entry that overlaps an exclude,
+    // even if a future registry edit introduces such an overlap.
+    if (isPathExcluded(entry.path, preset.exclude)) continue;
+    const abs = expandPath(stripTrailingSlash(entry.path));
+    if (await pathExists(abs)) {
+      tracked.push({
+        path: abs,
+        collapsed: collapsePath(abs),
+        category: entry.category,
+        isDir: await isDirectory(abs),
+      });
+    } else {
+      missing.push(collapsePath(abs));
+    }
+  }
+
+  const skippedSensitive: string[] = [];
+  for (const ex of preset.exclude) {
+    const abs = expandPath(stripTrailingSlash(ex));
+    if (await pathExists(abs)) skippedSensitive.push(collapsePath(abs));
+  }
+
+  return { preset, tracked, missing, skippedSensitive };
+};
+
+/**
+ * Canonical instruction-file targets for cross-agent translation (IDEAS 1.8):
+ * one canonical instructions file materialized to each agent's global
+ * instruction path.
+ */
+export interface InstructionTarget {
+  agent: string;
+  label: string;
+  /** Home-relative (`~/…`) instruction-file path. */
+  path: string;
+}
+
+const INSTRUCTION_TARGETS: InstructionTarget[] = [
+  { agent: 'claude-code', label: 'Claude Code', path: '~/.claude/CLAUDE.md' },
+  { agent: 'codex', label: 'Codex', path: '~/.codex/AGENTS.md' },
+  { agent: 'gemini', label: 'Gemini CLI', path: '~/.gemini/GEMINI.md' },
+];
+
+/** Agents translated by default (spec v1: Claude Code + Codex). */
+export const DEFAULT_TRANSLATION_AGENTS = ['claude-code', 'codex'];
+
+/** All known instruction targets, in stable order. */
+export const listInstructionTargets = (): InstructionTarget[] => INSTRUCTION_TARGETS;
+
+/** Look up an instruction target by agent id, or `undefined` if unknown. */
+export const getInstructionTarget = (agent: string): InstructionTarget | undefined =>
+  INSTRUCTION_TARGETS.find((t) => t.agent === agent);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,3 +10,4 @@ export * from './timemachine.js';
 export * from './merge.js';
 export * from './detect.js';
 export * from './remoteChecks.js';
+export * from './agentPresets.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,12 @@ export interface AddOptions extends CommonOptions {
   repo?: string | boolean;
   /** Explicit repoKey override (advanced; default derives from the remote). */
   repoKey?: string;
+  /**
+   * Track a curated AI-agent config preset instead of explicit paths, e.g.
+   * `--preset claude-code`. Enumerates the agent's safe-to-track allowlist and
+   * hard-excludes local/credential/history files.
+   */
+  preset?: string;
 }
 
 export interface RemoveOptions extends CommonOptions {

--- a/tests/commands/add-preset.test.ts
+++ b/tests/commands/add-preset.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `tuck add --preset <agent>` integration tests (IDEAS 1.2).
+ *
+ * Drive the real add pipeline against a sandboxed tuck repo + memfs home,
+ * proving the two behaviours that matter: safe allowlisted files land in the
+ * manifest, and sensitive files (credentials/local/session) are never tracked.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_HOME, TEST_TUCK_DIR, initTestTuck } from '../utils/testHelpers.js';
+import { loadManifest, clearManifestCache } from '../../src/lib/manifest.js';
+import { addCommand } from '../../src/commands/add.js';
+
+// Real tracking copies files but never touches a live remote; stub git so the
+// pipeline runs without a repository or network.
+vi.mock('simple-git', () => {
+  const mockGit = {
+    init: vi.fn().mockResolvedValue(undefined),
+    add: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue({ commit: 'abc123' }),
+    getRemotes: vi.fn().mockResolvedValue([]),
+    revparse: vi.fn().mockResolvedValue('main'),
+    raw: vi.fn().mockResolvedValue('main'),
+  };
+  return { default: vi.fn(() => mockGit), simpleGit: vi.fn(() => mockGit) };
+});
+
+const stageClaudeHome = (): void => {
+  vol.mkdirSync(join(TEST_HOME, '.claude', 'commands'), { recursive: true });
+  vol.writeFileSync(join(TEST_HOME, '.claude', 'CLAUDE.md'), '# global rules');
+  vol.writeFileSync(join(TEST_HOME, '.claude', 'settings.json'), '{"theme":"dark"}');
+  vol.writeFileSync(join(TEST_HOME, '.claude', 'commands', 'deploy.md'), 'deploy cmd');
+  // Sensitive — must never be tracked.
+  vol.writeFileSync(join(TEST_HOME, '.claude', '.credentials.json'), '{"token":"secret"}');
+  vol.writeFileSync(join(TEST_HOME, '.claude', 'settings.local.json'), '{"local":true}');
+};
+
+describe('tuck add --preset (integration)', () => {
+  let writes: string[];
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vol.reset();
+    vi.clearAllMocks();
+    clearManifestCache();
+    await initTestTuck();
+    const { setJsonMode, __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+    __resetJsonEmitState();
+    writes = [];
+    writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    writeSpy.mockRestore();
+    clearManifestCache();
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+  });
+
+  const jsonEnvelope = (): { ok: boolean; command: string; data?: any; error?: any } => {
+    const jsonLine = writes.find((w) => w.trim().startsWith('{'));
+    return JSON.parse((jsonLine ?? writes.join('')).trim());
+  };
+
+  it('tracks the safe allowlist and never the credentials/local files', async () => {
+    stageClaudeHome();
+
+    await addCommand.parseAsync(['node', 'tuck', '--preset', 'claude-code', '--yes']);
+
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    const sources = Object.values(manifest.files).map((f) => f.source);
+
+    // Safe files present.
+    expect(sources).toContain('~/.claude/CLAUDE.md');
+    expect(sources).toContain('~/.claude/settings.json');
+    expect(sources).toContain('~/.claude/commands');
+    // Sensitive files absent.
+    expect(sources.some((s) => s.includes('.credentials'))).toBe(false);
+    expect(sources.some((s) => s.includes('settings.local.json'))).toBe(false);
+    // All filed under the agents category.
+    for (const f of Object.values(manifest.files)) {
+      if (f.source.startsWith('~/.claude')) expect(f.category).toBe('agents');
+    }
+  });
+
+  it('is idempotent — re-running adds nothing new', async () => {
+    stageClaudeHome();
+    await addCommand.parseAsync(['node', 'tuck', '--preset', 'claude-code', '--yes']);
+    const first = Object.keys((await loadManifest(TEST_TUCK_DIR)).files).length;
+    clearManifestCache();
+
+    await addCommand.parseAsync(['node', 'tuck', '--preset', 'claude-code', '--yes']);
+    const second = Object.keys((await loadManifest(TEST_TUCK_DIR)).files).length;
+
+    expect(second).toBe(first);
+  });
+
+  it('reports nothing to track when the agent has no config on disk', async () => {
+    await addCommand.parseAsync(['node', 'tuck', '--preset', 'codex', '--json', '--yes']);
+
+    const env = jsonEnvelope();
+    expect(env.ok).toBe(true);
+    expect(env.data.added).toBe(0);
+    expect(Object.keys((await loadManifest(TEST_TUCK_DIR)).files)).toHaveLength(0);
+  });
+
+  it('rejects an unknown preset', async () => {
+    await expect(
+      addCommand.parseAsync(['node', 'tuck', '--preset', 'not-an-agent', '--json', '--yes'])
+    ).rejects.toMatchObject({ code: 'UNKNOWN_AGENT_PRESET' });
+  });
+
+  // NOTE: kept last on purpose. Commander stores option values on the shared
+  // command instance and does not reset booleans between parseAsync calls, so a
+  // `--plan` run must not precede a run that expects normal (mutating) mode.
+  it('--plan --json lists safe files and the skipped sensitive ones without mutating', async () => {
+    stageClaudeHome();
+
+    await addCommand.parseAsync(['node', 'tuck', '--preset', 'claude-code', '--plan', '--json']);
+
+    const env = jsonEnvelope();
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck add');
+    expect(env.data.preset).toBe('claude-code');
+    const planned = env.data.plan.map((p: { source: string }) => p.source);
+    expect(planned).toContain('~/.claude/CLAUDE.md');
+    expect(planned).toContain('~/.claude/commands');
+    expect(env.data.skipped).toContain('~/.claude/.credentials.json');
+    expect(env.data.skipped).toContain('~/.claude/settings.local.json');
+
+    // Plan is read-only: nothing tracked.
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    expect(Object.keys(manifest.files)).toHaveLength(0);
+  });
+});

--- a/tests/commands/preset.test.ts
+++ b/tests/commands/preset.test.ts
@@ -15,6 +15,7 @@ import {
   decidePresetOverwrite,
   bundledRegistryDir,
   applyAction,
+  translateAction,
 } from '../../src/commands/preset.js';
 
 // Spy on the snapshot helper so we can assert it is (or is not) called with the
@@ -73,10 +74,7 @@ describe('assertPresetTargetsSafe', () => {
 
   it('rejects the whole batch if any single target is unsafe', () => {
     expect(() =>
-      assertPresetTargetsSafe([
-        { target: '/test-home/.config/ok' },
-        { target: '/root/.bashrc' },
-      ])
+      assertPresetTargetsSafe([{ target: '/test-home/.config/ok' }, { target: '/root/.bashrc' }])
     ).toThrow();
   });
 });
@@ -184,7 +182,9 @@ describe('preset apply (integration)', () => {
 
     // Files landed under the (mocked) home. Built with resolve() to match
     // resolveWriteTarget's output on both POSIX and Windows (drive-prefixed).
-    expect(vol.readFileSync(resolve(TEST_HOME, '.claude', 'CLAUDE.md'), 'utf-8')).toBe('hello claude');
+    expect(vol.readFileSync(resolve(TEST_HOME, '.claude', 'CLAUDE.md'), 'utf-8')).toBe(
+      'hello claude'
+    );
     expect(vol.readFileSync(resolve(TEST_HOME, '.config', 'zshrc'), 'utf-8')).toBe('export A=1');
 
     const env = jsonEnvelope();
@@ -262,7 +262,7 @@ describe('preset apply (integration)', () => {
   });
 
   it.skipIf(process.platform === 'win32')(
-    'applies the preset file\'s declared permissions to the written target',
+    "applies the preset file's declared permissions to the written target",
     async () => {
       // Stage a preset whose (non-template) file declares a hardened mode, like
       // an SSH/credential config. The permissions field was parsed but never
@@ -296,6 +296,133 @@ describe('preset apply (integration)', () => {
       expect(mode.toString(8)).toBe('600');
     }
   );
+});
+
+/**
+ * preset translate — cross-agent instructions translation (IDEAS 1.8 v1).
+ *
+ * translateAction materializes one canonical instructions file into each
+ * agent's global instruction path. It reuses the same safety machinery as
+ * `preset apply` (home-confined targets, snapshot + overwrite refusal), so the
+ * tests focus on the fan-out, the self-target skip, and the refusal path.
+ */
+describe('preset translate', () => {
+  const SOURCE = join(TEST_HOME, 'canonical-instructions.md');
+  const CLAUDE = resolve(TEST_HOME, '.claude', 'CLAUDE.md');
+  const CODEX = resolve(TEST_HOME, '.codex', 'AGENTS.md');
+
+  let writes: string[];
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    createPreApplySnapshotMock.mockClear();
+    confirmMock.mockClear().mockResolvedValue(true);
+    const { setJsonMode, __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+    __resetJsonEmitState();
+    writes = [];
+    writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    writeSpy.mockRestore();
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+  });
+
+  const jsonEnvelope = (): { ok: boolean; command: string; data?: any; error?: any } => {
+    const jsonLine = writes.find((w) => w.trim().startsWith('{'));
+    return JSON.parse((jsonLine ?? writes.join('')).trim());
+  };
+
+  it('materializes the canonical file for both default agents (claude + codex)', async () => {
+    vol.writeFileSync(SOURCE, '# my canonical rules');
+
+    await translateAction(SOURCE, { json: true, yes: true });
+
+    expect(vol.readFileSync(CLAUDE, 'utf-8')).toBe('# my canonical rules');
+    expect(vol.readFileSync(CODEX, 'utf-8')).toBe('# my canonical rules');
+
+    const env = jsonEnvelope();
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck preset translate');
+    expect(env.data.translated).toBe(2);
+    // Fresh targets → no snapshot.
+    expect(createPreApplySnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the target that is the source itself', async () => {
+    // Source IS Claude's instruction file → only Codex should be written.
+    vol.mkdirSync(resolve(TEST_HOME, '.claude'), { recursive: true });
+    vol.writeFileSync(CLAUDE, '# claude rules');
+
+    await translateAction(CLAUDE, { json: true, yes: true });
+
+    const env = jsonEnvelope();
+    expect(env.data.translated).toBe(1);
+    expect(vol.readFileSync(CODEX, 'utf-8')).toBe('# claude rules');
+  });
+
+  it('refuses to overwrite non-interactively without --yes and writes nothing', async () => {
+    vol.writeFileSync(SOURCE, 'NEW');
+    vol.mkdirSync(resolve(TEST_HOME, '.codex'), { recursive: true });
+    vol.writeFileSync(CODEX, 'ORIGINAL');
+
+    await expect(translateAction(SOURCE, { json: true })).rejects.toMatchObject({
+      code: 'PRESET_OVERWRITE_REFUSED',
+    });
+
+    // Existing untouched; the fresh Claude target never got created either.
+    expect(vol.readFileSync(CODEX, 'utf-8')).toBe('ORIGINAL');
+    expect(vol.existsSync(CLAUDE)).toBe(false);
+    expect(createPreApplySnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('overwrites with --yes and snapshots the existing target first', async () => {
+    vol.writeFileSync(SOURCE, 'NEW');
+    vol.mkdirSync(resolve(TEST_HOME, '.codex'), { recursive: true });
+    vol.writeFileSync(CODEX, 'ORIGINAL');
+
+    await translateAction(SOURCE, { json: true, yes: true });
+
+    expect(vol.readFileSync(CODEX, 'utf-8')).toBe('NEW');
+    expect(createPreApplySnapshotMock).toHaveBeenCalledTimes(1);
+    const [snapTargets] = createPreApplySnapshotMock.mock.calls[0] as [string[], string];
+    expect(snapTargets).toEqual([CODEX]);
+  });
+
+  it('--plan emits the plan and writes nothing', async () => {
+    vol.writeFileSync(SOURCE, 'planme');
+
+    await translateAction(SOURCE, { json: true, plan: true });
+
+    const env = jsonEnvelope();
+    expect(env.ok).toBe(true);
+    expect(Array.isArray(env.data.plan)).toBe(true);
+    expect(env.data.plan.length).toBe(2);
+    expect(vol.existsSync(CLAUDE)).toBe(false);
+    expect(vol.existsSync(CODEX)).toBe(false);
+  });
+
+  it('rejects an unknown target agent', async () => {
+    vol.writeFileSync(SOURCE, 'x');
+    await expect(
+      translateAction(SOURCE, { to: 'claude-code,bogus', json: true, yes: true })
+    ).rejects.toMatchObject({ code: 'UNKNOWN_TRANSLATION_TARGET' });
+  });
+
+  it('errors when no source is given and no canonical file exists', async () => {
+    await expect(translateAction(undefined, { json: true, yes: true })).rejects.toMatchObject({
+      code: 'PRESET_SOURCE_MISSING',
+    });
+  });
 });
 
 describe('bundledRegistryDir', () => {

--- a/tests/commands/preset.test.ts
+++ b/tests/commands/preset.test.ts
@@ -370,6 +370,30 @@ describe('preset translate', () => {
     expect(vol.readFileSync(CODEX, 'utf-8')).toBe('# claude rules');
   });
 
+  it('skips a target that is a symlink resolving to the source (no circular symlink)', async () => {
+    // User previously ran `ln -s ~/.codex/AGENTS.md ~/.claude/CLAUDE.md`, then
+    // translates from the Claude path. The Codex target is the real file that
+    // the Claude symlink points at. A lexical compare misses this; with --link
+    // the old code would rm the real AGENTS.md and create a circular symlink,
+    // leaving both files unreadable. The realpath guard must skip Codex.
+    vol.mkdirSync(resolve(TEST_HOME, '.codex'), { recursive: true });
+    vol.mkdirSync(resolve(TEST_HOME, '.claude'), { recursive: true });
+    vol.writeFileSync(CODEX, '# canonical rules');
+    vol.symlinkSync(CODEX, CLAUDE);
+
+    await translateAction(CLAUDE, { json: true, yes: true, link: true });
+
+    const env = jsonEnvelope();
+    expect(env.ok).toBe(true);
+    // Nothing to translate: both requested targets resolve to the one file.
+    expect(env.data.translated).toBe(0);
+    // The real source survives with its content intact (not rm'd).
+    expect(vol.readFileSync(CODEX, 'utf-8')).toBe('# canonical rules');
+    // The Claude symlink still points at the real file (readable, no ELOOP).
+    expect(vol.readFileSync(CLAUDE, 'utf-8')).toBe('# canonical rules');
+    expect(createPreApplySnapshotMock).not.toHaveBeenCalled();
+  });
+
   it('refuses to overwrite non-interactively without --yes and writes nothing', async () => {
     vol.writeFileSync(SOURCE, 'NEW');
     vol.mkdirSync(resolve(TEST_HOME, '.codex'), { recursive: true });

--- a/tests/lib/agentPresets.test.ts
+++ b/tests/lib/agentPresets.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Agent preset registry unit tests (IDEAS 1.2 / 1.8).
+ *
+ * Cover the two invariants that make presets safe:
+ *   - allow and exclude sets are disjoint (no sensitive file is ever in an
+ *     allowlist), and
+ *   - resolveAgentPreset only surfaces files that exist, filed under the right
+ *     category, while separately reporting the sensitive files it skipped.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_HOME } from '../setup.js';
+import {
+  listAgentPresets,
+  getAgentPreset,
+  agentPresetIds,
+  isPathExcluded,
+  resolveAgentPreset,
+  listInstructionTargets,
+  getInstructionTarget,
+  DEFAULT_TRANSLATION_AGENTS,
+} from '../../src/lib/agentPresets.js';
+
+describe('agent preset registry', () => {
+  it('ships the five documented agent presets', () => {
+    expect(agentPresetIds().sort()).toEqual(
+      ['claude-code', 'codex', 'copilot', 'cursor', 'gemini'].sort()
+    );
+  });
+
+  it('every preset validates against the schema (non-empty fields)', () => {
+    for (const p of listAgentPresets()) {
+      expect(p.id).toBeTruthy();
+      expect(p.label).toBeTruthy();
+      expect(p.allow.length).toBeGreaterThan(0);
+      expect(p.configDirs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('allow and exclude sets are disjoint for every preset', () => {
+    // The core safety invariant: a sensitive file must never appear in an
+    // allowlist, and no allowlisted entry may live inside an excluded dir.
+    for (const p of listAgentPresets()) {
+      for (const entry of p.allow) {
+        expect(isPathExcluded(entry.path, p.exclude)).toBe(false);
+      }
+    }
+  });
+
+  it('claude-code excludes credentials, history, sessions, and projects', () => {
+    const p = getAgentPreset('claude-code');
+    expect(p).toBeDefined();
+    const excl = p!.exclude;
+    expect(excl).toContain('~/.claude/settings.local.json');
+    expect(excl).toContain('~/.claude/.credentials.json');
+    expect(excl).toContain('~/.claude/sessions/');
+    expect(excl).toContain('~/.claude/projects/');
+    // And the allowlist carries the safe, documented surface.
+    const allowPaths = p!.allow.map((a) => a.path);
+    expect(allowPaths).toContain('~/.claude/CLAUDE.md');
+    expect(allowPaths).toContain('~/.claude/commands/');
+    expect(allowPaths).toContain('~/.claude/skills/');
+  });
+});
+
+describe('isPathExcluded', () => {
+  it('matches exact paths', () => {
+    expect(isPathExcluded('~/.claude/settings.local.json', ['~/.claude/settings.local.json'])).toBe(
+      true
+    );
+  });
+
+  it('matches files inside an excluded directory', () => {
+    expect(isPathExcluded('~/.claude/sessions/abc.json', ['~/.claude/sessions/'])).toBe(true);
+  });
+
+  it('matches a bare (slash-free) exclude by basename', () => {
+    expect(isPathExcluded('~/nested/credentials', ['credentials'])).toBe(true);
+  });
+
+  it('does not match unrelated siblings', () => {
+    expect(isPathExcluded('~/.claude/settings.json', ['~/.claude/settings.local.json'])).toBe(
+      false
+    );
+  });
+});
+
+describe('resolveAgentPreset', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  it('throws a helpful error for an unknown preset', async () => {
+    await expect(resolveAgentPreset('nope')).rejects.toMatchObject({
+      code: 'UNKNOWN_AGENT_PRESET',
+    });
+  });
+
+  it('tracks only the allowlisted files that exist on disk', async () => {
+    // Stage a safe file, a safe dir, and a sensitive credential file.
+    vol.mkdirSync(join(TEST_HOME, '.claude', 'commands'), { recursive: true });
+    vol.writeFileSync(join(TEST_HOME, '.claude', 'CLAUDE.md'), '# rules');
+    vol.writeFileSync(join(TEST_HOME, '.claude', 'commands', 'x.md'), 'cmd');
+    vol.writeFileSync(join(TEST_HOME, '.claude', '.credentials.json'), '{"token":"x"}');
+    vol.writeFileSync(join(TEST_HOME, '.claude', 'settings.local.json'), '{}');
+
+    const res = await resolveAgentPreset('claude-code');
+
+    const tracked = res.tracked.map((t) => t.collapsed).sort();
+    expect(tracked).toEqual(['~/.claude/CLAUDE.md', '~/.claude/commands'].sort());
+
+    // The directory entry is flagged as such.
+    const commands = res.tracked.find((t) => t.collapsed === '~/.claude/commands');
+    expect(commands?.isDir).toBe(true);
+    expect(commands?.category).toBe('agents');
+
+    // Sensitive files that exist are reported as skipped, never tracked.
+    expect(res.skippedSensitive).toContain('~/.claude/.credentials.json');
+    expect(res.skippedSensitive).toContain('~/.claude/settings.local.json');
+    expect(tracked).not.toContain('~/.claude/.credentials.json');
+
+    // settings.json was never created → reported missing, not tracked.
+    expect(res.missing).toContain('~/.claude/settings.json');
+  });
+
+  it('returns nothing to track when no agent config exists', async () => {
+    const res = await resolveAgentPreset('codex');
+    expect(res.tracked).toEqual([]);
+    expect(res.skippedSensitive).toEqual([]);
+  });
+});
+
+describe('instruction targets (translation)', () => {
+  it('defaults to claude-code and codex', () => {
+    expect(DEFAULT_TRANSLATION_AGENTS).toEqual(['claude-code', 'codex']);
+  });
+
+  it('maps agents to their canonical instruction files', () => {
+    expect(getInstructionTarget('claude-code')?.path).toBe('~/.claude/CLAUDE.md');
+    expect(getInstructionTarget('codex')?.path).toBe('~/.codex/AGENTS.md');
+    expect(getInstructionTarget('gemini')?.path).toBe('~/.gemini/GEMINI.md');
+  });
+
+  it('lists all known targets', () => {
+    const agents = listInstructionTargets().map((t) => t.agent);
+    expect(agents).toContain('claude-code');
+    expect(agents).toContain('codex');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **AI agent config presets** (IDEAS 1.2) and a **cross-agent instructions translation v1** (IDEAS 1.8).

### `tuck add --preset <agent>`
One command that knows exactly which files under an AI agent's home config are safe to version-control, and hard-excludes the credential/local/history/session files that must never leave the machine. Ships presets for **claude-code, cursor, codex, gemini, copilot**.

- **Allowlist** (claude-code): `CLAUDE.md`, `settings.json`, `commands/`, `skills/`, `agents/`, `hooks/`, `rules/`, `output-styles/`
- **Hard-excludes** (claude-code): `settings.local.json`, `CLAUDE.local.md`, `.credentials.json`, `credentials`, `history`, `sessions/`, `projects/`, `todos/`, `statsig/`, `shell-snapshots/`, `ide/`, `~/.claude.json`
- Cursor resolves its per-OS Application Support path; codex/gemini/copilot get their own allow/exclude sets.
- Re-runs are **idempotent** (already-tracked files skipped), sensitive files found on disk are **reported as skipped**, and tuck's **secret scanner still runs** on every tracked file as the final backstop.
- Registry is zod-validated at load; allow/exclude disjointness is asserted in tests.
- Supports `--plan`/`--dry-run`, `--json`, `--yes`.

### `tuck preset translate [source]`
Materialize one canonical instructions file into each agent's global instruction path (default: `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`). Copies by default, `--link` to symlink. Reuses `preset apply`'s safety machinery: home-confined targets, snapshot-before-overwrite (`tuck undo`-able), and non-interactive overwrite refusal. Skips a target that is the source itself. `--to`, `--plan`/`--dry-run`, `--json`, `--yes`.

## Files
- `src/lib/agentPresets.ts` — new preset registry + resolution + instruction targets
- `src/commands/add.ts` — `--preset` flow
- `src/commands/preset.ts` — `translate` subcommand
- `src/types.ts`, `src/lib/index.ts` — wiring
- `README.md`, `docs/ERROR_CODES.md` — docs

## Test evidence
```
pnpm typecheck   # tsc --noEmit — pass
pnpm lint        # eslint src — pass
pnpm build       # tsup — build success
pnpm knip        # exit 0 — no new dead code
pnpm test        # 148 files, 1538 tests passing (41 new)
```
New tests: `tests/lib/agentPresets.test.ts` (registry invariants, exclusion matching, filesystem resolution), `tests/commands/add-preset.test.ts` (sandboxed integration: safe allowlist tracked, credentials never tracked, idempotency, `--plan --json`, unknown preset), and translate tests in `tests/commands/preset.test.ts` (fan-out, self-target skip, overwrite refusal, snapshot, `--plan`, unknown target). All sandboxed via memfs + mocked `os.homedir`/git — no real `$HOME`, keychain, or network.

## Deferred (from the full pitch)
- Directory allowlist entries (`commands/`, `skills/`) are tracked whole; per-file filtering *inside* a tracked dir is not done (none of the shipped allow dirs contain excluded content, and the secret scanner still covers their contents).
- Copilot's safe home surface is thin; the preset is conservative (config only, tokens excluded).
- Richer translation mapping (per-repo rules, MCP servers, ignore patterns — IDEAS 1.4/1.5) is out of scope for this v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
