### PR TITLE
release: agent-native tracking, safe apply, secrets UX, and OS settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Supported managers: `brew`, `apt`, `dnf`, `pacman`, `winget`, `scoop`, `cargo`, 
 | `tuck encryption`   | Manage at-rest backup encryption (AES-256-GCM, password-based)   |
 | `tuck secrets`      | Manage local secrets / placeholder replacement                   |
 | `tuck context`      | Track AI agent configs across home and per-repo scopes           |
+| `tuck rules`        | Fan one canonical rules file out to per-tool variants (CLAUDE.md, .cursorrules, …) |
 | `tuck preset`       | Apply or publish curated bundles of dotfiles & agent configs     |
 | `tuck repo`         | Manage machine-local repo bindings (for repo-scoped tracking)    |
 | `tuck settings`     | Capture, version, and replay OS settings (macOS `defaults`)      |

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ tuck is designed with security in mind:
 - **Never tracks private keys** — SSH keys, `.env` files, and credentials are blocked by default
 - **Secret scanning** — Warns if files contain API keys or tokens
 - **Placeholder support** — Replace secrets with `{{PLACEHOLDER}}` syntax
+- **Value-level encryption** — SOPS-style: encrypt only secret *values* in place while keys, structure, and comments stay plaintext, so `git diff`/`merge`/review keep working
 - **External-first secrets** — `security.secretBackend` defaults to `auto`, preferring external password managers before local fallback
 - **Local fallback secrets** — Store actual values in `secrets.local.json` when needed; it is gitignored by default
 - **Fix, don't just block** — When a secret is flagged at `tuck add`/`tuck sync` time, choose to redact-and-store it (rewriting the tracked copy as a template) or mark a false positive as safe — no more disabling the whole check
@@ -601,6 +602,15 @@ tuck secrets scan
 # Set a secret value locally
 tuck secrets set API_KEY
 
+# Encrypt secret VALUES in place (keys/structure stay plaintext, git-diffable)
+tuck secrets encrypt ~/.env
+
+# Decrypt them back to plaintext
+tuck secrets decrypt ~/.env
+```
+
+See [docs/VALUE-ENCRYPTION.md](docs/VALUE-ENCRYPTION.md) for the full value-level
+encryption workflow.
 # Mark a scanner false positive as safe (auditable, committed allowlist)
 tuck secrets allow add --file ~/.config/app.conf --reason "example value from docs"
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Supported managers: `brew`, `apt`, `dnf`, `pacman`, `winget`, `scoop`, `cargo`, 
 | `tuck context`      | Track AI agent configs across home and per-repo scopes           |
 | `tuck preset`       | Apply or publish curated bundles of dotfiles & agent configs     |
 | `tuck repo`         | Manage machine-local repo bindings (for repo-scoped tracking)    |
+| `tuck settings`     | Capture, version, and replay OS settings (macOS `defaults`)      |
+| `tuck mcp`          | Run the Model Context Protocol server (expose tuck to AI agents) |
 | `tuck mcp`          | Run the MCP server + manage your MCP fleet (define once, render per client) |
 
 ### MCP fleet — define servers once, render per client
@@ -296,6 +298,43 @@ tuck add ~/.zshrc --json --yes    # never hangs; fails fast if a prompt is neede
 ```
 
 See [docs/AGENT-MODE.md](docs/AGENT-MODE.md) and [docs/ERROR_CODES.md](docs/ERROR_CODES.md) for the full contract.
+
+### OS settings (`tuck settings`)
+
+Instead of hand-maintaining an undocumented `.macos` script that silently
+breaks across macOS releases, capture settings by changing them in the GUI while
+tuck diffs the affected `defaults` domains, then replay them on another machine
+with per-OS-version guards. Steps that can't be automated live in a tracked
+manual-steps checklist that tuck reminds you about per machine.
+
+| Command                                   | Description                                              |
+| ----------------------------------------- | -------------------------------------------------------- |
+| `tuck settings capture`                   | Diff `defaults` domains while you change a GUI setting    |
+| `tuck settings apply`                     | Replay tracked settings (version-guarded) + restart apps |
+| `tuck settings list`                      | Show tracked settings and the manual-steps checklist     |
+| `tuck settings remove <id>`               | Untrack a captured setting                               |
+| `tuck settings manual add/list/done/reset`| Manage the manual-steps checklist (per-machine done)     |
+
+```bash
+# Interactive: tuck snapshots defaults, you flip the toggle, tuck records the write
+tuck settings capture "Auto-hide the Dock" --domain com.apple.dock --restart Dock
+
+# Non-interactive / scripted capture of a known key
+tuck settings capture --domain com.apple.dock --key autohide --type boolean --value true --restart Dock
+
+# On a new machine: preview, then apply (version guards skip anything out of range)
+tuck settings apply --dry-run
+tuck settings apply
+
+# Track a step that can't be automated
+tuck settings manual add "Enable FileVault" -i "System Settings → Privacy & Security → FileVault"
+tuck settings manual done macos__manual__enable-filevault
+```
+
+Captured settings live in `~/.tuck/os-settings.json` (committed and shared);
+per-machine manual-step completion and pre-apply backups live in the platform
+state dir, never in the repo. macOS is supported today; the backend is
+abstracted so Linux/dconf can be added later.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ tuck init --from github.com/you/dotfiles
 tuck restore --all
 ```
 
+### Safe first apply
+
+`tuck apply` never touches a fresh machine blind:
+
+- It **shows a full diff summary first** — every file that will be created (`new`) vs
+  overwritten (`update`), with a one-line count — before anything is written.
+- It **auto-creates a Time Machine snapshot** of every destination (including files it
+  is about to create) before applying.
+- After it finishes — and after any other destructive change (`tuck sync` conflict
+  resolution, `tuck remove --delete`) — it prints a one-line breadcrumb showing exactly
+  how to roll back:
+
+  ```
+  Undo this change: tuck undo 2026-07-09-101112  (or tuck undo --latest)
+  ```
+
+`tuck init` leads with the scan-based **"adopt the dotfiles already on this machine"**
+path, so the fastest way to get started is to track what you already have — no remote or
+templating concepts required.
+
 ### Onto a remote box (SSH)
 
 Push the configs this machine already tracks — your agent configs (`.claude`,

--- a/README.md
+++ b/README.md
@@ -257,6 +257,24 @@ values are resolved from the same secret backends tuck uses for dotfiles; if any
 can't be resolved, apply refuses to write rather than leak an unresolved token.
 Supported clients: Claude Desktop, Claude Code, Cursor, Windsurf, VS Code.
 
+### Agent-native automation
+
+tuck is safe to drive from AI agents, scripts, and CI. Every command supports:
+
+- `--json` — one stable JSON envelope on stdout (`{ ok, command, data | error }`); human output and color are suppressed, diagnostics go to stderr.
+- `--non-interactive` — never prompt; fail fast with a typed error (`OPERATION_CANCELLED`) instead of hanging. Implied by `--json` and by a non-TTY stdin.
+- `-y, --yes` — auto-confirm prompts. Combine with `--json` for full automation.
+
+ANSI color is stripped automatically when output is not a terminal, in `--json`
+mode, or when `NO_COLOR` is set. Errors carry machine-readable codes, actionable
+suggestions, and specific exit codes (`2` = not initialized, `3` = merge conflicts).
+
+```bash
+tuck status --json | jq '.data'
+tuck add ~/.zshrc --json --yes    # never hangs; fails fast if a prompt is needed
+```
+
+See [docs/AGENT-MODE.md](docs/AGENT-MODE.md) and [docs/ERROR_CODES.md](docs/ERROR_CODES.md) for the full contract.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ tuck is designed with security in mind:
 - **Fix, don't just block** — When a secret is flagged at `tuck add`/`tuck sync` time, choose to redact-and-store it (rewriting the tracked copy as a template) or mark a false positive as safe — no more disabling the whole check
 - **Centralized allowlist** — Mark scanner false positives once with `tuck secrets allow`; entries are stored (as fingerprints, never raw values) in a committed, reviewable `secrets.allow.json` instead of scattered inline ignore comments
 - **Runtime state isolation** — Audit logs, snapshots, and fallback keystore data live outside the tracked tuck repo
+- **Read-only commands never prompt** — `tuck status`, `tuck diff`, and `tuck list` are guaranteed never to unlock the keystore or contact a secret backend. Drift in encrypted files is detected with a machine-local keyed HMAC (zero decryptions), and the commands that do need the key unlock it **once per session**. See [docs/TEMPLATES-AND-ENCRYPTION.md](docs/TEMPLATES-AND-ENCRYPTION.md#read-only-commands-never-prompt).
 
 ```bash
 # Scan tracked files for secrets

--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ auth recommended). `tuck` does not need to be installed on the remote for a push
 
 ### Managing Files
 
+| Command                          | Description                                                      |
+| -------------------------------- | --------------------------------------------------------------- |
+| `tuck add <paths>`               | Manually track specific files                                   |
+| `tuck add <file> --key <path>`   | Track only a JSON subtree (e.g. `mcpServers`) — see [JSON-key tracking](docs/JSON-KEY-TRACKING.md) |
+| `tuck remove <paths>`            | Stop tracking files                                             |
+| `tuck scan`                      | Discover dotfiles without syncing                               |
+| `tuck list`                      | List all tracked files by category                              |
+| `tuck diff [file]`               | Show what's changed                                             |
+
+**JSON-key-scoped tracking** lets you track a *subtree* of a JSON file instead of
+the whole thing. `tuck add ~/.claude.json --key mcpServers` extracts only the
+`mcpServers` value into your repo; on `tuck apply`/`tuck restore` it is
+deep-merged back into the live file, leaving OAuth tokens, session caches, and
+every other machine-managed key untouched. See
+[docs/JSON-KEY-TRACKING.md](docs/JSON-KEY-TRACKING.md).
 | Command                     | Description                                           |
 | --------------------------- | ----------------------------------------------------- |
 | `tuck add <paths>`          | Manually track specific files                         |

--- a/README.md
+++ b/README.md
@@ -521,6 +521,8 @@ tuck is designed with security in mind:
 - **Placeholder support** — Replace secrets with `{{PLACEHOLDER}}` syntax
 - **External-first secrets** — `security.secretBackend` defaults to `auto`, preferring external password managers before local fallback
 - **Local fallback secrets** — Store actual values in `secrets.local.json` when needed; it is gitignored by default
+- **Fix, don't just block** — When a secret is flagged at `tuck add`/`tuck sync` time, choose to redact-and-store it (rewriting the tracked copy as a template) or mark a false positive as safe — no more disabling the whole check
+- **Centralized allowlist** — Mark scanner false positives once with `tuck secrets allow`; entries are stored (as fingerprints, never raw values) in a committed, reviewable `secrets.allow.json` instead of scattered inline ignore comments
 - **Runtime state isolation** — Audit logs, snapshots, and fallback keystore data live outside the tracked tuck repo
 
 ```bash
@@ -529,8 +531,23 @@ tuck secrets scan
 
 # Set a secret value locally
 tuck secrets set API_KEY
+
+# Mark a scanner false positive as safe (auditable, committed allowlist)
+tuck secrets allow add --file ~/.config/app.conf --reason "example value from docs"
+
+# Review or revoke allowlisted findings
+tuck secrets allow list
+tuck secrets allow remove <fingerprint>
 ```
 
+### The secret allowlist
+
+`secrets.allow.json` records findings you have deliberately marked safe (false
+positives or intentionally-tracked non-secrets). It stores only a SHA-256
+**fingerprint** of each value — never the value itself — so it is safe to commit
+and share with teammates. Every scan path (`tuck add`, `tuck sync`,
+`tuck secrets scan`, the MCP server) honors it, and each add/remove is recorded
+in the audit log.
 ### MCP secrets extraction
 
 MCP clients (Claude Desktop, Claude Code, Cursor, VS Code) often store API keys

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Supported managers: `brew`, `apt`, `dnf`, `pacman`, `winget`, `scoop`, `cargo`, 
 | Command             | Description                                                       |
 | ------------------- | ---------------------------------------------------------------- |
 | `tuck bundle`       | Manage bundles — logical groups of tracked files                 |
+| `tuck merge`        | Manage structured (JSON) three-way merge policies for tracked files |
 | `tuck profile`      | Profiles / tags — apply work/personal/server/agent subsets       |
 | `tuck encryption`   | Manage at-rest backup encryption (AES-256-GCM, password-based)   |
 | `tuck secrets`      | Manage local secrets / placeholder replacement                   |
@@ -468,6 +469,15 @@ Configure tuck via `~/.tuck/.tuckrc.json` or the interactive `tuck config` menu 
 
 - **copy** (default) — Files are copied. Run `tuck sync` to update the repo.
 - **symlink** — tuck copies the file into the repo, then replaces the original path with a symlink to the repo file. Changes are instant, but this modifies your home dotfile paths.
+
+### Structured JSON smart merge
+
+High-churn, tool-rewritten JSON configs (Claude Code `settings.json`, `.mcp.json`, …)
+are reconciled **key-by-key** on `tuck sync` instead of being overwritten — so two
+machines that each edit the same config have their changes unioned rather than one
+silently clobbering the other. Permission allowlists and plugin lists are unioned;
+genuine conflicts are surfaced, not guessed. Manage per-file policies with
+`tuck merge` (set/unset/list/show). See [docs/JSON-SMART-MERGE.md](docs/JSON-SMART-MERGE.md).
 
 ## Windows Support
 

--- a/docs/AGENT-MODE.md
+++ b/docs/AGENT-MODE.md
@@ -1,0 +1,140 @@
+# Agent-Native CLI
+
+tuck is designed to be driven safely by AI agents, scripts, and CI — not just
+humans at a terminal. This document is the contract for that automation surface:
+what to pass, what you get back, and how failures are reported.
+
+> The emerging bar for an agent-friendly CLI is: `--json` everywhere, a guaranteed
+> non-interactive path everywhere, and output schemas treated as stable contracts.
+> tuck follows that bar.
+
+---
+
+## The three flags that matter
+
+| Flag | Effect |
+|------|--------|
+| `--json` | Emit exactly one JSON envelope on **stdout** and nothing else. Human banners, spinners, and colored logs are suppressed; diagnostics go to **stderr**. |
+| `--non-interactive` | Never prompt. If a command would need to ask a question, it fails fast with a typed error instead of hanging. Implied by `--json` and by a non-TTY stdin. |
+| `-y, --yes` | Auto-confirm prompts (answer "yes"). Pair with `--json`/`--non-interactive` for full automation of commands that would otherwise ask for confirmation. |
+
+`--non-interactive` is a **global** flag: it can be placed before the subcommand
+(`tuck --non-interactive add ...`). `--json` and `--yes` are per-command.
+
+### When does tuck refuse to prompt?
+
+A prompt is refused (fail-fast) when **any** of these is true:
+
+1. `--non-interactive` was passed, or
+2. `--json` was passed (a prompt would corrupt the single-object stdout stream), or
+3. stdin is not a TTY (piped input, CI, an agent harness).
+
+In every one of those cases a required prompt raises `OPERATION_CANCELLED`
+(non-zero exit; a JSON error envelope under `--json`) rather than blocking.
+
+---
+
+## The JSON envelope
+
+Every `--json` invocation prints exactly one JSON object on stdout. The envelope
+is stable across versions — field semantics may grow but never shrink.
+
+**Success:**
+
+```json
+{ "ok": true, "command": "sync", "data": { "committed": true, "pushed": true }, "warnings": ["hook skipped"] }
+```
+
+**Failure:**
+
+```json
+{
+  "ok": false,
+  "command": "push",
+  "error": {
+    "code": "GIT_ERROR",
+    "message": "Git operation failed: push rejected: the remote has commits you do not have locally",
+    "hint": "Run `tuck pull` first to integrate the remote changes, then push again",
+    "suggestions": [
+      "Run `tuck pull` first to integrate the remote changes, then push again",
+      "Or use `tuck push --force` to overwrite the remote (use with caution — this can discard remote history)"
+    ],
+    "exit_code": 1
+  }
+}
+```
+
+- `command` — the full command path (e.g. `"secrets add"`).
+- `data` — command-specific, documented per command.
+- `warnings` — present only when non-fatal warnings were emitted.
+- `error.code` — a stable, machine-readable code (see [ERROR_CODES.md](./ERROR_CODES.md)).
+- `error.hint` — the single most useful suggestion (`suggestions[0]`).
+- `error.exit_code` — the process exit code that accompanies this error.
+
+Parse the **last non-empty line** of stdout as the envelope; diagnostics (which
+never go to stdout in JSON mode) will not interfere.
+
+---
+
+## Exit codes
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success |
+| `1` | Generic failure (most `TuckError`s) |
+| `2` | `NOT_INITIALIZED` — run `tuck init` first |
+| `3` | `MERGE_CONFLICTS` — a pull left unresolved conflicts |
+
+Agents can branch on the specific exit code without parsing text. The exit code
+is also carried in `error.exit_code` in the JSON envelope.
+
+---
+
+## Color / ANSI suppression
+
+tuck strips ANSI color codes automatically for machine consumers. Color is
+disabled when:
+
+- `--json` is set, or
+- `--non-interactive` is set, or
+- the `NO_COLOR` environment variable is set (any value), or
+- stdout is not a TTY.
+
+An explicit `FORCE_COLOR` (a truthy value) overrides all of the above and keeps
+color on — useful when capturing colorized output deliberately.
+
+---
+
+## Contextual git errors
+
+Network operations (`push`, `pull`, `fetch`) classify git's terse stderr into an
+actionable message plus suggestions. For example, a rejected push reports "the
+remote has commits you do not have locally" with `tuck pull` / `tuck push --force`
+suggestions rather than a bare "Failed to push". The raw git output is preserved
+internally for debugging (`DEBUG=1`).
+
+---
+
+## Example: driving tuck from an agent
+
+```bash
+# Fully non-interactive add: fails fast (never hangs) if anything needs a prompt.
+tuck add ~/.zshrc --json --yes
+
+# Read status as structured data.
+tuck status --json | jq '.data'
+
+# Push, and branch on the machine-readable error code.
+out=$(tuck push --json) || {
+  code=$(printf '%s' "$out" | tail -n1 | jq -r '.error.code')
+  case "$code" in
+    GIT_ERROR) echo "sync needed"; tuck pull --json --yes && tuck push --json ;;
+    NOT_INITIALIZED) tuck init --bare --json ;;
+    *) echo "unhandled: $code" >&2; exit 1 ;;
+  esac
+}
+```
+
+See also: [ERROR_CODES.md](./ERROR_CODES.md) for the full code table, and
+`tuck mcp` for the Model Context Protocol server that exposes tuck to agents over
+JSON-RPC.

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -122,7 +122,13 @@ Suggestions:
 
 Using `--force` to bypass secret scanning is logged to the audit trail for security tracking, which helps identify when potentially sensitive operations occurred. The active audit log lives in the platform state directory — on macOS `~/Library/Application Support/tuck/audit.log`, on Linux `$XDG_STATE_HOME/tuck/audit.log` (falling back to `~/.local/state/tuck/audit.log`). (`~/.tuck/audit.log` is the deprecated legacy location.)
 
-### Non-Interactive Mode (CI/Scripts)
+### Non-Interactive Mode (CI/Scripts/Agents)
+
+Pass `--non-interactive` (or `--json`, which implies it) to guarantee tuck never
+blocks on a prompt: any command that would need to ask a question fails fast with
+`OPERATION_CANCELLED` instead of hanging. This is also the default whenever stdin
+is not a TTY. Combine with `-y/--yes` to auto-confirm ordinary prompts. See
+[AGENT-MODE.md](./AGENT-MODE.md) for the full JSON-envelope and exit-code contract.
 
 When running tuck in non-interactive environments (CI pipelines, scripts), dangerous operations that normally require typed confirmation will fail by default.
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -44,6 +44,7 @@ This document lists all error codes used by tuck for programmatic error handling
 | `INVALID_REQUIREMENT` | `InvalidRequirementError` | A `requires:` dependency spec is malformed | Missing `<manager>:` prefix or unknown manager | Use `<manager>:<package>` (e.g. `brew:starship`) |
 | `CYCLIC_DEPENDENCY` | `CyclicDependencyError` | The `requires:` graph contains a cycle | A package/file dependency loops back on itself | Remove one edge so dependencies form a DAG |
 | `BOOTSTRAP_ERROR` | `BootstrapError` | `tuck bootstrap` could not complete a phase | Missing git, unclonable repo, or no manifest | Follow the error's suggestions and re-run (idempotent) |
+| `ALLOW_REASON_REQUIRED` | `TuckError` | `tuck secrets allow add` needs a reason | Ran non-interactively without `--reason` | Pass `--reason "<why safe>"` |
 
 ---
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -51,6 +51,10 @@ This document lists all error codes used by tuck for programmatic error handling
 | `SETTING_NOT_FOUND` | `SettingNotFoundError` | No tracked setting/manual step with that id | Wrong id passed to `remove`/`manual done` | Run `tuck settings list` to see valid ids |
 | `READ_ONLY_VIOLATION` | `ReadOnlyViolationError` | A read-only command (status/diff/list) attempted a secret/keystore operation | Bug — these commands guarantee zero prompts | Use `tuck apply`/`tuck sync`/`tuck verify` for operations that need secrets |
 | `JSON_KEY_ERROR` | `JsonKeyError` | JSON-key tracking (`--key`) could not extract/merge a subtree | Non-JSON file, missing key path, malformed path, non-object top level | Pass a dot-delimited key path present in a strict-JSON object file |
+| `RULES_MANIFEST_CORRUPT` | `TuckError` | `rules.json` is not valid JSON | Hand-edit corrupted the rules fan-out manifest | Fix or delete `~/.tuck/rules.json` and re-run `tuck rules track` |
+| `RULES_MANIFEST_INVALID` | `TuckError` | `rules.json` failed schema validation | Unsafe path override or missing repo root | Correct the manifest per the message |
+| `RULES_SET_NOT_FOUND` | `TuckError` | No tracked rule set with the given id | Wrong `--id` / untrack id | Run `tuck rules list` to see tracked sets |
+| `RULES_UNKNOWN_TOOL` | `TuckError` | Unknown `--tool` name | Typo or unsupported tool | Use one of the known tools listed in the hint |
 
 ---
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -46,6 +46,9 @@ This document lists all error codes used by tuck for programmatic error handling
 | `BOOTSTRAP_ERROR` | `BootstrapError` | `tuck bootstrap` could not complete a phase | Missing git, unclonable repo, or no manifest | Follow the error's suggestions and re-run (idempotent) |
 | `ALLOW_REASON_REQUIRED` | `TuckError` | `tuck secrets allow add` needs a reason | Ran non-interactively without `--reason` | Pass `--reason "<why safe>"` |
 | `JSON_MERGE_CONFLICTS` | `JsonMergeConflictsError` | Structured JSON merge left unresolved key conflicts (**exit code 3**) | Same JSON key set to different values on two machines | Run `tuck sync` interactively, or set a policy with `tuck merge set <file> --conflict ours\|theirs` |
+| `SETTINGS_UNSUPPORTED_OS` | `SettingsUnsupportedOsError` | `tuck settings` not supported on this OS | Running on a non-macOS platform | macOS is supported today; Linux/dconf is planned |
+| `SETTINGS_ERROR` | `SettingsError` | OS-settings operation failed | Missing capture flags, no TTY for interactive capture | Follow the message; pass `--domain/--key/--type/--value` for non-interactive capture |
+| `SETTING_NOT_FOUND` | `SettingNotFoundError` | No tracked setting/manual step with that id | Wrong id passed to `remove`/`manual done` | Run `tuck settings list` to see valid ids |
 
 ---
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -50,6 +50,7 @@ This document lists all error codes used by tuck for programmatic error handling
 | `SETTINGS_ERROR` | `SettingsError` | OS-settings operation failed | Missing capture flags, no TTY for interactive capture | Follow the message; pass `--domain/--key/--type/--value` for non-interactive capture |
 | `SETTING_NOT_FOUND` | `SettingNotFoundError` | No tracked setting/manual step with that id | Wrong id passed to `remove`/`manual done` | Run `tuck settings list` to see valid ids |
 | `READ_ONLY_VIOLATION` | `ReadOnlyViolationError` | A read-only command (status/diff/list) attempted a secret/keystore operation | Bug — these commands guarantee zero prompts | Use `tuck apply`/`tuck sync`/`tuck verify` for operations that need secrets |
+| `JSON_KEY_ERROR` | `JsonKeyError` | JSON-key tracking (`--key`) could not extract/merge a subtree | Non-JSON file, missing key path, malformed path, non-object top level | Pass a dot-delimited key path present in a strict-JSON object file |
 
 ---
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -49,6 +49,7 @@ This document lists all error codes used by tuck for programmatic error handling
 | `SETTINGS_UNSUPPORTED_OS` | `SettingsUnsupportedOsError` | `tuck settings` not supported on this OS | Running on a non-macOS platform | macOS is supported today; Linux/dconf is planned |
 | `SETTINGS_ERROR` | `SettingsError` | OS-settings operation failed | Missing capture flags, no TTY for interactive capture | Follow the message; pass `--domain/--key/--type/--value` for non-interactive capture |
 | `SETTING_NOT_FOUND` | `SettingNotFoundError` | No tracked setting/manual step with that id | Wrong id passed to `remove`/`manual done` | Run `tuck settings list` to see valid ids |
+| `READ_ONLY_VIOLATION` | `ReadOnlyViolationError` | A read-only command (status/diff/list) attempted a secret/keystore operation | Bug — these commands guarantee zero prompts | Use `tuck apply`/`tuck sync`/`tuck verify` for operations that need secrets |
 
 ---
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -45,6 +45,7 @@ This document lists all error codes used by tuck for programmatic error handling
 | `CYCLIC_DEPENDENCY` | `CyclicDependencyError` | The `requires:` graph contains a cycle | A package/file dependency loops back on itself | Remove one edge so dependencies form a DAG |
 | `BOOTSTRAP_ERROR` | `BootstrapError` | `tuck bootstrap` could not complete a phase | Missing git, unclonable repo, or no manifest | Follow the error's suggestions and re-run (idempotent) |
 | `ALLOW_REASON_REQUIRED` | `TuckError` | `tuck secrets allow add` needs a reason | Ran non-interactively without `--reason` | Pass `--reason "<why safe>"` |
+| `JSON_MERGE_CONFLICTS` | `JsonMergeConflictsError` | Structured JSON merge left unresolved key conflicts (**exit code 3**) | Same JSON key set to different values on two machines | Run `tuck sync` interactively, or set a policy with `tuck merge set <file> --conflict ours\|theirs` |
 
 ---
 

--- a/docs/JSON-KEY-TRACKING.md
+++ b/docs/JSON-KEY-TRACKING.md
@@ -1,0 +1,82 @@
+# JSON-Key-Scoped Tracking
+
+Track a **subtree** of a JSON file instead of the whole file.
+
+```bash
+tuck add ~/.claude.json --key mcpServers
+```
+
+tuck extracts only the value at the given key path into your repo. On
+`tuck apply` / `tuck restore` that subtree is **deep-merged** back into the live
+file, leaving every other key — OAuth tokens, session caches, conversation
+history, and any other machine-managed state — untouched.
+
+## Why
+
+Some config files are monoliths that mix durable, shareable configuration with
+per-machine state. `~/.claude.json`, for example, holds MCP server definitions
+(worth syncing across machines) right next to OAuth tokens, startup counters,
+and conversation history (must **never** be committed or copied between
+machines). Whole-file tracking or symlinking is impossible for these files —
+you would either leak secrets or clobber machine state. JSON-key tracking lets
+you sync just the part you care about.
+
+The same applies to `settings.json`-style files and any other mixed
+config/state JSON.
+
+## How it works
+
+| Stage | Behavior |
+| --- | --- |
+| `tuck add <file> --key <path>` | Extracts the subtree at `<path>` and stores **only that subtree** in the repo (canonical, key-sorted JSON). The manifest records `jsonKey`. |
+| `tuck status` / `tuck verify` | Compares only the tracked subtree of the live file against the repo copy. Editing an untracked key (e.g. rotating a token) is **not** reported as drift. |
+| `tuck sync` | Re-extracts **only** the subtree from the live file back into the repo. Keys outside the tracked path are never captured or committed. |
+| `tuck apply` / `tuck restore` | Deep-merges the repo subtree back into the live file at `<path>`, preserving every other key. |
+
+### Deep-merge semantics
+
+- **Objects** are merged recursively and key-wise: sibling keys inside the
+  subtree that exist in the live file but not the repo copy are preserved.
+- **Arrays** and **scalars** replace the value at the exact tracked path (they
+  are opaque — element identity is undefined for config arrays).
+- Only the value at the tracked path is ever touched. Everything else in the
+  file is preserved.
+
+### Key paths
+
+Key paths are dot-delimited and address object properties:
+
+```bash
+tuck add ~/.config/app/config.json --key editor.settings
+```
+
+The leaf value may be any JSON type (object, array, or scalar); intermediate
+nodes must be objects. Array indices are not addressable in this version.
+
+## Secrets
+
+The subtree — not the whole file — is scanned for secrets at `tuck add` time.
+This is deliberate: a token that lives **outside** the tracked key can never
+reach the repo, so it should not block tracking the safe subtree. Placeholders
+inside the tracked subtree are resolved from your configured secret backend on
+apply/restore, exactly like whole-file entries.
+
+## Constraints
+
+- The file must be **strict JSON** with a top-level object. Files with comments
+  or trailing commas (JSONC) are rejected rather than silently corrupted.
+- `--key` cannot be combined with `--symlink`, `--encrypt`, `--template`, or
+  `--repo` (the repo copy must stay a plain, mergeable JSON subtree).
+- The live file is rewritten as 2-space-indented JSON on apply/restore. Key
+  **values** are preserved exactly; only whitespace formatting is normalized.
+
+## Example
+
+```bash
+# Track just the MCP server config from Claude Code's monolithic config.
+tuck add ~/.claude.json --key mcpServers
+tuck sync
+
+# On another machine, after cloning your dotfiles:
+tuck apply <you>        # merges mcpServers in; your local token stays put
+```

--- a/docs/JSON-SMART-MERGE.md
+++ b/docs/JSON-SMART-MERGE.md
@@ -1,0 +1,120 @@
+# Structured JSON Smart Merge
+
+tuck can reconcile high-churn, tool-rewritten JSON config files **key-by-key**
+instead of overwriting them wholesale. This is what makes syncing agent configs
+(Claude Code `settings.json`, `.mcp.json`, …) across machines safe: two machines
+can each mutate the same config and `tuck sync` unions their changes rather than
+silently keeping whichever synced last.
+
+## The problem it solves
+
+Agent tools constantly rewrite their own configuration — Claude Code appends
+permission entries, MCP servers get added, plugin lists grow. With a naive
+push/pull, this happens:
+
+1. Machine **A** adds a permission and syncs → the repo has A's version.
+2. Machine **B**'s agent independently added a different permission locally.
+3. Machine **B** runs `tuck sync`. It pulls A's version, then captures B's live
+   file back into the repo — **silently discarding A's permission**.
+
+A three-way merge, using the last-synced version as the common ancestor,
+recovers **both** sides' additions and only stops for a genuine conflict (the
+same key set to two different values).
+
+## How it works
+
+During `tuck sync`, when a merge-policy file was **modified locally** and the
+pull brought a **new version of the same file**, tuck performs a three-way
+merge:
+
+- **base** — the repo copy captured immediately before the pull (the state this
+  machine last synced from).
+- **ours** — your current live file.
+- **theirs** — the repo copy after the pull (the incoming version).
+
+The merged result is written to **both** the live file and the repo copy, so the
+two machines converge. A Time Machine snapshot of the live file is taken first,
+so `tuck undo` can always recover the pre-merge version.
+
+If a side is not valid JSON, tuck cannot smart-merge it and falls back to keeping
+your local version (with a warning) — never a silent data loss.
+
+## What gets a policy automatically
+
+These filenames are treated as structured-merge files out of the box (safe
+`union` arrays, `manual` conflict handling):
+
+- `settings.json`, `settings.local.json` (Claude Code / editor settings)
+- `.mcp.json`, `mcp.json` (Model Context Protocol servers)
+- `.claude.json`
+
+Everything else uses plain copy semantics unless you opt in.
+
+## `tuck merge` — manage policies
+
+```bash
+# Show every file with an effective merge policy (auto or explicit)
+tuck merge list
+
+# Show one file's effective policy
+tuck merge show ~/.claude/settings.json
+
+# Opt a file into structured merge (defaults: json, arrays=union, conflict=manual)
+tuck merge set ~/.config/app/config.json
+
+# Tune the strategies
+tuck merge set ~/.config/app/config.json --arrays concat --conflict theirs
+
+# Remove an explicit policy (reverts to auto-detected default, or none)
+tuck merge unset ~/.config/app/config.json
+```
+
+All subcommands accept `--json` for machine-readable output.
+
+### Array strategies (`--arrays`)
+
+| Value     | Behavior                                                                 |
+| --------- | ------------------------------------------------------------------------ |
+| `union`   | Combine both sides, dropping deep-duplicate entries (default). Ideal for allowlists. |
+| `concat`  | Append both sides verbatim, keeping duplicates.                          |
+| `replace` | Treat a diverged array as a scalar conflict (resolved via `--conflict`). |
+
+> Note: `union` combines both sides and does not attempt to honor a deletion
+> made on only one side — a removed allowlist entry that the other machine still
+> has will be re-added. This is the safe default for permission/plugin lists.
+
+### Conflict resolution (`--conflict`)
+
+Applies when both sides changed the **same scalar leaf** to different values (or
+when an array is under `replace`):
+
+| Value    | Behavior                                                          |
+| -------- | ----------------------------------------------------------------- |
+| `ours`   | Always keep the local value.                                      |
+| `theirs` | Always take the incoming value.                                   |
+| `manual` | Surface the conflict and stop instead of guessing (default).      |
+
+With `manual`, an interactive `tuck sync` prompts you to keep local, take
+incoming, or abort. A non-interactive sync (`--json` / `--yes`) exits with code
+`3` and a `JSON_MERGE_CONFLICTS` error listing the conflicting JSON paths, so
+automation can detect and report it.
+
+## Example
+
+`~/.claude/settings.json` on two machines, both starting from
+`{ "permissions": { "allow": ["Read"] } }`:
+
+- Machine A adds `WebFetch` → syncs.
+- Machine B's agent adds `Bash(git:*)` locally, then runs `tuck sync`.
+
+Result on both machines after B syncs:
+
+```json
+{
+  "permissions": {
+    "allow": ["Read", "Bash(git:*)", "WebFetch"]
+  }
+}
+```
+
+No data lost, no manual intervention.

--- a/docs/OS-SETTINGS.md
+++ b/docs/OS-SETTINGS.md
@@ -1,0 +1,126 @@
+# `tuck settings` — versioned OS settings
+
+`tuck settings` replaces the undocumented, silently-breaking `.macos` bootstrap
+script that every dotfiles guide reinvents. Instead of hand-writing
+`defaults write` incantations and hoping they still work three macOS releases
+later, you:
+
+1. **Capture** a setting by changing it in the GUI while tuck diffs the affected
+   `defaults` domains and records the exact write command plus the macOS version
+   it was captured on.
+2. **Apply** the captured settings on another machine, with per-OS-version
+   guards so a setting is skipped when the current OS is out of its supported
+   range, and affected apps are restarted automatically.
+3. Track a **manual-steps checklist** for things that can't be automated
+   ("do-nothing scripting"): tuck shows the instruction, you confirm it's done,
+   and tuck remembers that per machine.
+
+macOS (`defaults`) is the only backend in v1. The module is backend-abstracted
+(`src/lib/osSettings/`) so a Linux/dconf backend can be added later without
+touching the command layer.
+
+## Where data lives
+
+| Artifact | Location | Committed? |
+| --- | --- | --- |
+| Captured settings + manual-step definitions | `~/.tuck/os-settings.json` | Yes — shared across machines |
+| Manual-step completion (per machine) | platform state dir `.../tuck/os-settings-state.json` | No |
+| Pre-apply domain backups | platform state dir `.../tuck/os-settings-backups/<timestamp>/` | No |
+
+`os-settings.json` is picked up by `tuck sync`/`tuck push` like any other file in
+the repo. The machine-local state and backups deliberately stay out of the repo.
+
+## Commands
+
+### `tuck settings capture [description]`
+
+Interactive (diff) mode:
+
+```bash
+# Watch a specific domain (recommended — fast and precise)
+tuck settings capture "Auto-hide the Dock" --domain com.apple.dock --restart Dock
+# tuck snapshots the domain, prompts you to change the setting in System
+# Settings, snapshots again, and records the diff as a `defaults write`.
+```
+
+If you omit `--domain`, tuck snapshots **all** domains before and after — slower,
+but useful when you don't know which domain a toggle writes to.
+
+Direct (non-interactive/scriptable) mode records a known key without diffing:
+
+```bash
+tuck settings capture \
+  --domain com.apple.dock --key autohide --type boolean --value true \
+  --restart Dock
+```
+
+Options:
+
+- `-d, --domain <domain>` — domain to watch/record (repeatable; default: all)
+- `-k, --key <key>` — preference key (direct mode)
+- `-t, --type <boolean|integer|float|string|date>` — value type (direct mode)
+- `--value <value>` — value to record (direct mode)
+- `--delete` — record a key deletion instead of a write
+- `-m, --description <text>` — human description
+- `--min-version <v>` / `--max-version <v>` — inclusive OS-version guard for apply
+- `--restart <apps>` — comma-separated apps to restart on apply (e.g. `Dock,Finder`)
+- `-y, --yes` — skip confirmation prompts
+- `--json` — machine-readable envelope
+
+Only scalar `defaults` types (boolean/integer/float/string/date) are captured
+automatically. If a change writes a complex container (dict/array) or opaque
+data, tuck surfaces it and suggests recording a manual step instead.
+
+### `tuck settings apply`
+
+Replays tracked settings for the current OS, honoring each setting's version
+guard, backing up every affected domain first, and restarting the apps each
+applied setting declares.
+
+```bash
+tuck settings apply --dry-run   # preview: shows the exact defaults commands
+tuck settings apply             # apply (asks for confirmation in a TTY)
+```
+
+Options:
+
+- `--id <id>` — only apply this setting id (repeatable)
+- `--dry-run` — show what would change without changing anything
+- `--no-restart` — do not restart affected apps
+- `-y, --yes` — skip the confirmation prompt
+- `--json` — machine-readable envelope
+
+Skipped settings (version guard failed) and pending manual steps are reported so
+nothing is silently dropped.
+
+### `tuck settings list`
+
+Shows tracked settings and the manual-steps checklist, including whether each
+manual step is done on this machine. `--json` emits the full manifest.
+
+### `tuck settings remove <id>`
+
+Untracks a captured setting. Find ids with `tuck settings list`.
+
+### `tuck settings manual …`
+
+- `tuck settings manual add "<title>" -i "<instructions>"` — add a manual step
+- `tuck settings manual list` — list steps with per-machine completion
+- `tuck settings manual done <id>` — mark done on this machine
+- `tuck settings manual reset <id>` — mark not done on this machine
+
+```bash
+tuck settings manual add "Enable FileVault" \
+  -i "System Settings → Privacy & Security → FileVault → Turn On"
+tuck settings manual done macos__manual__enable-filevault
+```
+
+## Safety
+
+- Every real apply writes a backup of each affected domain (`defaults export`)
+  to the state dir before mutating it.
+- Apply prompts for confirmation in an interactive terminal; use `-y/--yes` or
+  `--json` for non-interactive runs, or `--dry-run` to preview.
+- All `defaults`/`sw_vers`/`killall` calls pass arguments as discrete argv
+  entries (never through a shell), so domain/key/value strings can't be
+  interpreted as shell syntax.

--- a/docs/RULES-FANOUT.md
+++ b/docs/RULES-FANOUT.md
@@ -1,0 +1,160 @@
+# Rules Fan-Out — one canonical file, many tool variants
+
+`tuck rules` keeps a single canonical rules/instructions file (e.g. `AGENTS.md`)
+as the source of truth and fans it out on demand into every tool-specific file
+your AI agents look for:
+
+| Tool key      | Destination                          |
+| ------------- | ------------------------------------ |
+| `claude`      | `CLAUDE.md`                          |
+| `cursor`      | `.cursorrules`                       |
+| `cursor-dir`  | `.cursor/rules/tuck.mdc`             |
+| `windsurf`    | `.windsurfrules`                     |
+| `copilot`     | `.github/copilot-instructions.md`    |
+| `gemini`      | `GEMINI.md`                          |
+| `agents`      | `AGENTS.md`                          |
+
+No more copying the same paragraph into five files and losing track of which one
+is canonical. tuck's repo-scoped tracking plus its template engine mean the whole
+set stays in lockstep — globally (`$HOME`) or per repo — with per-tool overrides.
+
+## Why
+
+> Teams "copy the same paragraph into five files, forget which one is canonical,
+> and six weeks later the agents are following conflicting orders."
+
+tuck owns the canonical file and regenerates the rest, so drift is visible
+(`tuck rules list`) and one command (`tuck rules apply`) reconciles it.
+
+## Quick start
+
+```bash
+# Track a canonical rules file. Scope is auto-detected: inside a git repo →
+# repo-scoped (variants land in the repo root); otherwise → home-scoped
+# (variants land in $HOME). With no --tool, every applicable tool is selected.
+tuck rules track ~/AGENTS.md
+
+# See what's tracked and how each variant currently compares on disk.
+tuck rules list
+
+# Materialize (or symlink) each variant from the canonical source.
+tuck rules apply
+```
+
+## Per-tool overrides via templating
+
+The canonical file is rendered through tuck's template engine on `apply`, with a
+`tool` variable bound to the target. Use it to include tool-specific sections
+while keeping one source:
+
+```md
+# Team Rules
+
+Always write tests before implementation.
+
+{{#if tool == "cursor"}}
+When editing, prefer `.cursor/rules` glob scoping.
+{{/if}}
+
+{{#if tool == "claude"}}
+Follow the conventions in this repo's CLAUDE.md exactly.
+{{/if}}
+```
+
+`CLAUDE.md` keeps only the `claude` block, `.cursorrules` keeps only the `cursor`
+block, and so on. The same `{{var}}`, `{{var | default "x"}}`, `os`/`arch`/env
+context and `# tuck:if` comment markers documented in
+[TEMPLATES-AND-ENCRYPTION.md](./TEMPLATES-AND-ENCRYPTION.md) are available; pass
+extra variables with `--var key=value`. Disable rendering entirely with
+`--no-template` (the source is copied verbatim to every variant).
+
+## Commands
+
+### `tuck rules track <path>`
+
+Designate a canonical rules file and its fan-out targets. Records the set in
+`~/.tuck/rules.json`; writes **no** tool variants (that's `apply`).
+
+| Flag                    | Meaning                                                        |
+| ----------------------- | ------------------------------------------------------------- |
+| `-t, --tool <name...>`  | Fan-out targets (space- or comma-separated). Default: all applicable tools. |
+| `--symlink`             | Symlink each variant at the source instead of materializing.  |
+| `--no-template`         | Copy the source verbatim; do not render templates on apply.   |
+| `--var <key=value...>`  | Extra template variables.                                     |
+| `--json`                | Emit a JSON envelope.                                          |
+
+The tool whose default destination *is* the canonical source is skipped
+automatically (tracking `AGENTS.md` won't fan `agents` → `AGENTS.md` onto
+itself). Re-running `track` on the same source updates its tool list in place.
+
+### `tuck rules list`
+
+Show every tracked set and, per tool, its status: `missing`, `in-sync`, `drift`
+(materialized content differs from the current render), or `foreign` (a real file
+where a symlink is expected, or vice-versa). `--json` for machine output.
+
+### `tuck rules apply`
+
+Materialize or symlink each variant from its canonical source.
+
+| Flag          | Meaning                                                              |
+| ------------- | ------------------------------------------------------------------- |
+| `--id <id>`   | Only apply the set with this id (see `tuck rules list`).             |
+| `--dry-run`   | Show what would change without writing.                             |
+| `-f, --force` | Overwrite differing variants without confirmation.                  |
+| `-y, --yes`   | Run non-interactively (undecided overwrites are skipped, not forced).|
+| `--json`      | Emit a JSON envelope.                                               |
+
+Safety:
+
+- **Snapshot first.** Any existing variant that would change is captured in a
+  Time Machine snapshot before it is touched (`tuck undo --latest` restores it).
+- **Never clobber silently.** A variant that already matches is left untouched.
+  A variant that differs is only overwritten with an interactive "yes" or
+  `--force`; otherwise it is reported as `skipped (differs (declined))`.
+- **Sandbox-aware.** All writes route through tuck's write context, so
+  `tuck --root <dir> rules apply` confines every variant under `<dir>`.
+
+`materialize` (the default) writes a real file and supports per-tool templating.
+`symlink` links the variant at the canonical source: always byte-identical, so
+per-tool overrides do **not** apply — pick it when every tool should read the
+exact same bytes.
+
+### `tuck rules untrack <id>`
+
+Stop tracking a set. Add `--clean` to also delete the generated variants from
+disk (confirmed unless `--yes`).
+
+## Data model
+
+`~/.tuck/rules.json` (validated by a zod schema on every load):
+
+```json
+{
+  "version": "1",
+  "sets": {
+    "home__agents.md": {
+      "source": "~/AGENTS.md",
+      "scope": "home",
+      "template": true,
+      "tools": [
+        { "tool": "claude", "strategy": "materialize" },
+        { "tool": "cursor", "strategy": "materialize" }
+      ],
+      "variables": {},
+      "added": "2026-07-09T00:00:00.000Z",
+      "modified": "2026-07-09T00:00:00.000Z"
+    }
+  }
+}
+```
+
+Repo-scoped sets additionally store the absolute `repoRoot` and identify the set
+by a machine-independent key, so the same manifest works across machines.
+
+## Notes & limitations
+
+- `tuck rules apply` is its own explicit step. Wiring rule fan-out into the
+  top-level `tuck apply` flow is a planned follow-up.
+- A tool's destination can be overridden per set with a `path` field in
+  `rules.json` (relative, non-escaping); a CLI flag for this is a follow-up.

--- a/docs/RULES-FANOUT.md
+++ b/docs/RULES-FANOUT.md
@@ -149,11 +149,29 @@ disk (confirmed unless `--yes`).
 }
 ```
 
-Repo-scoped sets additionally store the absolute `repoRoot` and identify the set
-by a machine-independent key, so the same manifest works across machines.
+Repo-scoped sets additionally store the **absolute** `repoRoot`, and their set id
+embeds that absolute path. This means repo-scoped sets are **machine-dependent**:
+the manifest is portable text, but a repo-scoped set only applies on a machine
+where the same absolute `repoRoot` exists and is a real git checkout. On apply,
+each repo-scoped set's `repoRoot` is validated (it must be an existing directory
+containing a `.git` entry, and may never be the filesystem root or your home
+directory); a set whose `repoRoot` fails validation — e.g. because that path does
+not exist on this machine — is **skipped with a warning**, and `tuck rules apply`
+exits non-zero while still applying every other valid set. Home-scoped sets are
+machine-independent (they resolve against `$HOME`). Cross-machine repo-scoped
+fan-out (identifying repos by a stable, path-independent key) is a follow-up.
 
 ## Notes & limitations
 
+- Applying is **per-set isolated**: one set failing (missing source, unusable
+  `repoRoot`) never blocks the others. Failures are reported and the command
+  exits non-zero.
+- A tool whose destination would be the canonical source itself (e.g. tracking
+  `AGENTS.md` and asking for the `agents` tool) is **rejected at track time** —
+  it would otherwise destroy the source on apply.
+- Re-tracking a set with a **smaller** tool list cleans up the variants for the
+  dropped tools (confirmed unless `--yes`; foreign/hand-edited files are left in
+  place).
 - `tuck rules apply` is its own explicit step. Wiring rule fan-out into the
   top-level `tuck apply` flow is a planned follow-up.
 - A tool's destination can be overridden per set with a `path` field in

--- a/docs/TEMPLATES-AND-ENCRYPTION.md
+++ b/docs/TEMPLATES-AND-ENCRYPTION.md
@@ -66,6 +66,47 @@ If no password is configured, `tuck add --encrypt` fails with a clear message ra
 committing plaintext. A file can be **both** encrypted and a template — apply decrypts first,
 then renders.
 
+## Read-only commands never prompt
+
+**`tuck status`, `tuck diff`, and `tuck list` are guaranteed never to unlock the
+keystore or contact a secret backend (1Password / Bitwarden / pass / local
+external).** They only read what is already on disk, so they can never trigger a
+biometric/password prompt — no matter how many encrypted files you track. This is
+the difference other managers stumble on, where "every command wanted me to log in
+to my password manager."
+
+How the guarantee is kept:
+
+- These commands enter a process-wide **read-only mode**. In that mode the keystore
+  accessor returns a value already cached in the process (or nothing) without ever
+  touching the OS keychain, and the secret resolver refuses to reach a backend
+  (a stray attempt throws `READ_ONLY_VIOLATION` rather than prompting).
+- Drift in **encrypted** files is detected with a **keyed HMAC** instead of a
+  decryption. A full command (`tuck verify`, and any non-read-only state check)
+  records a machine-local HMAC of the last-known-good plaintext, pinned to the
+  repo copy it came from. `tuck status`/`tuck diff` then HMAC the *live* bytes and
+  compare — zero decryptions, zero keystore access.
+  - The HMAC key and cache live in tuck's per-machine state dir (never in the repo
+    and never pushed to git). Keying — rather than a plain checksum — means the
+    fingerprint reveals nothing about the secret to anyone who doesn't already hold
+    the local key.
+  - Until the cache has been warmed for a given encrypted file, read-only commands
+    report it as **unchanged** rather than guessing (they never emit a false drift
+    and never decrypt to find out). Run **`tuck verify`** once to warm the cache;
+    after that `tuck status` detects local edits to encrypted files offline.
+  - `tuck diff` on a changed encrypted file reports *that* it changed but withholds
+    the line-level diff (showing it would require decrypting the repo copy). Run
+    `tuck verify` or `tuck apply` for a full comparison.
+- Pure (non-encrypted) template files touch no secret, so read-only commands render
+  them directly as before.
+
+### One prompt per session
+
+For the commands that *do* need the encryption key (`tuck apply`, `tuck restore`),
+the unlocked passphrase is cached in memory for the process with a TTL, so a run
+that decrypts many files unlocks the keystore **at most once** — one prompt per
+session, not one per file.
+
 ## Limitations
 
 - Template/encrypted files are **copy-only** — they cannot use the symlink strategy (a symlink

--- a/docs/VALUE-ENCRYPTION.md
+++ b/docs/VALUE-ENCRYPTION.md
@@ -1,0 +1,118 @@
+# Value-Level (SOPS-Style) Encryption
+
+tuck can encrypt **only the secret values** inside a config file while leaving
+keys, structure, whitespace, and comments in plaintext. This is the same idea
+[SOPS](https://github.com/getsops/sops) made popular for infrastructure configs,
+brought to dotfiles.
+
+Because only the value changes, an encrypted file stays **diffable and
+mergeable**:
+
+```diff
+ # ~/.env
+ AWS_REGION=us-east-1
+-AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
++AWS_SECRET_ACCESS_KEY=ENC[tuck:v1:AAknwO2INTZ4mT9hFXgZ6ux2Mki...]
+```
+
+`git diff`, `git merge`, and code review keep working on the file — you can see
+exactly which keys changed, review structure changes, and resolve conflicts,
+without ever exposing the plaintext secret. This is the property whole-file
+encryption (git-crypt, `tuck add --encrypt`) throws away.
+
+## How it differs from the other secret features
+
+| Feature | Repo copy holds | Good for |
+| --- | --- | --- |
+| `{{PLACEHOLDER}}` (redaction) | a placeholder; value stored in a backend/local store | resolving a value from 1Password/Bitwarden/pass on apply |
+| `tuck add --encrypt` (whole-file) | opaque `TCKE2` ciphertext for the whole file | files that are *entirely* sensitive (`.netrc`) |
+| **value-level encryption** | plaintext structure with inline `ENC[tuck:v1:…]` tokens | configs that are mostly plaintext with a few secret values, where you still want diffs |
+
+## Quick start
+
+```bash
+# One-time: configure the encryption password in your OS keystore.
+tuck encryption setup
+
+# Encrypt every detected secret value across a file (or all tracked files).
+tuck secrets encrypt ~/.env
+
+# IMPORTANT: encrypt rewrites the LIVE file; the tracked repo copy under
+# ~/.tuck still holds plaintext until a sync captures the encrypted version.
+tuck sync
+
+# ... commit / push the file with encrypted values ...
+git -C ~/.tuck add . && git -C ~/.tuck commit -m "rotate keys"
+
+# On another machine (or to use the values locally): decrypt back to plaintext.
+tuck secrets decrypt ~/.env
+```
+
+`tuck secrets encrypt` uses tuck's secret **scanner** to locate the value spans,
+then replaces each span with a self-contained ciphertext token. With no path
+arguments it operates on **all tracked files**; pass explicit paths to scope it.
+
+## The token format
+
+Each encrypted value becomes an inline token:
+
+```
+ENC[tuck:v1:<base64>]
+```
+
+The base64 payload is self-contained — it carries its own PBKDF2 iteration count,
+salt, AES-GCM nonce, and authentication tag — so every value decrypts
+independently. A three-way merge that moves or reorders lines can never corrupt a
+value, and re-encrypting a file leaves already-encrypted tokens **byte-for-byte
+unchanged** for clean diffs.
+
+Crypto: **PBKDF2-HMAC-SHA256** (600,000 iterations, OWASP-recommended) derives a
+256-bit key; **AES-256-GCM** encrypts each value under a unique 96-bit nonce.
+Within one `encrypt` run the key is derived once for all values.
+
+## The password
+
+Value encryption reuses the single **encryption password** that
+`tuck encryption setup` stores in your OS keystore (macOS Keychain, libsecret,
+Windows Credential Manager, or the encrypted fallback) — the same password
+`tuck add --encrypt` and `tuck apply` use for whole-file decryption.
+
+Resolution order:
+
+1. `TUCK_ENCRYPTION_PASSWORD` environment variable (for CI — never put it in argv)
+2. the OS keystore
+3. an interactive prompt
+
+If none is available in non-interactive mode, the command fails with a clear
+message rather than guessing.
+
+## Safety
+
+- **Snapshot first** — every `encrypt`/`decrypt` takes a Time Machine snapshot of
+  the target files before mutating them, so `tuck undo` can revert.
+- **Atomic writes** — files are written via a temp-file + rename, so a crash never
+  leaves a truncated file.
+- **Confirmation** — interactive runs confirm before rewriting files. Use `--yes`
+  (or `--json`) for non-interactive use.
+- **Never leaks values** — human and `--json` output only ever report counts and
+  paths, never the plaintext.
+
+## Scope (v1)
+
+- Works on any UTF-8 text file; it is designed for and tested against **env-style**
+  (`KEY=value`) and **JSON** configs. The base64 token alphabet is safe inside both
+  env values and JSON strings.
+- The commands are **manual and explicit** (`tuck secrets encrypt` /
+  `tuck secrets decrypt`). A typical workflow is to encrypt before committing and
+  decrypt after pulling.
+
+### Deferred to a later iteration
+
+- **Automatic decrypt-on-apply / sync integration.** A future `valueEncrypted`
+  manifest flag would let `tuck apply`/`tuck restore` decrypt tokens automatically
+  and stop `tuck sync` from capturing plaintext back into the repo (the same
+  one-directional model whole-file encryption uses today). Until then, run
+  `tuck secrets decrypt` explicitly.
+- **YAML/TOML-aware value detection.** v1 relies on the generic secret scanner to
+  find spans; format-aware value selection is future work.
+```

--- a/docs/VALUE-ENCRYPTION.md
+++ b/docs/VALUE-ENCRYPTION.md
@@ -97,6 +97,37 @@ message rather than guessing.
 - **Never leaks values** — human and `--json` output only ever report counts and
   paths, never the plaintext.
 
+## Security notes
+
+### No context binding (token transplant)
+
+Each `ENC[tuck:v1:…]` token is authenticated with AES-GCM, so tampering with a
+token's *bytes* is detected — decryption fails loudly. What the auth tag does
+**not** cover is the token's **context**: it authenticates only the encrypted
+value, not the key name it sits beside or the file it lives in. tuck's tokens
+carry no associated data (AAD) and there is no file-level MAC (the mechanism
+[SOPS](https://github.com/getsops/sops) uses to bind every value to the file).
+
+The practical consequence: an attacker who already has **write access to the
+repo** can move a valid token from one place to another — swap two keys' values,
+or copy a token between files — and it will still decrypt cleanly under the
+correct passphrase. Because the value was legitimately encrypted, nothing at
+decrypt time flags the substitution.
+
+- This is **not** a confidentiality break: the attacker never learns any
+  plaintext, and cannot forge a token for a value they don't already have in
+  ciphertext.
+- The token format is intentionally frozen for v1 compatibility, so context
+  binding is **not** added by changing the token.
+- **Mitigation:** a transplant is a change to tracked files, so it shows up in
+  `git diff` and `git log`. Review diffs and protect the repo's write access
+  (branch protection, signed commits, trusted remotes) — the same discipline that
+  protects any config in version control.
+
+If you need cryptographic guarantees against reordering/transplant within a
+single file, use whole-file encryption (`tuck add --encrypt`) for that file
+instead, at the cost of losing per-value diffs.
+
 ## Scope (v1)
 
 - Works on any UTF-8 text file; it is designed for and tested against **env-style**

--- a/docs/man/tuck.1.md
+++ b/docs/man/tuck.1.md
@@ -25,6 +25,7 @@ tuck is a modern dotfiles manager that provides a beautiful CLI for managing you
 * **bootstrap**: One-command, idempotent machine setup (install packages, apply dotfiles, run doctor)
 * **undo**: Restore files from a Time Machine backup snapshot
 * **scan**: Scan the system for dotfiles and select which to track
+* **secrets**: Manage local secrets, backends, and the allowlist for placeholder replacement. Subcommands include **secrets allow add|list|remove** to manage a committed, auditable allowlist of scanner false positives (stored as fingerprints in *secrets.allow.json*, never raw values)
 * **secrets**: Manage local secrets for placeholder replacement (incl. `secrets extract --mcp` to pull inline credentials out of MCP config files)
 * **encryption**: Manage backup encryption (AES-256-GCM, password-based)
 * **doctor**: Run repository health and safety diagnostics

--- a/docs/man/tuck.1.md
+++ b/docs/man/tuck.1.md
@@ -10,6 +10,9 @@ tuck [command] [options]
 tuck is a modern dotfiles manager that provides a beautiful CLI for managing your configuration files across machines.
 
 ## COMMANDS
+* **init**: Initialize tuck
+* **add**: Track new dotfiles (use `--key <json.path>` to track only a JSON subtree, deep-merged back on apply/restore)
+* **remove**: Stop tracking dotfiles
 * **init**: Initialize tuck (leads with the scan-based "adopt existing dotfiles" path)
 * **add**: Track new dotfiles
 * **remove**: Stop tracking dotfiles (snapshots the repo copy before **--delete**)
@@ -21,12 +24,9 @@ tuck is a modern dotfiles manager that provides a beautiful CLI for managing you
 * **list**: List all tracked files
 * **diff**: Show differences between system and repository
 * **config**: Manage tuck configuration
-<<<<<<< HEAD
 * **apply**: Apply dotfiles from a repository to this machine (shows a full diff summary and auto-creates a snapshot before touching anything)
-=======
 * **apply**: Apply dotfiles from a repository to this machine, or push locally-tracked configs onto a remote box with **--target ssh://[user@]host** (or **--ssh host**); **--print-bootstrap** prints a remote install-and-apply one-liner
 * **bootstrap**: One-command, idempotent machine setup (install packages, apply dotfiles, run doctor)
->>>>>>> origin/development
 * **undo**: Restore files from a Time Machine backup snapshot
 * **scan**: Scan the system for dotfiles and select which to track
 * **secrets**: Manage local secrets, backends, and the allowlist for placeholder replacement. Subcommands include **secrets allow add|list|remove** to manage a committed, auditable allowlist of scanner false positives (stored as fingerprints in *secrets.allow.json*, never raw values)

--- a/docs/man/tuck.1.md
+++ b/docs/man/tuck.1.md
@@ -38,6 +38,10 @@ tuck is a modern dotfiles manager that provides a beautiful CLI for managing you
 ## OPTIONS
 * **-h, --help**: Show help
 * **-v, --version**: Show version
+* **--non-interactive**: Never prompt; fail fast with a typed error if a prompt would be required. Implied by **--json** and by a non-TTY stdin. Pair with **-y, --yes** to auto-confirm.
+* **--json**: (per-command) Emit a single stable JSON envelope on stdout for agents/CI; suppresses human output and color.
+* **-y, --yes**: (per-command) Auto-confirm prompts.
+* **--root** *dir*: Confine all writes under *dir* (sandbox / dry-home mode; also **TUCK_TARGET_ROOT**).
 
 ## FILES
 * `~/.tuck`: Default tuck directory

--- a/docs/man/tuck.1.md
+++ b/docs/man/tuck.1.md
@@ -10,9 +10,9 @@ tuck [command] [options]
 tuck is a modern dotfiles manager that provides a beautiful CLI for managing your configuration files across machines.
 
 ## COMMANDS
-* **init**: Initialize tuck
+* **init**: Initialize tuck (leads with the scan-based "adopt existing dotfiles" path)
 * **add**: Track new dotfiles
-* **remove**: Stop tracking dotfiles
+* **remove**: Stop tracking dotfiles (snapshots the repo copy before **--delete**)
 * **sync**: Sync all dotfile changes (pull, detect, scan, track, commit, push)
 * **push**: Push changes to remote
 * **pull**: Pull changes from remote
@@ -21,8 +21,12 @@ tuck is a modern dotfiles manager that provides a beautiful CLI for managing you
 * **list**: List all tracked files
 * **diff**: Show differences between system and repository
 * **config**: Manage tuck configuration
+<<<<<<< HEAD
+* **apply**: Apply dotfiles from a repository to this machine (shows a full diff summary and auto-creates a snapshot before touching anything)
+=======
 * **apply**: Apply dotfiles from a repository to this machine, or push locally-tracked configs onto a remote box with **--target ssh://[user@]host** (or **--ssh host**); **--print-bootstrap** prints a remote install-and-apply one-liner
 * **bootstrap**: One-command, idempotent machine setup (install packages, apply dotfiles, run doctor)
+>>>>>>> origin/development
 * **undo**: Restore files from a Time Machine backup snapshot
 * **scan**: Scan the system for dotfiles and select which to track
 * **secrets**: Manage local secrets, backends, and the allowlist for placeholder replacement. Subcommands include **secrets allow add|list|remove** to manage a committed, auditable allowlist of scanner false positives (stored as fingerprints in *secrets.allow.json*, never raw values)

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -87,6 +87,10 @@ const addFiles = async (
       trackedFile.name = f.nameOverride;
     }
 
+    if (f.jsonKey) {
+      trackedFile.jsonKey = f.jsonKey;
+    }
+
     if (options.bundle) {
       trackedFile.bundle = options.bundle;
     }
@@ -160,6 +164,7 @@ const runInteractiveAdd = async (tuckDir: string, options: AddOptions = {}): Pro
       encrypt: options.encrypt,
       repo: options.repo,
       repoKey: options.repoKey,
+      jsonKey: options.key,
     });
   } catch (error) {
     if (error instanceof Error) {
@@ -242,6 +247,7 @@ export const addFilesFromPaths = async (
     encrypt: options.encrypt,
     repo: options.repo,
     repoKey: options.repoKey,
+    jsonKey: options.key,
   });
 
   if (filesToAdd.length === 0) {
@@ -442,6 +448,7 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
       encrypt: options.encrypt,
       repo: options.repo,
       repoKey: options.repoKey,
+      jsonKey: options.key,
     });
 
     const bundle = options.bundle ?? 'default';
@@ -474,6 +481,7 @@ const runAdd = async (paths: string[], options: AddOptions): Promise<void> => {
     encrypt: options.encrypt,
     repo: options.repo,
     repoKey: options.repoKey,
+    jsonKey: options.key,
   });
 
   if (filesToAdd.length === 0) {
@@ -534,6 +542,10 @@ export const addCommand = new Command('add')
   .option(
     '--repo-key <key>',
     'Explicit stable repo identity (advanced; default derives from the remote)'
+  )
+  .option(
+    '--key <json.path>',
+    'Track only the JSON subtree at this dot-delimited key path (e.g. mcpServers); written back into the live file at that path on apply/restore'
   )
   .option('-f, --force', 'Skip secret scanning (not recommended)')
   .option('-b, --bundle <name>', 'Bundle to assign the file to (defaults to "default")')

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -46,6 +46,13 @@ import {
 import { getProvider, type ProviderMode, type RemoteConfig as ProviderRemoteConfig } from '../lib/providers/index.js';
 import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from '../lib/materialize.js';
+import {
+  summarizeApplyDiff,
+  formatApplyDiffLine,
+  type ApplyDiffItem,
+  type ApplyDiffSummary,
+} from '../lib/applyDiff.js';
+import { undoBreadcrumb, UNDO_BREADCRUMB_TITLE } from '../lib/undoHint.js';
 
 // Track if Windows permission warning has been shown this session
 let windowsPermissionWarningShown = false;
@@ -368,6 +375,38 @@ interface ApplyResult {
 }
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Resolve the new/modify status of every file about to be applied by checking
+ * whether its live destination already exists. Feeds the pre-apply diff summary
+ * (IDEAS 2.4) shown before anything is touched.
+ */
+const buildApplyDiffItems = async (files: ApplyFile[]): Promise<ApplyDiffItem[]> =>
+  Promise.all(
+    files.map(async (file) => ({
+      destination: collapsePath(file.destination),
+      category: file.category,
+      status: (await pathExists(file.destination)) ? ('modify' as const) : ('new' as const),
+    }))
+  );
+
+/**
+ * Print the full pre-apply diff summary to the human (non-JSON) logger: a
+ * per-file new/update listing grouped by category, followed by a one-line count.
+ * Shown BEFORE the snapshot and before any write, so a fresh-machine apply
+ * always reveals exactly what it is about to change.
+ */
+const printApplyDiffSummary = (summary: ApplyDiffSummary): void => {
+  logger.heading('Changes to apply:');
+  for (const item of summary.items) {
+    const label =
+      item.status === 'new'
+        ? `${item.destination} ${c.green('(new)')}`
+        : `${item.destination} ${c.yellow('(update)')}`;
+    logger.file(item.status === 'new' ? 'add' : 'modify', label);
+  }
+  logger.info(formatApplyDiffLine(summary));
+};
 
 export type ApplySourceKind = 'provider-prefixed' | 'git-url' | 'local' | 'repo-id' | 'username';
 
@@ -1260,8 +1299,10 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
       return;
     }
 
-    // Show what will be applied
-    prompts.log.info(`Found ${files.length} file(s) to apply:`);
+    // Full diff summary — always shown before anything is touched (IDEAS 2.4).
+    const diffSummary = summarizeApplyDiff(await buildApplyDiffItems(files));
+
+    prompts.log.info(`Found ${files.length} file(s) to apply (${formatApplyDiffLine(diffSummary)}):`);
     console.log();
 
     // Group by category
@@ -1273,12 +1314,16 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
       byCategory[file.category].push(file);
     }
 
+    const statusByDestination = new Map(
+      diffSummary.items.map((item) => [item.destination, item.status])
+    );
+
     for (const [category, categoryFiles] of Object.entries(byCategory)) {
       const categoryConfig = CATEGORIES[category] || { icon: '📄' };
       console.log(c.bold(`  ${categoryConfig.icon} ${category}`));
       for (const file of categoryFiles) {
-        const exists = await pathExists(file.destination);
-        const status = exists ? c.yellow('(will update)') : c.green('(new)');
+        const isNew = statusByDestination.get(collapsePath(file.destination)) === 'new';
+        const status = isNew ? c.green('(new)') : c.yellow('(will update)');
         console.log(c.dim(`    ${collapsePath(file.destination)} ${status}`));
       }
     }
@@ -1345,10 +1390,12 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
     // returning the system to its true pre-apply state.
     const snapshotPaths = files.map((f) => f.destination);
 
+    let snapshotId: string | undefined;
     if (snapshotPaths.length > 0 && !options.dryRun) {
       const spinner = prompts.spinner();
       spinner.start('Creating backup snapshot...');
       const snapshot = await createPreApplySnapshot(snapshotPaths, repoId);
+      snapshotId = snapshot.id;
       spinner.stop(`Backup created: ${snapshot.id}`);
       console.log();
     }
@@ -1387,8 +1434,8 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
     if (!options.dryRun) {
       console.log();
       prompts.note(
-        'To undo this apply, run:\n  tuck undo --latest\n\nTo see all backups:\n  tuck undo --list',
-        'Undo'
+        `${undoBreadcrumb(snapshotId)}\n\nTo see all backups:\n  tuck undo --list`,
+        UNDO_BREADCRUMB_TITLE
       );
     }
 
@@ -1478,16 +1525,28 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
     // Determine strategy
     const strategy = options.replace ? 'replace' : 'merge';
 
+    // Full diff summary — shown BEFORE the snapshot and before any write so even
+    // the non-interactive path reveals exactly what it will change (IDEAS 2.4).
+    // Suppressed in JSON mode (the envelope is the machine-readable contract) and
+    // in dry-run (the apply loop already lists every file below).
+    if (!options.dryRun && !isJsonMode()) {
+      const diffSummary = summarizeApplyDiff(await buildApplyDiffItems(files));
+      printApplyDiffSummary(diffSummary);
+      logger.blank();
+    }
+
     // Create backup if not dry run. Snapshot EVERY destination (not just existing
     // ones) so `tuck undo` can also delete files this apply newly created —
     // createSnapshot records missing paths as existed:false and restoreSnapshot
     // removes them on undo.
+    let snapshotId: string | undefined;
     if (!options.dryRun) {
       const snapshotPaths = files.map((f) => f.destination);
 
       if (snapshotPaths.length > 0) {
         if (!isJsonMode()) logger.info('Creating backup snapshot...');
         const snapshot = await createPreApplySnapshot(snapshotPaths, source);
+        snapshotId = snapshot.id;
         if (!isJsonMode()) logger.success(`Backup created: ${snapshot.id}`);
       }
     }
@@ -1548,7 +1607,7 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
     }
 
     if (!options.dryRun) {
-      logger.info('To undo: tuck undo --latest');
+      logger.info(undoBreadcrumb(snapshotId));
     }
   } finally {
     // Clean up temp directory

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -17,7 +17,8 @@ import {
   getTuckDir,
 } from '../lib/paths.js';
 import { resolveWriteTarget, setKnownRepoRoots, allowedRoots, type RepoWriteTarget } from '../lib/writeContext.js';
-import { setFilePermissions, copyFileOrDir } from '../lib/files.js';
+import { setFilePermissions, copyFileOrDir, getFileChecksum } from '../lib/files.js';
+import { recordDriftEntry } from '../lib/crypto/driftCache.js';
 import { resolveLiveTarget, resolveRepoRoot, bindRepo } from '../lib/repoScope.js';
 import { cloneRepo } from '../lib/git.js';
 import { isGhInstalled, ghCloneRepo, repoExists } from '../lib/github.js';
@@ -258,12 +259,12 @@ const prepareWriteTarget = async (writeTarget: string): Promise<void> => {
  * is per-file and does not apply to a directory tree.
  */
 const applyDirectoryEntry = async (file: ApplyFile, dryRun: boolean): Promise<void> => {
-  const exists = await pathExists(file.destination);
+  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+  const exists = await pathExists(writeTarget);
   if (dryRun) {
     logger.file(exists ? 'modify' : 'add', `${collapsePath(file.destination)} (directory)`);
     return;
   }
-  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
   await prepareWriteTarget(writeTarget);
   await copyFileOrDir(file.repoPath, writeTarget, { overwrite: true });
   await applyRecordedPermissions(writeTarget, file.permissions);
@@ -296,12 +297,12 @@ export const isValidUtf8 = (buf: Buffer): boolean => {
  * materialized).
  */
 const applyBinaryEntry = async (file: ApplyFile, dryRun: boolean): Promise<void> => {
-  const exists = await pathExists(file.destination);
+  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+  const exists = await pathExists(writeTarget);
   if (dryRun) {
     logger.file(exists ? 'modify' : 'add', collapsePath(file.destination));
     return;
   }
-  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
   await prepareWriteTarget(writeTarget);
   await copyFileOrDir(file.repoPath, writeTarget, { overwrite: true });
   await applyRecordedPermissions(writeTarget, file.permissions);
@@ -338,6 +339,8 @@ export interface ApplyOptions {
 }
 
 export interface ApplyFile {
+  /** Manifest file id — used to key the encrypted-file drift cache. */
+  id: string;
   source: string;
   /** Absolute LIVE write target on this machine (home path or repo checkout path). */
   destination: string;
@@ -375,6 +378,14 @@ interface ApplyResult {
      * home file, escaping the sandbox.
      */
     writeTarget: string;
+    /**
+     * True when the written file is a JSON-key subtree entry. Such files carry
+     * UNTRACKED keys tuck does not manage, so the whole-file local-store secret
+     * restore must SKIP them — their subtree secrets are resolved in-place during
+     * apply. Rewriting the whole file could splice a secret into (or emit a bogus
+     * unresolved warning about) an untracked key.
+     */
+    jsonKey?: boolean;
   }>;
   /** repo-scoped sources skipped because their repo is unbound on this machine. */
   skippedUnboundRepos: string[];
@@ -383,8 +394,31 @@ interface ApplyResult {
 const execFileAsync = promisify(execFile);
 
 /**
+ * Warm the encrypted-file drift cache after apply writes an encrypted file's
+ * plaintext. Records a keyed-HMAC fingerprint pinned to the repo copy's checksum
+ * so a later read-only `tuck status`/`tuck diff` can detect local drift WITHOUT
+ * decrypting (see lib/crypto/driftCache.ts). Best-effort: a cache miss/failure
+ * must NEVER fail the apply — the worst case is the next status degrades to
+ * "unknown" for this file.
+ */
+const recordEncryptedDrift = async (
+  fileId: string,
+  repoPath: string,
+  plaintext: string
+): Promise<void> => {
+  try {
+    const repoChecksum = await getFileChecksum(repoPath);
+    await recordDriftEntry(fileId, plaintext, repoChecksum);
+  } catch {
+    // Never fail an apply over a drift-cache write.
+  }
+};
+
+/**
  * Resolve the new/modify status of every file about to be applied by checking
- * whether its live destination already exists. Feeds the pre-apply diff summary
+ * whether its RESOLVED write target already exists. Under --root the write
+ * target is the sandbox copy, so a file present in the real home but absent in
+ * the sandbox correctly labels as "(new)". Feeds the pre-apply diff summary
  * (IDEAS 2.4) shown before anything is touched.
  */
 const buildApplyDiffItems = async (files: ApplyFile[]): Promise<ApplyDiffItem[]> =>
@@ -392,7 +426,9 @@ const buildApplyDiffItems = async (files: ApplyFile[]): Promise<ApplyDiffItem[]>
     files.map(async (file) => ({
       destination: collapsePath(file.destination),
       category: file.category,
-      status: (await pathExists(file.destination)) ? ('modify' as const) : ('new' as const),
+      status: (await pathExists(resolveWriteTarget(file.destination, file.repoTarget)))
+        ? ('modify' as const)
+        : ('new' as const),
     }))
   );
 
@@ -734,7 +770,7 @@ export const prepareFilesToApply = async (
   const skipped: string[] = [];
   const unsafe: string[] = [];
 
-  for (const [_id, file] of Object.entries(manifest.files)) {
+  for (const [id, file] of Object.entries(manifest.files)) {
     // Scope to a single bundle when requested. Treat missing/legacy bundle
     // values as "default" so legacy manifests stay applicable.
     if (bundle && (file.bundle ?? 'default') !== bundle) {
@@ -817,6 +853,7 @@ export const prepareFilesToApply = async (
     }
 
     files.push({
+      id,
       source: file.source,
       destination: liveTarget,
       category: file.category,
@@ -877,9 +914,19 @@ const resolveFileSecrets = async (
  * Apply a JSON-key entry: deep-merge the repo's stored subtree back into the
  * live file, leaving every other key untouched. Used by BOTH the merge and
  * replace strategies — a JSON subtree is never allowed to clobber the whole
- * file, so "replace" still means "replace only the tracked key". Secret
- * placeholders inside the subtree are resolved on the merged content, exactly
- * like whole-file entries.
+ * file, so "replace" still means "replace only the tracked key".
+ *
+ * The live/merge-base JSON is read from the RESOLVED write target (the sandbox
+ * copy under --root), never `file.destination` (the real home) — otherwise a
+ * sandboxed apply would copy the operator's real-home untracked keys (tokens,
+ * machine state) into the agent-readable sandbox and ignore existing sandbox
+ * content as the merge base.
+ *
+ * Secret placeholders are resolved on the TRACKED SUBTREE ONLY, before it is
+ * merged into the live file — never on the untracked remainder, which tuck does
+ * not manage. Resolving over the whole merged file would splice a tuck secret
+ * into an untracked key that happens to contain `{{NAME}}` text (corrupting data
+ * tuck doesn't own) or emit a bogus "unresolved placeholder" warning for it.
  */
 const applyJsonKeyEntry = async (
   file: ApplyFile,
@@ -888,27 +935,33 @@ const applyJsonKeyEntry = async (
   dryRun: boolean,
   result: ApplyResult
 ): Promise<void> => {
+  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
   const repoSubtree = rawBytes.toString('utf8');
-  const exists = await pathExists(file.destination);
-  const liveContent = exists ? await readFile(file.destination, 'utf8') : null;
-  let merged = mergeSubtreeIntoLive(liveContent, repoSubtree, file.jsonKey as string);
 
-  const secretsResult = await resolveFileSecrets(merged, tuckDir);
-  merged = secretsResult.content;
+  // Resolve secrets in the tracked subtree BEFORE merging it into the live file.
+  const secretsResult = await resolveFileSecrets(repoSubtree, tuckDir);
+  const resolvedSubtree = secretsResult.content;
   if (secretsResult.unresolved.length > 0) {
     result.filesWithPlaceholders.push({
       path: collapsePath(file.destination),
       placeholders: secretsResult.unresolved,
-      writeTarget: resolveWriteTarget(file.destination, file.repoTarget),
+      writeTarget,
+      // Flag so the whole-file local-store restore skips this file — its subtree
+      // secrets were already handled here and its untracked keys must not be
+      // rewritten.
+      jsonKey: true,
     });
   }
+
+  const exists = await pathExists(writeTarget);
+  const liveContent = exists ? await readFile(writeTarget, 'utf8') : null;
+  const merged = mergeSubtreeIntoLive(liveContent, resolvedSubtree, file.jsonKey as string);
 
   if (dryRun) {
     logger.file(exists ? 'modify' : 'add', `${collapsePath(file.destination)} (--key ${file.jsonKey})`);
     return;
   }
 
-  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
   await prepareWriteTarget(writeTarget);
   await writeFile(writeTarget, merged, 'utf-8');
   await applyRecordedPermissions(writeTarget, file.permissions);
@@ -988,6 +1041,11 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
       throw err;
     }
 
+    // The materialized plaintext BEFORE secret resolution — this is the drift
+    // fingerprint stateModel compares against (it records materialize(repo), not
+    // the post-resolution bytes), so warm the cache with the same value.
+    const materialized = fileContent;
+
     // Resolve placeholders using configured backend (1Password, Bitwarden, pass, or local)
     const secretsResult = await resolveFileSecrets(fileContent, tuckDir);
     fileContent = secretsResult.content;
@@ -1003,9 +1061,15 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
       });
     }
 
-    if (isShellFile(file.source) && (await pathExists(file.destination))) {
-      // Use smart merge for shell files
-      const mergeResult = await smartMerge(file.destination, fileContent);
+    // Confine the write under --root (no-op when not sandboxed). Repo files route
+    // through their repo descriptor so the target is the local checkout. Existence
+    // (merge decision + labels) is tested on the RESOLVED target, not the real
+    // home — under --root a home-present/sandbox-absent file must label "(add)".
+    const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+
+    if (isShellFile(file.source) && (await pathExists(writeTarget))) {
+      // Use smart merge for shell files, merging against the resolved target.
+      const mergeResult = await smartMerge(writeTarget, fileContent);
 
       if (dryRun) {
         logger.file(
@@ -1013,25 +1077,18 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
           `${collapsePath(file.destination)} (${mergeResult.preservedBlocks} blocks preserved)`
         );
       } else {
-        // Confine the write under --root (no-op when not sandboxed). Repo files
-        // route through their repo descriptor so the target is the local checkout.
-        const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
         await prepareWriteTarget(writeTarget);
         await writeFile(writeTarget, mergeResult.content, 'utf-8');
         await applyRecordedPermissions(writeTarget, file.permissions);
+        if (file.encrypted) await recordEncryptedDrift(file.id, file.repoPath, materialized);
         logger.file('merge', collapsePath(file.destination));
       }
     } else {
       // Copy non-shell files directly
+      const fileExists = await pathExists(writeTarget);
       if (dryRun) {
-        if (await pathExists(file.destination)) {
-          logger.file('modify', collapsePath(file.destination));
-        } else {
-          logger.file('add', collapsePath(file.destination));
-        }
+        logger.file(fileExists ? 'modify' : 'add', collapsePath(file.destination));
       } else {
-        const fileExists = await pathExists(file.destination);
-        const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
         // Write file content directly instead of copying (to preserve resolved secrets)
         await prepareWriteTarget(writeTarget);
         await writeFile(writeTarget, fileContent, 'utf-8');
@@ -1039,6 +1096,7 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
         // then the SSH/GPG fixup enforces its stricter floor for those dirs.
         await applyRecordedPermissions(writeTarget, file.permissions);
         await fixSecurePermissions(writeTarget);
+        if (file.encrypted) await recordEncryptedDrift(file.id, file.repoPath, materialized);
         logger.file(fileExists ? 'modify' : 'add', collapsePath(file.destination));
       }
     }
@@ -1122,6 +1180,10 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       throw err;
     }
 
+    // The materialized plaintext BEFORE secret resolution — the drift
+    // fingerprint stateModel compares against (materialize(repo)).
+    const materialized = fileContent;
+
     // Resolve placeholders using configured backend (1Password, Bitwarden, pass, or local)
     const secretsResult = await resolveFileSecrets(fileContent, tuckDir);
     fileContent = secretsResult.content;
@@ -1137,15 +1199,17 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       });
     }
 
+    // Existence (labels) is tested on the RESOLVED write target, not the real
+    // home — under --root a home-present/sandbox-absent file must label "(add)".
+    const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+    const fileExists = await pathExists(writeTarget);
     if (dryRun) {
-      if (await pathExists(file.destination)) {
+      if (fileExists) {
         logger.file('modify', `${collapsePath(file.destination)} (replace)`);
       } else {
         logger.file('add', collapsePath(file.destination));
       }
     } else {
-      const fileExists = await pathExists(file.destination);
-      const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
       // Write file content directly instead of copying (to preserve resolved secrets)
       await prepareWriteTarget(writeTarget);
       await writeFile(writeTarget, fileContent, 'utf-8');
@@ -1153,6 +1217,7 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       // then the SSH/GPG fixup enforces its stricter floor for those dirs.
       await applyRecordedPermissions(writeTarget, file.permissions);
       await fixSecurePermissions(writeTarget);
+      if (file.encrypted) await recordEncryptedDrift(file.id, file.repoPath, materialized);
       logger.file(fileExists ? 'modify' : 'add', collapsePath(file.destination));
     }
 
@@ -1276,7 +1341,12 @@ export const tryRestoreSecretsFromLocalStore = async (
     // target (already absolute and sandbox-confined under --root), never
     // expandPath(f.path) — that would resolve the operator's REAL ~ file and
     // rewrite it with plaintext secrets, escaping the sandbox.
-    const pathsToRestore = filesWithPlaceholders.map(f => f.writeTarget);
+    //
+    // JSON-key files are EXCLUDED: their written form carries untracked keys tuck
+    // does not manage, and their tracked subtree's secrets were already resolved
+    // during apply. A whole-file rewrite here could splice a secret into (or warn
+    // about) an untracked key that happens to contain `{{NAME}}` text.
+    const pathsToRestore = filesWithPlaceholders.filter(f => !f.jsonKey).map(f => f.writeTarget);
     const result = await restoreSecrets(pathsToRestore, tuckDir);
 
     if (interactive && result.totalRestored > 0) {
@@ -1479,15 +1549,28 @@ const runInteractiveApply = async (source: string, options: ApplyOptions): Promi
     // as existed:false, and restoreSnapshot (undo) deletes those on rollback — so
     // a `tuck undo` after this apply also removes files this apply newly created,
     // returning the system to its true pre-apply state.
-    const snapshotPaths = files.map((f) => f.destination);
+    //
+    // The snapshot must cover the ACTUAL write targets (resolveWriteTarget), not
+    // `file.destination` (the real live path). Under --root every write is rebased
+    // into the sandbox, so snapshotting the real home would both back up untouched
+    // files AND make `tuck undo` overwrite real-home originals the apply never
+    // touched. resolveWriteTarget is identity when not sandboxed.
+    const snapshotPaths = files.map((f) => resolveWriteTarget(f.destination, f.repoTarget));
 
     let snapshotId: string | undefined;
     if (snapshotPaths.length > 0 && !options.dryRun) {
       const spinner = prompts.spinner();
       spinner.start('Creating backup snapshot...');
-      const snapshot = await createPreApplySnapshot(snapshotPaths, repoId);
-      snapshotId = snapshot.id;
-      spinner.stop(`Backup created: ${snapshot.id}`);
+      // try/finally so a snapshot throw stops the clack spinner instead of
+      // leaving it hung; the abort itself remains fail-closed (error propagates).
+      try {
+        const snapshot = await createPreApplySnapshot(snapshotPaths, repoId);
+        snapshotId = snapshot.id;
+        spinner.stop(`Backup created: ${snapshot.id}`);
+      } catch (err) {
+        spinner.stop('Backup snapshot failed');
+        throw err;
+      }
       console.log();
     }
 
@@ -1629,10 +1712,13 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
     // Create backup if not dry run. Snapshot EVERY destination (not just existing
     // ones) so `tuck undo` can also delete files this apply newly created —
     // createSnapshot records missing paths as existed:false and restoreSnapshot
-    // removes them on undo.
+    // removes them on undo. Snapshot the ACTUAL write targets (resolveWriteTarget)
+    // — under --root the writes are rebased into the sandbox, so snapshotting the
+    // real home would back up untouched files and let undo overwrite real-home
+    // originals. Identity when not sandboxed.
     let snapshotId: string | undefined;
     if (!options.dryRun) {
-      const snapshotPaths = files.map((f) => f.destination);
+      const snapshotPaths = files.map((f) => resolveWriteTarget(f.destination, f.repoTarget));
 
       if (snapshotPaths.length > 0) {
         if (!isJsonMode()) logger.info('Creating backup snapshot...');
@@ -1665,6 +1751,10 @@ export const runApply = async (source: string, options: ApplyOptions): Promise<v
         dryRun: !!options.dryRun,
         skipped: allSkipped,
         profile: activeProfile ?? undefined,
+        // Recovery pointer for agents: the pre-apply snapshot id and the exact
+        // command to roll this apply back.
+        snapshot: snapshotId,
+        undo: snapshotId ? undoBreadcrumb(snapshotId) : undefined,
       });
       return;
     }
@@ -1759,7 +1849,10 @@ export const applyRepoDir = async (
   }
 
   if (!options.dryRun) {
-    const snapshotPaths = files.map((f) => f.destination);
+    // Snapshot the ACTUAL write targets so a sandboxed (--root) bootstrap backs
+    // up the sandbox files, not the untouched real home. Identity when not
+    // sandboxed.
+    const snapshotPaths = files.map((f) => resolveWriteTarget(f.destination, f.repoTarget));
     if (snapshotPaths.length > 0) {
       await createPreApplySnapshot(snapshotPaths, source);
     }

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -32,7 +32,8 @@ import { findPlaceholders, restoreContent, restoreFiles as restoreSecrets, getAl
 import { createResolver } from '../lib/secretBackends/index.js';
 import { loadConfig } from '../lib/config.js';
 import { IS_WINDOWS } from '../lib/platform.js';
-import { RepositoryNotFoundError, MaterializeError, InvalidManifestError, NotInitializedError, ValidationError, RemoteApplyError } from '../errors.js';
+import { RepositoryNotFoundError, MaterializeError, JsonKeyError, InvalidManifestError, NotInitializedError, ValidationError, RemoteApplyError } from '../errors.js';
+import { mergeSubtreeIntoLive } from '../lib/jsonKey.js';
 import {
   parseSshTarget,
   buildRemotePlan,
@@ -354,6 +355,11 @@ export interface ApplyFile {
   template: boolean;
   /** Decrypt the repo source (TCKE1) before writing to the live system. */
   encrypted: boolean;
+  /**
+   * Dot-delimited JSON key path when the repo copy is only a subtree. On apply
+   * it is deep-merged back into the live file, preserving all other keys.
+   */
+  jsonKey?: string;
 }
 
 interface ApplyResult {
@@ -819,6 +825,7 @@ export const prepareFilesToApply = async (
       permissions: file.permissions,
       template: file.template,
       encrypted: file.encrypted,
+      jsonKey: file.jsonKey,
     });
   }
 
@@ -867,6 +874,48 @@ const resolveFileSecrets = async (
 };
 
 /**
+ * Apply a JSON-key entry: deep-merge the repo's stored subtree back into the
+ * live file, leaving every other key untouched. Used by BOTH the merge and
+ * replace strategies — a JSON subtree is never allowed to clobber the whole
+ * file, so "replace" still means "replace only the tracked key". Secret
+ * placeholders inside the subtree are resolved on the merged content, exactly
+ * like whole-file entries.
+ */
+const applyJsonKeyEntry = async (
+  file: ApplyFile,
+  rawBytes: Buffer,
+  tuckDir: string,
+  dryRun: boolean,
+  result: ApplyResult
+): Promise<void> => {
+  const repoSubtree = rawBytes.toString('utf8');
+  const exists = await pathExists(file.destination);
+  const liveContent = exists ? await readFile(file.destination, 'utf8') : null;
+  let merged = mergeSubtreeIntoLive(liveContent, repoSubtree, file.jsonKey as string);
+
+  const secretsResult = await resolveFileSecrets(merged, tuckDir);
+  merged = secretsResult.content;
+  if (secretsResult.unresolved.length > 0) {
+    result.filesWithPlaceholders.push({
+      path: collapsePath(file.destination),
+      placeholders: secretsResult.unresolved,
+      writeTarget: resolveWriteTarget(file.destination, file.repoTarget),
+    });
+  }
+
+  if (dryRun) {
+    logger.file(exists ? 'modify' : 'add', `${collapsePath(file.destination)} (--key ${file.jsonKey})`);
+    return;
+  }
+
+  const writeTarget = resolveWriteTarget(file.destination, file.repoTarget);
+  await prepareWriteTarget(writeTarget);
+  await writeFile(writeTarget, merged, 'utf-8');
+  await applyRecordedPermissions(writeTarget, file.permissions);
+  logger.file(exists ? 'modify' : 'add', `${collapsePath(file.destination)} (--key ${file.jsonKey})`);
+};
+
+/**
  * Apply files with merge strategy
  */
 const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<ApplyResult> => {
@@ -890,6 +939,27 @@ const applyWithMerge = async (files: ApplyFile[], dryRun: boolean): Promise<Appl
       continue;
     }
     const rawBytes = await readFile(file.repoPath);
+
+    // JSON-key entries write their stored subtree into the live file at the
+    // tracked path, preserving every other key (never routed through
+    // materialize/smart-merge/binary). A corrupt/JSONC live file must skip
+    // THIS entry loudly and keep the rest of the run going, like
+    // MaterializeError below.
+    if (file.jsonKey) {
+      try {
+        await applyJsonKeyEntry(file, rawBytes, tuckDir, dryRun, result);
+        result.appliedCount++;
+      } catch (err) {
+        if (err instanceof JsonKeyError) {
+          const msg = `Skipped ${collapsePath(file.destination)}: ${err.message}`;
+          logger.warning(msg);
+          if (isJsonMode()) addJsonWarning(msg);
+        } else {
+          throw err;
+        }
+      }
+      continue;
+    }
 
     // Binary (non-UTF-8) files that are neither templated nor encrypted must be
     // copied byte-for-byte — the text pipeline below would UTF-8 round-trip them
@@ -1003,6 +1073,27 @@ const applyWithReplace = async (files: ApplyFile[], dryRun: boolean): Promise<Ap
       continue;
     }
     const rawBytes = await readFile(file.repoPath);
+
+    // JSON-key entries write their stored subtree into the live file at the
+    // tracked path, preserving every other key (never routed through
+    // materialize/smart-merge/binary). A corrupt/JSONC live file must skip
+    // THIS entry loudly and keep the rest of the run going, like
+    // MaterializeError below.
+    if (file.jsonKey) {
+      try {
+        await applyJsonKeyEntry(file, rawBytes, tuckDir, dryRun, result);
+        result.appliedCount++;
+      } catch (err) {
+        if (err instanceof JsonKeyError) {
+          const msg = `Skipped ${collapsePath(file.destination)}: ${err.message}`;
+          logger.warning(msg);
+          if (isJsonMode()) addJsonWarning(msg);
+        } else {
+          throw err;
+        }
+      }
+      continue;
+    }
 
     // Binary (non-UTF-8) files that are neither templated nor encrypted must be
     // copied byte-for-byte — the text pipeline below would UTF-8 round-trip them

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -28,6 +28,8 @@ import {
   keystorePassphrase,
   buildMaterializeCtx,
 } from '../lib/materialize.js';
+import { enterReadOnlyMode, isReadOnlyMode } from '../lib/readOnlyMode.js';
+import { compareLiveToCache } from '../lib/crypto/driftCache.js';
 import {
   getStoredValueMap,
   getRedactedChecksum,
@@ -47,6 +49,12 @@ export interface FileDiff {
   repoSize?: number;
   systemContent?: string;
   repoContent?: string;
+  /**
+   * Set for an ENCRYPTED file whose drift was detected in read-only mode via the
+   * keyed-HMAC cache: we know it changed but deliberately did NOT decrypt the
+   * repo copy, so the line-level diff is withheld (no keystore unlock, no prompt).
+   */
+  encryptedHidden?: boolean;
 }
 
 const isBinary = async (path: string): Promise<boolean> => {
@@ -173,6 +181,22 @@ export const getFileDiff = async (
   // change. Compare the live file against materialize(repo) instead — matching
   // the state model that `tuck verify`/`tuck status` use.
   if (tracked.file.template || tracked.file.encrypted) {
+    // Read-only + ENCRYPTED: never decrypt. Decide changed/unchanged from the
+    // keyed-HMAC cache (zero decryption, no keystore, no prompt) and withhold the
+    // line-level diff rather than unlocking the repo copy. Pure templates touch
+    // no secret and render cheaply, so they fall through to the normal path.
+    if (tracked.file.encrypted && isReadOnlyMode()) {
+      const liveBytes = await readFile(systemPath);
+      const repoChecksum = await getFileChecksum(repoPath);
+      const cmp = await compareLiveToCache(tracked.id, liveBytes, repoChecksum);
+      if (cmp === 'mismatch') {
+        diff.hasChanges = true;
+        diff.encryptedHidden = true;
+      }
+      // 'match' or 'unknown' → no reportable diff in read-only mode.
+      return diff;
+    }
+
     let materialized: string;
     try {
       const ctx = await buildMaterializeCtx(tuckDir);
@@ -294,6 +318,13 @@ const formatUnifiedDiff = (diff: FileDiff): string => {
     return lines.join('\n');
   }
 
+  if (diff.encryptedHidden) {
+    lines.push(c.yellow('Encrypted file changed'));
+    lines.push(c.dim('  Contents hidden — read-only diff never decrypts.'));
+    lines.push(c.dim("  Run 'tuck verify' or 'tuck apply' for a full comparison."));
+    return lines.join('\n');
+  }
+
   const { systemContent, repoContent } = diff;
 
   // Check if systemContent is explicitly undefined (missing) vs empty string
@@ -393,6 +424,9 @@ const formatUnifiedDiff = (diff: FileDiff): string => {
 };
 
 const runDiff = async (paths: string[], options: DiffOptions): Promise<void> => {
+  // diff is a read-only inspection command: it must never unlock the keystore or
+  // touch a secret backend. This guarantees zero prompts (see lib/readOnlyMode).
+  enterReadOnlyMode();
   if (options.json) setJsonMode(true, 'tuck diff');
   const tuckDir = getTuckDir();
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -131,13 +131,31 @@ export const getFileDiff = async (
       diff.fileCount = files.length;
     } else {
       const systemContent = await readFile(systemPath, 'utf-8');
-      // This branch dumps the WHOLE live file as systemContent — redact known
-      // secrets before display so `tuck diff` never prints cleartext (#100).
-      // systemSize stays the real (un-redacted) file length.
       const store = valueMap ?? (await getStoredValueMap(tuckDir));
-      diff.systemContent =
-        store.size > 0 ? redactValuesInContent(systemContent, store) : systemContent;
-      diff.systemSize = systemContent.length;
+      if (tracked.file.jsonKey) {
+        // JSON-key entries track only a SUBTREE. The whole live file holds
+        // untracked keys (oauthToken, session state, history) that a jsonKey add
+        // NEVER wrote to the local secrets store — so redaction here cannot cover
+        // them and dumping the whole file would leak them. Show ONLY the tracked
+        // subtree (still redacted for any known values it does contain).
+        let subtree: string;
+        try {
+          subtree = extractSubtree(systemContent, tracked.file.jsonKey);
+        } catch {
+          // Corrupt live JSON or missing key path: withhold content entirely
+          // rather than fall back to the whole file. hasChanges stays true.
+          return diff;
+        }
+        diff.systemContent = store.size > 0 ? redactValuesInContent(subtree, store) : subtree;
+        diff.systemSize = subtree.length;
+      } else {
+        // This branch dumps the WHOLE live file as systemContent — redact known
+        // secrets before display so `tuck diff` never prints cleartext (#100).
+        // systemSize stays the real (un-redacted) file length.
+        diff.systemContent =
+          store.size > 0 ? redactValuesInContent(systemContent, store) : systemContent;
+        diff.systemSize = systemContent.length;
+      }
     }
     return diff;
   }
@@ -183,6 +201,13 @@ export const getFileDiff = async (
   // tokens included) in the hunks.
   if (tracked.file.jsonKey) {
     const repoContent = await readFile(repoPath, 'utf-8');
+    // Both the live subtree and the repo copy are plain JSON that can carry
+    // cleartext secret values, so redact known values before display — the same
+    // pass every other text branch applies (#100). systemSize/repoSize keep the
+    // real (un-redacted) lengths.
+    const store = valueMap ?? (await getStoredValueMap(tuckDir));
+    const redact = (text: string): string =>
+      store.size > 0 ? redactValuesInContent(text, store) : text;
     let liveSubtree: string;
     try {
       const liveRaw = await readFile(systemPath, 'utf-8');
@@ -191,15 +216,15 @@ export const getFileDiff = async (
       // Corrupt live JSON or missing key path: fall back to whole-repo view so
       // the divergence is visible without dumping unrelated live keys.
       diff.hasChanges = true;
-      diff.repoContent = repoContent;
+      diff.repoContent = redact(repoContent);
       diff.repoSize = repoContent.length;
       return diff;
     }
     diff.hasChanges = liveSubtree !== repoContent;
     if (diff.hasChanges) {
-      diff.systemContent = liveSubtree;
+      diff.systemContent = redact(liveSubtree);
       diff.systemSize = liveSubtree.length;
-      diff.repoContent = repoContent;
+      diff.repoContent = redact(repoContent);
       diff.repoSize = repoContent.length;
     }
     return diff;

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -23,6 +23,7 @@ import { NotInitializedError, FileNotFoundError, PermissionError } from '../erro
 import { isBinaryExecutable } from '../lib/binary.js';
 import { isIgnored } from '../lib/tuckignore.js';
 import { resolveLiveTarget } from '../lib/repoScope.js';
+import { extractSubtree } from '../lib/jsonKey.js';
 import {
   materializeForLive,
   keystorePassphrase,
@@ -173,6 +174,34 @@ export const getFileDiff = async (
     }
     diff.hasChanges = dirChanged;
 
+    return diff;
+  }
+
+  // JSON-key entries track only a SUBTREE of the live file: compare
+  // extractSubtree(live) against the repo copy — diffing the whole live file
+  // would always report changes AND print every untracked live key (machine
+  // tokens included) in the hunks.
+  if (tracked.file.jsonKey) {
+    const repoContent = await readFile(repoPath, 'utf-8');
+    let liveSubtree: string;
+    try {
+      const liveRaw = await readFile(systemPath, 'utf-8');
+      liveSubtree = extractSubtree(liveRaw, tracked.file.jsonKey);
+    } catch {
+      // Corrupt live JSON or missing key path: fall back to whole-repo view so
+      // the divergence is visible without dumping unrelated live keys.
+      diff.hasChanges = true;
+      diff.repoContent = repoContent;
+      diff.repoSize = repoContent.length;
+      return diff;
+    }
+    diff.hasChanges = liveSubtree !== repoContent;
+    if (diff.hasChanges) {
+      diff.systemContent = liveSubtree;
+      diff.systemSize = liveSubtree.length;
+      diff.repoContent = repoContent;
+      diff.repoSize = repoContent.length;
+    }
     return diff;
   }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,4 +20,5 @@ export { mergeCommand } from './merge.js';
 export { profileCommand } from './profile.js';
 export { verifyCommand } from './verify.js';
 export { repoCommand } from './repo.js';
+export { settingsCommand } from './settings.js';
 export { bootstrapCommand } from './bootstrap.js';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,5 +20,6 @@ export { mergeCommand } from './merge.js';
 export { profileCommand } from './profile.js';
 export { verifyCommand } from './verify.js';
 export { repoCommand } from './repo.js';
+export { rulesCommand } from './rules.js';
 export { settingsCommand } from './settings.js';
 export { bootstrapCommand } from './bootstrap.js';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,6 +16,7 @@ export { secretsCommand } from './secrets.js';
 export { encryptionCommand } from './encryption.js';
 export { doctorCommand } from './doctor.js';
 export { bundleCommand } from './bundle.js';
+export { mergeCommand } from './merge.js';
 export { profileCommand } from './profile.js';
 export { verifyCommand } from './verify.js';
 export { repoCommand } from './repo.js';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,7 +12,7 @@ import {
   pathExists,
   collapsePath,
 } from '../lib/paths.js';
-import { saveConfig } from '../lib/config.js';
+import { saveConfig, loadConfig } from '../lib/config.js';
 import { createManifest, clearManifestCache } from '../lib/manifest.js';
 import { loadManifestFile } from '../lib/manifestFile.js';
 import type { TuckManifest, RemoteConfig } from '../types.js';
@@ -1230,6 +1230,354 @@ const initFromRemote = async (tuckDir: string, remoteUrl: string): Promise<void>
   }
 };
 
+/**
+ * How the user wants to start an interactive init.
+ *
+ * `adopt` (scan the machine and track existing dotfiles) is deliberately the
+ * FIRST, recommended option: a fresh machine should be guided into the safe,
+ * scan-based "adopt existing dotfiles" path before any provider/remote setup,
+ * with zero templating concepts (IDEAS 2.4). `clone` restores from an existing
+ * repo; `fresh` keeps the provider-first flow for users who want to configure a
+ * remote up front.
+ */
+export type InitStartPath = 'adopt' | 'clone' | 'fresh';
+
+/** Ordered start-path menu for interactive init — adopt-existing listed first. */
+export const buildInitStartChoices = (): Array<{
+  value: InitStartPath;
+  label: string;
+  hint: string;
+}> => [
+  {
+    value: 'adopt',
+    label: 'Adopt the dotfiles already on this machine',
+    hint: 'Recommended — scan and track your existing configs',
+  },
+  {
+    value: 'clone',
+    label: 'Clone an existing dotfiles repository',
+    hint: 'Restore dotfiles from a repo you already have',
+  },
+  {
+    value: 'fresh',
+    label: 'Start fresh / configure a remote first',
+    hint: 'Set up a Git provider, then add files',
+  },
+];
+
+/**
+ * Scan the system for dotfiles and interactively track a selection of them.
+ * Returns the number of files actually tracked. Shared by the adopt-first path
+ * and the tail of the fresh-init flow so both behave identically.
+ */
+const scanAndTrackLocalDotfiles = async (tuckDir: string): Promise<number> => {
+  const scanSpinner = prompts.spinner();
+  scanSpinner.start('Scanning for dotfiles...');
+  const detectedFiles = await detectDotfiles();
+  const nonSensitiveFiles = detectedFiles.filter((f) => !f.sensitive);
+  const sensitiveFiles = detectedFiles.filter((f) => f.sensitive);
+  scanSpinner.stop(`Found ${detectedFiles.length} dotfiles on your system`);
+
+  let trackedCount = 0;
+
+  // Handle non-sensitive files
+  if (nonSensitiveFiles.length > 0) {
+    // Group by category and show summary
+    const grouped: Record<string, DetectedFile[]> = {};
+    for (const file of nonSensitiveFiles) {
+      if (!grouped[file.category]) grouped[file.category] = [];
+      grouped[file.category].push(file);
+    }
+
+    console.log();
+    const categoryOrder = ['shell', 'git', 'editors', 'terminal', 'ssh', 'misc'];
+    const sortedCategories = Object.keys(grouped).sort((a, b) => {
+      const aIdx = categoryOrder.indexOf(a);
+      const bIdx = categoryOrder.indexOf(b);
+      if (aIdx === -1 && bIdx === -1) return a.localeCompare(b);
+      if (aIdx === -1) return 1;
+      if (bIdx === -1) return -1;
+      return aIdx - bIdx;
+    });
+
+    for (const category of sortedCategories) {
+      const files = grouped[category];
+      const config = DETECTION_CATEGORIES[category] || { icon: '-', name: category };
+      console.log(`  ${config.icon} ${config.name}: ${files.length} files`);
+    }
+    console.log();
+
+    const trackNow = await prompts.confirm('Would you like to track some of these now?', true);
+
+    if (trackNow) {
+      // Show multiselect with all files PRE-SELECTED by default
+      const options = nonSensitiveFiles.map((f) => ({
+        value: f.path,
+        label: `${collapsePath(f.path)}`,
+        hint: f.category,
+      }));
+
+      // Pre-select all non-sensitive files
+      const initialValues = nonSensitiveFiles.map((f) => f.path);
+
+      const selectedFiles = await prompts.multiselect(
+        'Select files to track (all pre-selected; use space to toggle selection):',
+        options,
+        { initialValues }
+      );
+
+      // Handle sensitive files with individual prompts
+      const filesToTrack = [...selectedFiles];
+
+      if (sensitiveFiles.length > 0) {
+        console.log();
+        prompts.log.warning(`Found ${sensitiveFiles.length} sensitive file(s):`);
+
+        for (const sf of sensitiveFiles) {
+          console.log(c.warning(`  ! ${collapsePath(sf.path)} - ${sf.description || sf.category}`));
+        }
+
+        console.log();
+        const trackSensitive = await prompts.confirm(
+          'Would you like to review sensitive files? (Ensure your repo is PRIVATE)',
+          false
+        );
+
+        if (trackSensitive) {
+          for (const sf of sensitiveFiles) {
+            const track = await prompts.confirm(`Track ${collapsePath(sf.path)}?`, false);
+            if (track) {
+              filesToTrack.push(sf.path);
+            }
+          }
+        }
+      }
+
+      if (filesToTrack.length > 0) {
+        // Track files with beautiful progress display
+        trackedCount = await trackFilesWithProgressInit(filesToTrack, tuckDir);
+      }
+    } else {
+      prompts.log.info("Run 'tuck scan' later to interactively add files");
+    }
+  }
+
+  // Handle case where only sensitive files were found
+  if (nonSensitiveFiles.length === 0 && sensitiveFiles.length > 0) {
+    console.log();
+    prompts.log.warning(`Found ${sensitiveFiles.length} sensitive file(s):`);
+
+    for (const sf of sensitiveFiles) {
+      console.log(c.warning(`  ! ${collapsePath(sf.path)} - ${sf.description || sf.category}`));
+    }
+
+    console.log();
+    const trackSensitive = await prompts.confirm(
+      'Would you like to review these sensitive files? (Ensure your repo is PRIVATE)',
+      false
+    );
+
+    if (trackSensitive) {
+      const filesToTrack: string[] = [];
+      for (const sf of sensitiveFiles) {
+        const track = await prompts.confirm(`Track ${collapsePath(sf.path)}?`, false);
+        if (track) {
+          filesToTrack.push(sf.path);
+        }
+      }
+
+      if (filesToTrack.length > 0) {
+        // Track files with beautiful progress display
+        trackedCount = await trackFilesWithProgressInit(filesToTrack, tuckDir);
+      }
+    } else {
+      prompts.log.info("Run 'tuck scan' later to interactively add files");
+    }
+  }
+
+  // Handle case where no files were found
+  if (detectedFiles.length === 0) {
+    console.log();
+    prompts.log.info('No dotfiles detected on your system');
+    prompts.log.info("Run 'tuck add <path>' to manually track files");
+  }
+
+  return trackedCount;
+};
+
+/**
+ * After tracking, offer to commit (and push, when a remote is configured) the
+ * newly-tracked dotfiles. Shared by the adopt-first path and the fresh-init flow.
+ */
+const commitAndOfferPush = async (
+  tuckDir: string,
+  trackedCount: number,
+  remoteUrl: string | null
+): Promise<void> => {
+  if (trackedCount <= 0) {
+    return;
+  }
+
+  console.log();
+
+  if (remoteUrl) {
+    // Remote is configured - offer to commit AND push
+    const action = await prompts.select('Your files are tracked. What would you like to do?', [
+      {
+        value: 'commit-push',
+        label: 'Commit and push to remote',
+        hint: 'Recommended - sync your dotfiles now',
+      },
+      {
+        value: 'commit-only',
+        label: 'Commit only',
+        hint: "Save locally, push later with 'tuck push'",
+      },
+      {
+        value: 'skip',
+        label: 'Skip for now',
+        hint: "Run 'tuck sync' later",
+      },
+    ]);
+
+    if (action !== 'skip') {
+      const commitSpinner = prompts.spinner();
+      commitSpinner.start('Committing changes...');
+
+      await stageAll(tuckDir);
+      const commitHash = await commit(tuckDir, `Add ${trackedCount} dotfiles via tuck init`);
+
+      commitSpinner.stop(`Committed: ${commitHash.slice(0, 7)}`);
+
+      if (action === 'commit-push') {
+        const pushSpinner = prompts.spinner();
+        pushSpinner.start('Pushing to remote...');
+
+        try {
+          await push(tuckDir, { remote: 'origin', branch: 'main', setUpstream: true });
+          pushSpinner.stop('Pushed successfully!');
+
+          // Show success with URL
+          let viewUrl = remoteUrl;
+          if (viewUrl.startsWith('git@github.com:')) {
+            viewUrl = viewUrl
+              .replace('git@github.com:', 'https://github.com/')
+              .replace('.git', '');
+          } else if (viewUrl.startsWith('https://github.com/')) {
+            viewUrl = viewUrl.replace('.git', '');
+          }
+
+          console.log();
+          prompts.note(
+            `Your dotfiles are now live at:\n${viewUrl}\n\n` +
+              `On a new machine, run:\n  tuck init --from ${viewUrl}`,
+            'Success!'
+          );
+        } catch (error) {
+          pushSpinner.stop('Push failed');
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          prompts.log.warning(`Could not push: ${errorMsg}`);
+          prompts.log.info("Run 'tuck push' to try again");
+        }
+      } else {
+        prompts.log.info("Run 'tuck push' when you're ready to upload to remote");
+      }
+    }
+  } else {
+    // No remote configured
+    const shouldCommit = await prompts.confirm('Commit these changes locally?', true);
+
+    if (shouldCommit) {
+      const commitSpinner = prompts.spinner();
+      commitSpinner.start('Committing...');
+
+      await stageAll(tuckDir);
+      const commitHash = await commit(tuckDir, `Add ${trackedCount} dotfiles via tuck init`);
+
+      commitSpinner.stop(`Committed: ${commitHash.slice(0, 7)}`);
+      prompts.log.info("Set up a remote with 'tuck push' to backup your dotfiles");
+    }
+  }
+};
+
+/**
+ * Clone an existing dotfiles repository from a URL and optionally restore it.
+ * Returns true when the clone path fully handled init (the caller should stop).
+ */
+const cloneFromUrlFlow = async (tuckDir: string): Promise<void> => {
+  const repoUrl = await prompts.text('Enter repository URL:', {
+    placeholder: 'git@host:user/dotfiles.git or https://host/user/dotfiles.git',
+    validate: validateGitUrl,
+  });
+
+  await initFromRemote(tuckDir, repoUrl);
+
+  prompts.log.success('Repository cloned successfully!');
+
+  const shouldRestore = await prompts.confirm('Would you like to restore dotfiles now?', true);
+
+  if (shouldRestore) {
+    console.log();
+    // Dynamically import and run restore
+    const { runRestore } = await import('./restore.js');
+    await runRestore({ all: true });
+  }
+
+  prompts.outro('Tuck initialized successfully!');
+  nextSteps([`View status: tuck status`, `Add files:   tuck add ~/.zshrc`, `Sync:        tuck sync`]);
+};
+
+/**
+ * Adopt-first init path: scan and track the dotfiles already on this machine,
+ * then optionally connect a remote and commit/push. No provider setup happens
+ * until the user has decided what to track, so the fastest path to a working
+ * tuck repo has zero remote/templating concepts (IDEAS 2.4).
+ */
+const runAdoptExistingInit = async (tuckDir: string): Promise<void> => {
+  // Create a local repo to track into. Remote (if any) is configured afterwards.
+  await initFromScratch(tuckDir, { remoteConfig: buildRemoteConfig('local') });
+
+  // Scan the machine and track a selection FIRST — the headline of this path.
+  const trackedCount = await scanAndTrackLocalDotfiles(tuckDir);
+
+  // Offer to connect a remote AFTER the user has chosen what to track.
+  let remoteUrl: string | null = null;
+  const connectRemote = await prompts.confirm(
+    'Back up your dotfiles to a Git remote now?',
+    true
+  );
+
+  if (connectRemote) {
+    const providerResult = await setupProvider();
+    if (providerResult) {
+      // Persist the chosen provider over the local default written above.
+      const existingConfig = await loadConfig(tuckDir);
+      await saveConfig({ ...existingConfig, remote: providerResult.config }, tuckDir);
+      console.log();
+      prompts.log.info(`Provider: ${describeProviderConfig(providerResult.config)}`);
+
+      if (providerResult.remoteUrl) {
+        await addRemote(tuckDir, 'origin', providerResult.remoteUrl);
+        remoteUrl = providerResult.remoteUrl;
+      } else if (providerResult.mode === 'github') {
+        // GitHub auto-create / manual repo setup wizard.
+        const ghResult = await setupGitHubRepo(tuckDir);
+        remoteUrl = ghResult.remoteUrl;
+      } else if (providerResult.mode !== 'local') {
+        // GitLab/custom providers return no remoteUrl from setupProvider —
+        // mirror the fresh-init flow so answering YES to the remote prompt
+        // never silently falls through with no origin configured.
+        remoteUrl = await setupRemoteForChosenProvider(providerResult.mode, tuckDir);
+      }
+    }
+  }
+
+  await commitAndOfferPush(tuckDir, trackedCount, remoteUrl);
+
+  prompts.outro('Tuck initialized successfully!');
+  nextSteps([`View status: tuck status`, `Add files:   tuck add ~/.zshrc`, `Sync:        tuck sync`]);
+};
+
 const runInteractiveInit = async (): Promise<void> => {
   banner();
   prompts.intro('tuck init');
@@ -1246,6 +1594,27 @@ const runInteractiveInit = async (): Promise<void> => {
     prompts.outro('Use `tuck status` to see current state');
     return;
   }
+
+  // ========== START: How do you want to begin? ==========
+  // Adopt-existing (scan the machine) is offered FIRST so a fresh machine takes
+  // the safe, zero-config path before any provider/remote setup (IDEAS 2.4).
+  console.log();
+  const startPath = await prompts.select(
+    'How would you like to start with tuck?',
+    buildInitStartChoices()
+  );
+
+  if (startPath === 'adopt') {
+    await runAdoptExistingInit(tuckDir);
+    return;
+  }
+
+  if (startPath === 'clone') {
+    await cloneFromUrlFlow(tuckDir);
+    return;
+  }
+
+  // startPath === 'fresh': continue with the provider-first flow below.
 
   // ========== STEP 0: Provider Selection ==========
   console.log();
@@ -1532,220 +1901,10 @@ const runInteractiveInit = async (): Promise<void> => {
   }
 
   // ========== STEP 2: Detect and Select Files ==========
-  const scanSpinner = prompts.spinner();
-  scanSpinner.start('Scanning for dotfiles...');
-  const detectedFiles = await detectDotfiles();
-  const nonSensitiveFiles = detectedFiles.filter((f) => !f.sensitive);
-  const sensitiveFiles = detectedFiles.filter((f) => f.sensitive);
-  scanSpinner.stop(`Found ${detectedFiles.length} dotfiles on your system`);
-
-  let trackedCount = 0;
-
-  // Handle non-sensitive files
-  if (nonSensitiveFiles.length > 0) {
-    // Group by category and show summary
-    const grouped: Record<string, DetectedFile[]> = {};
-    for (const file of nonSensitiveFiles) {
-      if (!grouped[file.category]) grouped[file.category] = [];
-      grouped[file.category].push(file);
-    }
-
-    console.log();
-    const categoryOrder = ['shell', 'git', 'editors', 'terminal', 'ssh', 'misc'];
-    const sortedCategories = Object.keys(grouped).sort((a, b) => {
-      const aIdx = categoryOrder.indexOf(a);
-      const bIdx = categoryOrder.indexOf(b);
-      if (aIdx === -1 && bIdx === -1) return a.localeCompare(b);
-      if (aIdx === -1) return 1;
-      if (bIdx === -1) return -1;
-      return aIdx - bIdx;
-    });
-
-    for (const category of sortedCategories) {
-      const files = grouped[category];
-      const config = DETECTION_CATEGORIES[category] || { icon: '-', name: category };
-      console.log(`  ${config.icon} ${config.name}: ${files.length} files`);
-    }
-    console.log();
-
-    const trackNow = await prompts.confirm('Would you like to track some of these now?', true);
-
-    if (trackNow) {
-      // Show multiselect with all files PRE-SELECTED by default
-      const options = nonSensitiveFiles.map((f) => ({
-        value: f.path,
-        label: `${collapsePath(f.path)}`,
-        hint: f.category,
-      }));
-
-      // Pre-select all non-sensitive files
-      const initialValues = nonSensitiveFiles.map((f) => f.path);
-
-      const selectedFiles = await prompts.multiselect(
-        'Select files to track (all pre-selected; use space to toggle selection):',
-        options,
-        { initialValues }
-      );
-
-      // Handle sensitive files with individual prompts
-      const filesToTrack = [...selectedFiles];
-
-      if (sensitiveFiles.length > 0) {
-        console.log();
-        prompts.log.warning(`Found ${sensitiveFiles.length} sensitive file(s):`);
-
-        for (const sf of sensitiveFiles) {
-          console.log(c.warning(`  ! ${collapsePath(sf.path)} - ${sf.description || sf.category}`));
-        }
-
-        console.log();
-        const trackSensitive = await prompts.confirm(
-          'Would you like to review sensitive files? (Ensure your repo is PRIVATE)',
-          false
-        );
-
-        if (trackSensitive) {
-          for (const sf of sensitiveFiles) {
-            const track = await prompts.confirm(`Track ${collapsePath(sf.path)}?`, false);
-            if (track) {
-              filesToTrack.push(sf.path);
-            }
-          }
-        }
-      }
-
-      if (filesToTrack.length > 0) {
-        // Track files with beautiful progress display
-        trackedCount = await trackFilesWithProgressInit(filesToTrack, tuckDir);
-      }
-    } else {
-      prompts.log.info("Run 'tuck scan' later to interactively add files");
-    }
-  }
-
-  // Handle case where only sensitive files were found
-  if (nonSensitiveFiles.length === 0 && sensitiveFiles.length > 0) {
-    console.log();
-    prompts.log.warning(`Found ${sensitiveFiles.length} sensitive file(s):`);
-
-    for (const sf of sensitiveFiles) {
-      console.log(c.warning(`  ! ${collapsePath(sf.path)} - ${sf.description || sf.category}`));
-    }
-
-    console.log();
-    const trackSensitive = await prompts.confirm(
-      'Would you like to review these sensitive files? (Ensure your repo is PRIVATE)',
-      false
-    );
-
-    if (trackSensitive) {
-      const filesToTrack: string[] = [];
-      for (const sf of sensitiveFiles) {
-        const track = await prompts.confirm(`Track ${collapsePath(sf.path)}?`, false);
-        if (track) {
-          filesToTrack.push(sf.path);
-        }
-      }
-
-      if (filesToTrack.length > 0) {
-        // Track files with beautiful progress display
-        trackedCount = await trackFilesWithProgressInit(filesToTrack, tuckDir);
-      }
-    } else {
-      prompts.log.info("Run 'tuck scan' later to interactively add files");
-    }
-  }
-
-  // Handle case where no files were found
-  if (detectedFiles.length === 0) {
-    console.log();
-    prompts.log.info('No dotfiles detected on your system');
-    prompts.log.info("Run 'tuck add <path>' to manually track files");
-  }
+  const trackedCount = await scanAndTrackLocalDotfiles(tuckDir);
 
   // ========== STEP 3: Commit and Push ==========
-  if (trackedCount > 0) {
-    console.log();
-
-    if (remoteUrl) {
-      // Remote is configured - offer to commit AND push
-      const action = await prompts.select('Your files are tracked. What would you like to do?', [
-        {
-          value: 'commit-push',
-          label: 'Commit and push to remote',
-          hint: 'Recommended - sync your dotfiles now',
-        },
-        {
-          value: 'commit-only',
-          label: 'Commit only',
-          hint: "Save locally, push later with 'tuck push'",
-        },
-        {
-          value: 'skip',
-          label: 'Skip for now',
-          hint: "Run 'tuck sync' later",
-        },
-      ]);
-
-      if (action !== 'skip') {
-        const commitSpinner = prompts.spinner();
-        commitSpinner.start('Committing changes...');
-
-        await stageAll(tuckDir);
-        const commitHash = await commit(tuckDir, `Add ${trackedCount} dotfiles via tuck init`);
-
-        commitSpinner.stop(`Committed: ${commitHash.slice(0, 7)}`);
-
-        if (action === 'commit-push') {
-          const pushSpinner = prompts.spinner();
-          pushSpinner.start('Pushing to remote...');
-
-          try {
-            await push(tuckDir, { remote: 'origin', branch: 'main', setUpstream: true });
-            pushSpinner.stop('Pushed successfully!');
-
-            // Show success with URL
-            let viewUrl = remoteUrl;
-            if (viewUrl.startsWith('git@github.com:')) {
-              viewUrl = viewUrl
-                .replace('git@github.com:', 'https://github.com/')
-                .replace('.git', '');
-            } else if (viewUrl.startsWith('https://github.com/')) {
-              viewUrl = viewUrl.replace('.git', '');
-            }
-
-            console.log();
-            prompts.note(
-              `Your dotfiles are now live at:\n${viewUrl}\n\n` +
-                `On a new machine, run:\n  tuck init --from ${viewUrl}`,
-              'Success!'
-            );
-          } catch (error) {
-            pushSpinner.stop('Push failed');
-            const errorMsg = error instanceof Error ? error.message : String(error);
-            prompts.log.warning(`Could not push: ${errorMsg}`);
-            prompts.log.info("Run 'tuck push' to try again");
-          }
-        } else {
-          prompts.log.info("Run 'tuck push' when you're ready to upload to remote");
-        }
-      }
-    } else {
-      // No remote configured
-      const shouldCommit = await prompts.confirm('Commit these changes locally?', true);
-
-      if (shouldCommit) {
-        const commitSpinner = prompts.spinner();
-        commitSpinner.start('Committing...');
-
-        await stageAll(tuckDir);
-        const commitHash = await commit(tuckDir, `Add ${trackedCount} dotfiles via tuck init`);
-
-        commitSpinner.stop(`Committed: ${commitHash.slice(0, 7)}`);
-        prompts.log.info("Set up a remote with 'tuck push' to backup your dotfiles");
-      }
-    }
-  }
+  await commitAndOfferPush(tuckDir, trackedCount, remoteUrl);
 
   prompts.outro('Tuck initialized successfully!');
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,6 +4,7 @@ import { prompts, logger, formatCount, colors as c } from '../ui/index.js';
 import { getTuckDir } from '../lib/paths.js';
 import { loadManifest, getAllTrackedFiles } from '../lib/manifest.js';
 import { NotInitializedError } from '../errors.js';
+import { enterReadOnlyMode } from '../lib/readOnlyMode.js';
 import { setJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 import { CATEGORIES } from '../constants.js';
 import type { ListOptions } from '../types.js';
@@ -108,6 +109,9 @@ const printJson = (groups: CategoryGroup[]): void => {
 };
 
 const runList = async (options: ListOptions): Promise<void> => {
+  // list is a read-only inspection command: it must never unlock the keystore or
+  // touch a secret backend. This guarantees zero prompts (see lib/readOnlyMode).
+  enterReadOnlyMode();
   const tuckDir = getTuckDir();
 
   // Verify tuck is initialized

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -1,0 +1,235 @@
+/**
+ * `tuck merge` — manage per-file structured (JSON) three-way merge policies.
+ *
+ * A merge policy tells `tuck sync` to reconcile a tracked JSON file key-by-key
+ * (union allowlists, deep-merge objects, surface real conflicts) instead of
+ * silently overwriting it when local and remote have both diverged. High-churn
+ * agent configs (Claude `settings.json`, `.mcp.json`, …) get a safe default
+ * policy automatically; everything else is opt-in here.
+ *
+ * Subcommands:
+ *   list                     show every file's effective merge policy
+ *   show <path-or-id>        show one file's effective policy (and its source)
+ *   set  <path-or-id>        set/override the policy on a file
+ *   unset <path-or-id>       remove an explicit policy (reverts to auto/none)
+ */
+
+import { Command } from 'commander';
+import { logger, colors as c } from '../ui/index.js';
+import { getTuckDir, collapsePath, expandPath } from '../lib/paths.js';
+import { loadManifest, updateFileInManifest } from '../lib/manifest.js';
+import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { resolveMergePolicy, DEFAULT_JSON_MERGE_POLICY } from '../lib/jsonMerge.js';
+import type {
+  ArrayMergeStrategy,
+  ConflictResolution,
+  MergePolicy,
+} from '../lib/jsonMerge.js';
+import { NotInitializedError, TuckError } from '../errors.js';
+import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
+
+const ARRAY_STRATEGIES: ReadonlySet<string> = new Set(['union', 'concat', 'replace']);
+const CONFLICT_STRATEGIES: ReadonlySet<string> = new Set(['ours', 'theirs', 'manual']);
+
+const ensureInitialized = async (): Promise<string> => {
+  const tuckDir = getTuckDir();
+  try {
+    await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+  return tuckDir;
+};
+
+/** Resolve a tracked file by manifest id first, then by source path. */
+const resolveTrackedFile = (
+  files: Record<string, TrackedFileOutput>,
+  target: string
+): { id: string; file: TrackedFileOutput } => {
+  if (files[target]) return { id: target, file: files[target] };
+  // Manifest sources are stored collapsed (~/...); the shell expands unquoted
+  // ~ arguments to absolute paths, so normalize before comparing (same as
+  // `tuck remove`).
+  const collapsed = collapsePath(expandPath(target));
+  for (const [id, file] of Object.entries(files)) {
+    if (file.source === target || file.source === collapsed) return { id, file };
+  }
+  throw new TuckError(`No tracked file matches: ${target}`, 'FILE_NOT_TRACKED', [
+    'Pass either a manifest id or the original source path (e.g. ~/.claude/settings.json).',
+    'Run `tuck list` to see tracked files.',
+  ]);
+};
+
+interface EffectivePolicy {
+  source: string;
+  explicit: boolean;
+  policy: MergePolicy | null;
+}
+
+const describeEffective = (file: TrackedFileOutput): EffectivePolicy => ({
+  source: file.source,
+  explicit: file.merge !== undefined,
+  policy: resolveMergePolicy(file.source, file.merge),
+});
+
+const policyLabel = (eff: EffectivePolicy): string => {
+  if (!eff.policy) return c.dim('none (plain copy)');
+  const origin = eff.explicit ? c.cyan('explicit') : c.dim('auto');
+  return `${origin} ${c.dim(`json · arrays=${eff.policy.arrays} · conflict=${eff.policy.conflict}`)}`;
+};
+
+export const listAction = async (opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck merge list');
+  const tuckDir = await ensureInitialized();
+  const manifest = await loadManifest(tuckDir);
+
+  const rows = Object.values(manifest.files)
+    .map(describeEffective)
+    .filter((e) => e.policy !== null)
+    .sort((a, b) => a.source.localeCompare(b.source));
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      count: rows.length,
+      files: rows.map((e) => ({
+        source: e.source,
+        explicit: e.explicit,
+        policy: e.policy,
+      })),
+    });
+    return;
+  }
+
+  if (rows.length === 0) {
+    logger.info('No files have a structured merge policy.');
+    logger.dim('Set one with: tuck merge set <path> --arrays union --conflict manual');
+    return;
+  }
+
+  console.log();
+  console.log(c.bold('Structured merge policies:'));
+  for (const e of rows) {
+    console.log(`  ${c.cyan(collapsePath(e.source).padEnd(34))} ${policyLabel(e)}`);
+  }
+  console.log();
+};
+
+export const showAction = async (target: string, opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck merge show');
+  const tuckDir = await ensureInitialized();
+  const manifest = await loadManifest(tuckDir);
+  const { file } = resolveTrackedFile(manifest.files, target);
+  const eff = describeEffective(file);
+
+  if (isJsonMode()) {
+    emitJsonOk({ source: eff.source, explicit: eff.explicit, policy: eff.policy });
+    return;
+  }
+
+  console.log();
+  console.log(`${c.bold('File:')}   ${c.cyan(collapsePath(eff.source))}`);
+  console.log(`${c.bold('Policy:')} ${policyLabel(eff)}`);
+  if (!eff.explicit && eff.policy) {
+    logger.dim('This policy is auto-applied to a known agent config. Use `tuck merge set` to override.');
+  }
+  console.log();
+};
+
+export const setAction = async (
+  target: string,
+  opts: { json?: boolean; arrays?: string; conflict?: string }
+): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck merge set');
+  const tuckDir = await ensureInitialized();
+  const manifest = await loadManifest(tuckDir);
+  const { id, file } = resolveTrackedFile(manifest.files, target);
+
+  if (opts.arrays && !ARRAY_STRATEGIES.has(opts.arrays)) {
+    throw new TuckError(`Invalid --arrays value: ${opts.arrays}`, 'MERGE_POLICY_INVALID', [
+      'Valid values: union, concat, replace.',
+    ]);
+  }
+  if (opts.conflict && !CONFLICT_STRATEGIES.has(opts.conflict)) {
+    throw new TuckError(`Invalid --conflict value: ${opts.conflict}`, 'MERGE_POLICY_INVALID', [
+      'Valid values: ours, theirs, manual.',
+    ]);
+  }
+
+  // Start from the existing explicit policy (if any) so a partial update keeps
+  // the other field; otherwise fall back to the safe defaults.
+  const previous = file.merge ?? DEFAULT_JSON_MERGE_POLICY;
+  const policy: MergePolicy = {
+    format: 'json',
+    arrays: (opts.arrays as ArrayMergeStrategy | undefined) ?? previous.arrays,
+    conflict: (opts.conflict as ConflictResolution | undefined) ?? previous.conflict,
+  };
+
+  await updateFileInManifest(tuckDir, id, { merge: policy });
+
+  if (isJsonMode()) {
+    emitJsonOk({ source: file.source, policy });
+    return;
+  }
+
+  logger.success(`Set merge policy for ${collapsePath(file.source)}`);
+  logger.dim(`json · arrays=${policy.arrays} · conflict=${policy.conflict}`);
+};
+
+export const unsetAction = async (target: string, opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck merge unset');
+  const tuckDir = await ensureInitialized();
+  const manifest = await loadManifest(tuckDir);
+  const { id, file } = resolveTrackedFile(manifest.files, target);
+
+  const hadPolicy = file.merge !== undefined;
+  // Setting to undefined drops the key on serialization (JSON.stringify omits it).
+  await updateFileInManifest(tuckDir, id, { merge: undefined });
+
+  const effectiveAfter = resolveMergePolicy(file.source, undefined);
+
+  if (isJsonMode()) {
+    emitJsonOk({ source: file.source, removed: hadPolicy, effectivePolicy: effectiveAfter });
+    return;
+  }
+
+  if (!hadPolicy) {
+    logger.info(`${collapsePath(file.source)} had no explicit merge policy.`);
+  } else {
+    logger.success(`Removed explicit merge policy for ${collapsePath(file.source)}`);
+  }
+  if (effectiveAfter) {
+    logger.dim('A default policy still applies automatically (known agent config).');
+  }
+};
+
+export const mergeCommand = new Command('merge')
+  .description('Manage structured (JSON) three-way merge policies for tracked files')
+  .addCommand(
+    new Command('list')
+      .description('List files with an effective structured merge policy')
+      .option('--json', 'Emit JSON envelope')
+      .action(listAction)
+  )
+  .addCommand(
+    new Command('show')
+      .description("Show a file's effective merge policy")
+      .argument('<path-or-id>', 'Manifest id or source path of the tracked file')
+      .option('--json', 'Emit JSON envelope')
+      .action(showAction)
+  )
+  .addCommand(
+    new Command('set')
+      .description('Set (or override) the structured merge policy on a file')
+      .argument('<path-or-id>', 'Manifest id or source path of the tracked file')
+      .option('--arrays <strategy>', 'Array reconciliation: union | concat | replace')
+      .option('--conflict <strategy>', 'Scalar conflict resolution: ours | theirs | manual')
+      .option('--json', 'Emit JSON envelope')
+      .action(setAction)
+  )
+  .addCommand(
+    new Command('unset')
+      .description('Remove an explicit merge policy (reverts to auto-detected or none)')
+      .argument('<path-or-id>', 'Manifest id or source path of the tracked file')
+      .option('--json', 'Emit JSON envelope')
+      .action(unsetAction)
+  );

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -12,10 +12,11 @@ import {
   getCurrentBranch,
   addRemote,
 } from '../lib/git.js';
-import { NotInitializedError, GitError } from '../errors.js';
+import { NotInitializedError, GitError, OperationCancelledError } from '../errors.js';
 import type { PushOptions } from '../types.js';
 import { logForcePush } from '../lib/audit.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { isNonInteractive } from '../lib/agentMode.js';
 import { loadConfig } from '../lib/config.js';
 import { assertRemoteAvailable } from '../lib/providers/index.js';
 
@@ -201,10 +202,18 @@ const runPush = async (options: PushOptions): Promise<void> => {
     }
   }
 
-  // Require explicit confirmation for force push. In non-interactive mode
-  // (--json / --yes) the caller has already opted in, so skip the prompt.
+  // Require explicit confirmation for force push. Only `--json` / `--yes` count
+  // as opting in (see `nonInteractive` above). If the caller did NOT opt in but
+  // we also cannot prompt (--non-interactive, JSON mode, or a non-TTY stdin),
+  // we must fail LOUDLY: silently cancelling here previously exited 0 having
+  // pushed nothing — a false success an agent could not detect.
   if (options.force) {
     if (!nonInteractive) {
+      if (isNonInteractive()) {
+        throw new OperationCancelledError(
+          're-run with --yes to confirm the --force push (force push cannot be confirmed non-interactively)'
+        );
+      }
       const confirmed = await prompts.confirmDangerous(
         'Force push will overwrite remote history.\n' +
           'This can cause data loss for collaborators and is generally discouraged.',

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -120,23 +120,19 @@ const runInteractivePush = async (tuckDir: string): Promise<void> => {
     });
     prompts.log.success('Pushed successfully!');
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
-
-    // Provide specific guidance based on common errors
-    if (errorMsg.includes('Permission denied') || errorMsg.includes('publickey')) {
-      prompts.log.error('Authentication failed');
-      prompts.log.info('Check your SSH keys with: ssh -T git@github.com');
-      prompts.log.info('Or try switching to HTTPS: git remote set-url origin https://...');
-    } else if (errorMsg.includes('Could not resolve host') || errorMsg.includes('Network')) {
-      prompts.log.error('Network error - could not reach remote');
-      prompts.log.info('Check your internet connection and try again');
-    } else if (errorMsg.includes('rejected') || errorMsg.includes('non-fast-forward')) {
-      prompts.log.error('Push rejected - remote has changes');
-      prompts.log.info("Run 'tuck pull' first, then push again");
-      prompts.log.info("Or use 'tuck push --force' to overwrite (use with caution)");
-    } else {
-      prompts.log.error(`Push failed: ${errorMsg}`);
+    // The lib layer (describeGitError) already classified the failure with a
+    // contextual message and suggestions; re-classifying here by substring
+    // misfires (e.g. "authentication ... was rejected" matched the
+    // push-rejected branch). Present the lib's diagnosis verbatim.
+    if (error instanceof GitError) {
+      prompts.log.error(error.message);
+      for (const suggestion of error.suggestions ?? []) {
+        prompts.log.info(suggestion);
+      }
+      return;
     }
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    prompts.log.error(`Push failed: ${errorMsg}`);
     return;
   }
 
@@ -241,17 +237,13 @@ const runPush = async (options: PushOptions): Promise<void> => {
     }
     logger.success('Pushed successfully!');
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
-
-    if (errorMsg.includes('Permission denied') || errorMsg.includes('publickey')) {
-      throw new GitError('Authentication failed', 'Check your SSH keys: ssh -T git@github.com');
-    } else if (errorMsg.includes('Could not resolve host') || errorMsg.includes('Network')) {
-      throw new GitError('Network error', 'Check your internet connection');
-    } else if (errorMsg.includes('rejected') || errorMsg.includes('non-fast-forward')) {
-      throw new GitError('Push rejected', "Run 'tuck pull' first, or use --force");
-    } else {
-      throw new GitError('Push failed', errorMsg);
+    // Lib-layer GitErrors are already contextual (describeGitError) — rethrow
+    // as-is instead of re-classifying by message substring, which misfired on
+    // messages like "authentication with the remote was rejected".
+    if (error instanceof GitError) {
+      throw error;
     }
+    throw new GitError('Push failed', error instanceof Error ? error.message : String(error));
   }
 };
 

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -13,6 +13,8 @@ import {
 import { loadManifest, removeFileFromManifest, getAllTrackedFiles } from '../lib/manifest.js';
 import { deleteFileOrDir, copyFileOrDir } from '../lib/files.js';
 import { resolveLiveTarget } from '../lib/repoScope.js';
+import { createSnapshot } from '../lib/timemachine.js';
+import { undoBreadcrumb } from '../lib/undoHint.js';
 import { NotInitializedError, FileNotTrackedError } from '../errors.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 import type { RemoveOptions, FileStrategy } from '../types.js';
@@ -149,6 +151,33 @@ const removeFiles = async (
   tuckDir: string,
   options: RemoveOptions
 ): Promise<void> => {
+  // ONE snapshot covering every repo copy this run will delete, taken BEFORE
+  // the loop — a per-file snapshot would leave the undo breadcrumb pointing at
+  // a checkpoint that restores only the LAST file. A snapshot hiccup must not
+  // block the removal.
+  let snapshotId: string | undefined;
+  if (options.delete) {
+    const deletablePaths: string[] = [];
+    for (const file of filesToRemove) {
+      if (await pathExists(file.destination)) deletablePaths.push(file.destination);
+    }
+    if (deletablePaths.length > 0) {
+      try {
+        const snapshot = await createSnapshot(
+          deletablePaths,
+          `Pre-remove delete backup: ${filesToRemove.map((f) => f.source).join(', ')}`
+        );
+        snapshotId = snapshot.id;
+      } catch (error) {
+        if (!isJsonMode()) {
+          logger.dim(
+            `  Pre-delete snapshot skipped: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
+    }
+  }
+
   for (const file of filesToRemove) {
     // Restore a symlinked original to a real file first (unless --keep-original),
     // so untracking + optional --delete can never leave a dangling symlink with
@@ -179,6 +208,13 @@ const removeFiles = async (
         logger.dim('  Also deleted from repository');
       }
     }
+  }
+
+  // Surface the recovery path after a destructive delete (IDEAS 6.5). Only shown
+  // when --delete actually removed a repo copy we snapshotted — a plain untrack
+  // leaves the repo copy intact, so `tuck undo` would not be the right recovery.
+  if (!isJsonMode() && snapshotId) {
+    logger.info(undoBreadcrumb(snapshotId));
   }
 };
 

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -15,8 +15,8 @@ import { deleteFileOrDir, copyFileOrDir } from '../lib/files.js';
 import { resolveLiveTarget } from '../lib/repoScope.js';
 import { createSnapshot } from '../lib/timemachine.js';
 import { undoBreadcrumb } from '../lib/undoHint.js';
-import { NotInitializedError, FileNotTrackedError } from '../errors.js';
-import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { NotInitializedError, FileNotTrackedError, BackupError } from '../errors.js';
+import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import type { RemoveOptions, FileStrategy } from '../types.js';
 import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
 
@@ -169,11 +169,23 @@ const removeFiles = async (
         );
         snapshotId = snapshot.id;
       } catch (error) {
-        if (!isJsonMode()) {
-          logger.dim(
-            `  Pre-delete snapshot skipped: ${error instanceof Error ? error.message : String(error)}`
+        const reason = error instanceof Error ? error.message : String(error);
+        // Fail CLOSED: a destructive `--delete` must not proceed without a
+        // recovery snapshot. Abort with a clear error unless the user explicitly
+        // opted into `--force`, in which case proceed but surface a warning
+        // (into the JSON envelope in --json mode) so the missing backup is never
+        // silent.
+        if (!options.force) {
+          throw new BackupError(
+            `Could not create a pre-delete backup snapshot: ${reason}. ` +
+              'Refusing to delete without a recovery point.',
+            ['Re-run with --force to delete anyway (no backup will be made)', 'Check available disk space']
           );
         }
+        const warning =
+          `Pre-delete snapshot failed (${reason}); proceeding without a backup because --force was given.`;
+        if (isJsonMode()) addJsonWarning(warning);
+        else logger.warning(warning);
       }
     }
   }
@@ -281,6 +293,7 @@ const runInteractiveRemove = async (tuckDir: string, options: RemoveOptions = {}
   await removeFiles(filesToRemove, tuckDir, {
     delete: shouldDelete,
     keepOriginal: options.keepOriginal,
+    force: options.force,
   });
 
   prompts.outro(`Removed ${selectedFiles.length} ${selectedFiles.length === 1 ? 'file' : 'files'}`);
@@ -325,6 +338,7 @@ export const removeCommand = new Command('remove')
   .description('Stop tracking dotfiles')
   .argument('[paths...]', 'Paths to dotfiles to untrack')
   .option('--delete', 'Also delete from tuck repository')
+  .option('--force', 'With --delete, proceed even if the pre-delete backup snapshot fails (no backup)')
   .option('--keep-original', "Don't restore symlinks to regular files")
   .option('--json', 'Emit JSON envelope to stdout (suppresses interactive UI)')
   .option('-y, --yes', 'Auto-confirm prompts (required with --json for the interactive picker)')

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -22,7 +22,8 @@ import {
   loadReposRegistry,
 } from '../lib/repoScope.js';
 import { loadConfig } from '../lib/config.js';
-import { copyFileOrDir, createSymlink, setFilePermissions } from '../lib/files.js';
+import { copyFileOrDir, createSymlink, setFilePermissions, getFileChecksum } from '../lib/files.js';
+import { recordDriftEntry } from '../lib/crypto/driftCache.js';
 import { ensureDir } from 'fs-extra';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from '../lib/materialize.js';
 import { mergeSubtreeIntoLive } from '../lib/jsonKey.js';
@@ -32,7 +33,7 @@ import { NotInitializedError, FileNotFoundError, TuckError, MaterializeError, Js
 import { CATEGORIES } from '../constants.js';
 import type { RestoreOptions } from '../types.js';
 import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
-import { restoreFiles as restoreSecrets, getSecretCount } from '../lib/secrets/index.js';
+import { restoreFiles as restoreSecrets, restoreContent, getAllSecrets, getSecretCount } from '../lib/secrets/index.js';
 
 /**
  * Fix permissions for SSH files after restore
@@ -208,6 +209,17 @@ const restoreFilesInternal = async (
   const ctx = await buildMaterializeCtx(tuckDir);
   const shouldBackup = options.backup ?? config.files.backupOnRestore;
 
+  // Load stored secrets ONCE when any restore may need them (non-dry-run, not
+  // --no-secrets, and the store is non-empty). getSecretCount gates getAllSecrets
+  // so a zero-secret run never reads the store. jsonKey subtrees resolve their
+  // placeholders in-place during the merge below (subtree-scoped, never the
+  // untracked remainder); whole (non-jsonKey) files run the batch restore pass at
+  // the end.
+  const wantSecrets = !options.noSecrets && !options.dryRun;
+  const secretCount = wantSecrets ? await getSecretCount(tuckDir) : 0;
+  const secretsMap = secretCount > 0 ? await getAllSecrets(tuckDir) : {};
+  const hasSecrets = Object.keys(secretsMap).length > 0;
+
   // Prepare hook options
   const hookOptions: HookOptions = {
     skipHooks: options.noHooks,
@@ -230,6 +242,12 @@ const restoreFilesInternal = async (
 
   let restoredCount = 0;
   const restoredPaths: string[] = [];
+  // Non-jsonKey targets get the whole-file batch secret restore. jsonKey files
+  // are EXCLUDED — their untracked keys must not be rewritten — and their subtree
+  // secrets are resolved in-place during the merge (accumulated below).
+  const wholeFileRestorePaths: string[] = [];
+  let jsonKeySecretsRestored = 0;
+  const jsonKeyUnresolved = new Set<string>();
   const skipped: string[] = [];
 
   for (const file of files) {
@@ -336,7 +354,17 @@ const restoreFilesInternal = async (
     let jsonKeyMerged: string | null = null;
     if (file.jsonKey) {
       try {
-        const repoSubtree = await readFile(file.destination, 'utf8');
+        let repoSubtree = await readFile(file.destination, 'utf8');
+        // Resolve secrets in the tracked SUBTREE ONLY, before merging it into the
+        // live file — never over the untracked remainder, which tuck does not
+        // manage. This is why jsonKey files are excluded from the whole-file
+        // batch restore pass at the end.
+        if (hasSecrets) {
+          const r = restoreContent(repoSubtree, secretsMap);
+          repoSubtree = r.restoredContent;
+          jsonKeySecretsRestored += r.restored;
+          for (const u of r.unresolved) jsonKeyUnresolved.add(u);
+        }
         const liveContent = (await pathExists(targetPath)) ? await readFile(targetPath, 'utf8') : null;
         jsonKeyMerged = mergeSubtreeIntoLive(liveContent, repoSubtree, file.jsonKey);
       } catch (err) {
@@ -388,20 +416,36 @@ const restoreFilesInternal = async (
       await fixGPGPermissions(targetPath);
     });
 
+    // Warm the encrypted-file drift cache with the materialized plaintext we just
+    // wrote, pinned to the repo copy's checksum, so a later read-only status/diff
+    // can detect local drift WITHOUT decrypting (lib/crypto/driftCache.ts).
+    // Best-effort — a cache failure must never fail the restore.
+    if (file.encrypted && materialized !== null) {
+      try {
+        const repoChecksum = await getFileChecksum(file.destination);
+        await recordDriftEntry(file.id, materialized, repoChecksum);
+      } catch {
+        // Never fail a restore over a drift-cache write.
+      }
+    }
+
     restoredCount++;
     restoredPaths.push(targetPath);
+    // jsonKey files are excluded from the whole-file batch restore (their subtree
+    // secrets were already handled above); everything else runs it.
+    if (!file.jsonKey) wholeFileRestorePaths.push(targetPath);
   }
 
-  // Restore secrets (replace placeholders with actual values)
-  let secretsRestored = 0;
-  let unresolvedPlaceholders: string[] = [];
+  // Restore secrets (replace placeholders with actual values) for whole
+  // (non-jsonKey) files. jsonKey subtree secrets were resolved in-place above.
+  let secretsRestored = jsonKeySecretsRestored;
+  const unresolvedPlaceholders: string[] = [...jsonKeyUnresolved];
 
-  if (!options.noSecrets && !options.dryRun && restoredPaths.length > 0) {
-    const secretCount = await getSecretCount(tuckDir);
-    if (secretCount > 0) {
-      const secretResult = await restoreSecrets(restoredPaths, tuckDir);
-      secretsRestored = secretResult.totalRestored;
-      unresolvedPlaceholders = secretResult.allUnresolved;
+  if (hasSecrets && wholeFileRestorePaths.length > 0) {
+    const secretResult = await restoreSecrets(wholeFileRestorePaths, tuckDir);
+    secretsRestored += secretResult.totalRestored;
+    for (const u of secretResult.allUnresolved) {
+      if (!unresolvedPlaceholders.includes(u)) unresolvedPlaceholders.push(u);
     }
   }
 

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -25,9 +25,10 @@ import { loadConfig } from '../lib/config.js';
 import { copyFileOrDir, createSymlink, setFilePermissions } from '../lib/files.js';
 import { ensureDir } from 'fs-extra';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from '../lib/materialize.js';
+import { mergeSubtreeIntoLive } from '../lib/jsonKey.js';
 import { createBackup } from '../lib/backup.js';
 import { runPreRestoreHook, runPostRestoreHook, type HookOptions } from '../lib/hooks.js';
-import { NotInitializedError, FileNotFoundError, TuckError, MaterializeError } from '../errors.js';
+import { NotInitializedError, FileNotFoundError, TuckError, MaterializeError, JsonKeyError } from '../errors.js';
 import { CATEGORIES } from '../constants.js';
 import type { RestoreOptions } from '../types.js';
 import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
@@ -104,6 +105,11 @@ interface FileToRestore {
   template: boolean;
   /** Decrypt the repo source (TCKE1) before writing to the live system. */
   encrypted: boolean;
+  /**
+   * Dot-delimited JSON key path when the repo copy is only a subtree. On restore
+   * it is deep-merged back into the live file rather than overwriting it.
+   */
+  jsonKey?: string;
 }
 
 interface RestoreResult {
@@ -157,6 +163,7 @@ const prepareFilesToRestore = async (
         permissions: tracked.file.permissions,
         template: tracked.file.template,
         encrypted: tracked.file.encrypted,
+        jsonKey: tracked.file.jsonKey,
       });
     }
   } else {
@@ -182,6 +189,7 @@ const prepareFilesToRestore = async (
         permissions: file.permissions,
         template: file.template,
         encrypted: file.encrypted,
+        jsonKey: file.jsonKey,
       });
     }
   }
@@ -296,7 +304,9 @@ const restoreFilesInternal = async (
     // place, never SYMLINKED — a symlink would expose raw TCKE1 ciphertext or the
     // {{ }} template source at the live path. Force copy+materialize for them even
     // when the symlink strategy is otherwise in effect (--symlink / config).
-    const linkThisFile = useSymlink && !file.template && !file.encrypted;
+    // JSON-key files are ALSO copy/merge-only: symlinking would expose the
+    // subtree AS the whole live file and drop every other key.
+    const linkThisFile = useSymlink && !file.template && !file.encrypted && !file.jsonKey;
 
     // Pre-materialize template/encrypted files (decrypt/render) BEFORE any write,
     // so a failed / absent-passphrase decryption skips this file and never ships
@@ -320,9 +330,36 @@ const restoreFilesInternal = async (
       }
     }
 
+    // JSON-key merge is computed BEFORE the spinner so a corrupt/JSONC live
+    // file skips THIS entry loudly (like MaterializeError above) and the rest
+    // of the run continues.
+    let jsonKeyMerged: string | null = null;
+    if (file.jsonKey) {
+      try {
+        const repoSubtree = await readFile(file.destination, 'utf8');
+        const liveContent = (await pathExists(targetPath)) ? await readFile(targetPath, 'utf8') : null;
+        jsonKeyMerged = mergeSubtreeIntoLive(liveContent, repoSubtree, file.jsonKey);
+      } catch (err) {
+        if (err instanceof JsonKeyError) {
+          const msg = `Skipped ${file.source}: ${err.message}`;
+          logger.warning(msg);
+          if (isJsonMode()) addJsonWarning(msg);
+          skipped.push(file.source);
+          continue;
+        }
+        throw err;
+      }
+    }
+
     // Restore file
     await withSpinner(`Restoring ${file.source}...`, async () => {
-      if (linkThisFile) {
+      if (file.jsonKey && jsonKeyMerged !== null) {
+        // Write the tracked subtree back into the live file, preserving every
+        // other key (tokens, caches, machine state). A backup was already
+        // taken above when the live file existed.
+        await ensureDir(dirname(targetPath));
+        await writeFile(targetPath, jsonKeyMerged, 'utf-8');
+      } else if (linkThisFile) {
         await createSymlink(file.destination, targetPath, { overwrite: true });
       } else if (materialized !== null) {
         // Decrypted/rendered content written directly (not a raw repo copy).

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,0 +1,385 @@
+/**
+ * `tuck rules` — rules fan-out (one canonical AGENTS.md, many tool files).
+ *
+ * Track a single canonical rules/instructions file and fan it out on demand
+ * into every tool-specific variant your agents look for (CLAUDE.md, .cursorrules,
+ * .windsurfrules, copilot-instructions.md, GEMINI.md, .cursor/rules), globally
+ * or per-repo, with per-tool overrides via tuck's template engine. See §1.4.
+ *
+ * Subcommands:
+ *   track <path>   — designate a canonical rules file and its fan-out targets
+ *   list           — show tracked sets and per-tool sync status
+ *   apply          — materialize/symlink each variant (snapshots + confirms)
+ *   untrack <id>   — stop tracking a set (optionally deleting generated files)
+ */
+
+import { Command } from 'commander';
+import { getTuckDir, collapsePath } from '../lib/paths.js';
+import { loadManifest } from '../lib/manifest.js';
+import { NotInitializedError, TuckError } from '../errors.js';
+import {
+  setJsonMode,
+  isJsonMode,
+  emitJsonOk,
+} from '../lib/jsonOutput.js';
+import { logger, prompts, colors as c } from '../ui/index.js';
+import {
+  trackRuleSet,
+  untrackRuleSet,
+  loadRulesManifest,
+  applyRuleSets,
+  computeSetStatus,
+  buildRulesContext,
+  removeToolVariants,
+  isKnownTool,
+  TOOL_LABELS,
+  ALL_TOOLS,
+  type ToolStatus,
+  listExistingToolVariants,
+} from '../lib/rulesFanout.js';
+import { createSnapshot } from '../lib/timemachine.js';
+import type { RuleToolName } from '../schemas/rules.schema.js';
+
+const ensureInitialized = async (tuckDir: string): Promise<void> => {
+  try {
+    await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+};
+
+/** Parse a repeatable/comma-separated `--tool` option into known tool names. */
+const parseTools = (raw: string[] | undefined): RuleToolName[] => {
+  if (!raw || raw.length === 0) return [];
+  const names = raw.flatMap((v) => v.split(',')).map((v) => v.trim()).filter(Boolean);
+  const out: RuleToolName[] = [];
+  for (const n of names) {
+    if (!isKnownTool(n)) {
+      throw new TuckError(`Unknown tool "${n}"`, 'RULES_UNKNOWN_TOOL', [
+        `Known tools: ${ALL_TOOLS.join(', ')}`,
+      ]);
+    }
+    if (!out.includes(n)) out.push(n);
+  }
+  return out;
+};
+
+/** Parse repeatable `--var k=v` into a flat record. */
+const parseVars = (raw: string[] | undefined): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const entry of raw ?? []) {
+    const eq = entry.indexOf('=');
+    if (eq <= 0) {
+      throw new TuckError(`Invalid --var "${entry}" (expected key=value)`, 'RULES_BAD_VAR');
+    }
+    out[entry.slice(0, eq).trim()] = entry.slice(eq + 1);
+  }
+  return out;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// track
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TrackOpts {
+  json?: boolean;
+  tool?: string[];
+  symlink?: boolean;
+  template?: boolean; // commander `--no-template` sets this false
+  var?: string[];
+}
+
+const trackAction = async (pathArg: string, opts: TrackOpts): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck rules track');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const { id, set } = await trackRuleSet(tuckDir, pathArg, {
+    tools: parseTools(opts.tool),
+    strategy: opts.symlink ? 'symlink' : 'materialize',
+    template: opts.template,
+    variables: parseVars(opts.var),
+  });
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      id,
+      source: set.source,
+      scope: set.scope,
+      repoRoot: set.repoRoot,
+      template: set.template,
+      tools: set.tools.map((t) => ({ tool: t.tool, strategy: t.strategy, path: t.path })),
+    });
+    return;
+  }
+
+  logger.success(`Tracking rules source: ${set.source}`);
+  logger.dim(`  id=${id}  scope=${set.scope}${set.repoRoot ? `  repo=${collapsePath(set.repoRoot)}` : ''}`);
+  logger.dim(`  fan-out → ${set.tools.map((t) => t.tool).join(', ')} (${set.tools[0]?.strategy})`);
+  logger.blank();
+  logger.info('Run `tuck rules apply` to write the tool variants.');
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// list
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STATUS_COLOR: Record<ToolStatus, (s: string) => string> = {
+  'in-sync': c.green,
+  missing: c.dim,
+  drift: c.yellow,
+  foreign: c.red,
+};
+
+const listAction = async (opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck rules list');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const manifest = await loadRulesManifest(tuckDir);
+  const base = await buildRulesContext(tuckDir);
+  const sets = Object.entries(manifest.sets);
+
+  const statuses = await Promise.all(
+    sets.map(async ([id, set]) => ({ id, ...(await computeSetStatus(set, base)) }))
+  );
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      count: statuses.length,
+      sets: statuses.map((s) => ({
+        id: s.id,
+        source: s.set.source,
+        scope: s.set.scope,
+        repoRoot: s.set.repoRoot,
+        sourceExists: s.sourceExists,
+        tools: s.tools.map((t) => ({
+          tool: t.tool,
+          strategy: t.strategy,
+          target: collapsePath(t.target),
+          status: t.status,
+        })),
+      })),
+    });
+    return;
+  }
+
+  if (statuses.length === 0) {
+    logger.info('No rules sources tracked yet.');
+    logger.dim('Run `tuck rules track <path>` to start.');
+    return;
+  }
+
+  for (const s of statuses) {
+    console.log();
+    console.log(`${c.bold(c.cyan(s.set.source))} ${c.dim(`[${s.set.scope}]`)}`);
+    console.log(`  ${c.dim(s.id)}`);
+    if (!s.sourceExists) console.log(`  ${c.red('! canonical source is missing on disk')}`);
+    for (const t of s.tools) {
+      const color = STATUS_COLOR[t.status];
+      console.log(
+        `    ${color('•')} ${t.tool.padEnd(11)} ${c.dim(collapsePath(t.target))} ${color(`(${t.status})`)}`
+      );
+    }
+  }
+  console.log();
+  logger.dim('Run `tuck rules apply` to bring variants in sync.');
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apply
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ApplyOpts {
+  json?: boolean;
+  id?: string;
+  dryRun?: boolean;
+  force?: boolean;
+  yes?: boolean;
+}
+
+const applyAction = async (opts: ApplyOpts): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck rules apply');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const nonInteractive = isJsonMode() || opts.yes || opts.force || !process.stdout.isTTY;
+  const context = await buildRulesContext(tuckDir);
+
+  const results = await applyRuleSets(tuckDir, {
+    id: opts.id,
+    dryRun: opts.dryRun,
+    force: opts.force,
+    context,
+    confirmOverwrite: nonInteractive
+      ? undefined
+      : async (target: string) =>
+          prompts.confirm(`Overwrite existing ${collapsePath(target)}?`, false),
+  });
+
+  const flat = results.flatMap((r) => r.applied.map((a) => ({ id: r.id, ...a })));
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      dryRun: !!opts.dryRun,
+      sets: results.length,
+      applied: flat.map((a) => ({
+        id: a.id,
+        tool: a.tool,
+        target: collapsePath(a.target),
+        action: a.action,
+        reason: a.reason,
+      })),
+    });
+    return;
+  }
+
+  if (flat.length === 0) {
+    logger.info('No tracked rule sets to apply.');
+    logger.dim('Run `tuck rules track <path>` first.');
+    return;
+  }
+
+  for (const a of flat) {
+    const label =
+      a.action === 'skipped'
+        ? c.dim(`skipped (${a.reason})`)
+        : opts.dryRun
+          ? c.yellow(`would ${a.action}`)
+          : c.green(a.action);
+    console.log(`  ${a.tool.padEnd(11)} ${c.dim(collapsePath(a.target))} — ${label}`);
+  }
+  logger.blank();
+  const changed = flat.filter((a) => a.action !== 'skipped').length;
+  if (opts.dryRun) {
+    logger.info(`Dry run: ${changed} variant${changed !== 1 ? 's' : ''} would change.`);
+  } else {
+    logger.success(`Fanned out ${changed} variant${changed !== 1 ? 's' : ''}.`);
+    if (changed > 0) logger.dim('To undo: tuck undo --latest');
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// untrack
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface UntrackOpts {
+  json?: boolean;
+  clean?: boolean;
+  yes?: boolean;
+}
+
+const untrackAction = async (idArg: string, opts: UntrackOpts): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck rules untrack');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const manifest = await loadRulesManifest(tuckDir);
+  const set = manifest.sets[idArg];
+  if (!set) {
+    throw new TuckError(`No tracked rule set with id "${idArg}"`, 'RULES_SET_NOT_FOUND', [
+      'Run `tuck rules list` to see tracked sets.',
+    ]);
+  }
+
+  let cleaned: string[] = [];
+  if (opts.clean) {
+    // --clean permanently deletes generated files: non-interactive callers
+    // must OPT IN with --yes (a redirected stdout or --json alone is not
+    // consent), and every deletable path is snapshotted first so `tuck undo`
+    // can bring the variants back.
+    if (!opts.yes) {
+      if (isJsonMode() || !process.stdout.isTTY) {
+        throw new TuckError(
+          '--clean deletes generated files and requires --yes when non-interactive',
+          'RULES_CLEAN_REQUIRES_YES',
+          ['Re-run with --yes to confirm the deletion', 'Or drop --clean to untrack only']
+        );
+      }
+      const ok = await prompts.confirm(
+        `Delete the generated tool variants for ${set.source}?`,
+        false
+      );
+      if (!ok) {
+        logger.info('Aborted — nothing removed.');
+        return;
+      }
+    }
+    const deletable = await listExistingToolVariants(set);
+    if (deletable.length > 0) {
+      await createSnapshot(deletable, `Pre rules-untrack clean: ${set.source}`);
+    }
+    cleaned = await removeToolVariants(set);
+    if (cleaned.length > 0 && !isJsonMode()) {
+      logger.dim('  Restore them with `tuck undo --latest`');
+    }
+  }
+
+  await untrackRuleSet(tuckDir, idArg);
+
+  if (isJsonMode()) {
+    emitJsonOk({ id: idArg, removed: true, cleaned: cleaned.map((p) => collapsePath(p)) });
+    return;
+  }
+  logger.success(`Untracked rules source: ${set.source}`);
+  if (cleaned.length > 0) {
+    logger.dim(`  removed ${cleaned.length} generated variant(s)`);
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+const toolListHelp = ALL_TOOLS.map((t) => `${t} (${TOOL_LABELS[t]})`).join(', ');
+
+/**
+ * Build a fresh `rules` command tree. A factory (rather than a shared singleton)
+ * so tests can parse repeatedly without Commander's per-instance option state
+ * (variadic `--tool`, booleans) leaking between invocations.
+ */
+export const createRulesCommand = (): Command =>
+  new Command('rules')
+  .description('Fan one canonical rules file out to per-tool variants (CLAUDE.md, .cursorrules, …)')
+  .addCommand(
+    new Command('track')
+      .description('Track a canonical rules file and its fan-out targets')
+      .argument('<path>', 'Path to the canonical rules/instructions file (e.g. AGENTS.md)')
+      .option(
+        '-t, --tool <name...>',
+        `Fan-out target (space- or comma-separated). Known: ${toolListHelp}`
+      )
+      .option('--symlink', 'Symlink each variant to the source instead of materializing')
+      .option('--no-template', 'Do not render the source as a template on apply')
+      .option('--var <key=value...>', 'Extra template variable (repeatable)')
+      .option('--json', 'Emit JSON envelope to stdout')
+      .action(trackAction)
+  )
+  .addCommand(
+    new Command('list')
+      .description('List tracked rules sources and per-tool sync status')
+      .option('--json', 'Emit JSON envelope to stdout')
+      .action(listAction)
+  )
+  .addCommand(
+    new Command('apply')
+      .description('Materialize or symlink each tool variant from the canonical source')
+      .option('--id <id>', 'Only apply the set with this id')
+      .option('--dry-run', 'Show what would change without writing')
+      .option('-f, --force', 'Overwrite differing variants without confirmation')
+      .option('-y, --yes', 'Assume yes; run non-interactively (skips undecided overwrites)')
+      .option('--json', 'Emit JSON envelope to stdout')
+      .action(applyAction)
+  )
+  .addCommand(
+    new Command('untrack')
+      .description('Stop tracking a rules source')
+      .argument('<id>', 'Rule set id (see `tuck rules list`)')
+      .option('--clean', 'Also delete the generated tool variants from disk')
+      .option('-y, --yes', 'Auto-confirm deletion')
+      .option('--json', 'Emit JSON envelope to stdout')
+      .action(untrackAction)
+  );
+
+/** Shared instance registered by the top-level CLI. */
+export const rulesCommand = createRulesCommand();

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -87,6 +87,7 @@ interface TrackOpts {
   symlink?: boolean;
   template?: boolean; // commander `--no-template` sets this false
   var?: string[];
+  yes?: boolean;
 }
 
 const trackAction = async (pathArg: string, opts: TrackOpts): Promise<void> => {
@@ -94,11 +95,23 @@ const trackAction = async (pathArg: string, opts: TrackOpts): Promise<void> => {
   const tuckDir = getTuckDir();
   await ensureInitialized(tuckDir);
 
-  const { id, set } = await trackRuleSet(tuckDir, pathArg, {
+  // Re-tracking with a smaller tool list orphans the dropped tools' variants.
+  // Deleting them is destructive: prompt interactively, require --yes when
+  // non-interactive; otherwise leave the orphan in place and just report it.
+  const nonInteractive = isJsonMode() || opts.yes || !process.stdout.isTTY;
+  const { id, set, orphansRemoved, orphansSkipped } = await trackRuleSet(tuckDir, pathArg, {
     tools: parseTools(opts.tool),
     strategy: opts.symlink ? 'symlink' : 'materialize',
     template: opts.template,
     variables: parseVars(opts.var),
+    force: opts.yes,
+    confirmRemove: nonInteractive
+      ? undefined
+      : async (target: string) =>
+          prompts.confirm(
+            `Remove stale variant ${collapsePath(target)} (its tool is no longer a fan-out target)?`,
+            false
+          ),
   });
 
   if (isJsonMode()) {
@@ -109,6 +122,8 @@ const trackAction = async (pathArg: string, opts: TrackOpts): Promise<void> => {
       repoRoot: set.repoRoot,
       template: set.template,
       tools: set.tools.map((t) => ({ tool: t.tool, strategy: t.strategy, path: t.path })),
+      orphansRemoved: orphansRemoved.map((p) => collapsePath(p)),
+      orphansSkipped: orphansSkipped.map((p) => collapsePath(p)),
     });
     return;
   }
@@ -116,6 +131,12 @@ const trackAction = async (pathArg: string, opts: TrackOpts): Promise<void> => {
   logger.success(`Tracking rules source: ${set.source}`);
   logger.dim(`  id=${id}  scope=${set.scope}${set.repoRoot ? `  repo=${collapsePath(set.repoRoot)}` : ''}`);
   logger.dim(`  fan-out → ${set.tools.map((t) => t.tool).join(', ')} (${set.tools[0]?.strategy})`);
+  if (orphansRemoved.length > 0) {
+    logger.dim(`  removed ${orphansRemoved.length} stale variant(s) for dropped tool(s)`);
+  }
+  for (const p of orphansSkipped) {
+    logger.warning(`Left stale variant in place (foreign or not confirmed): ${collapsePath(p)}`);
+  }
   logger.blank();
   logger.info('Run `tuck rules apply` to write the tool variants.');
 };
@@ -218,6 +239,9 @@ const applyAction = async (opts: ApplyOpts): Promise<void> => {
   });
 
   const flat = results.flatMap((r) => r.applied.map((a) => ({ id: r.id, ...a })));
+  // Per-set failures are isolated: valid sets still applied. Report the failures
+  // and exit non-zero so callers/CI notice, without discarding the good work.
+  const failures = results.filter((r) => r.error).map((r) => ({ id: r.id, error: r.error! }));
 
   if (isJsonMode()) {
     emitJsonOk({
@@ -230,11 +254,13 @@ const applyAction = async (opts: ApplyOpts): Promise<void> => {
         action: a.action,
         reason: a.reason,
       })),
+      errors: failures,
     });
+    if (failures.length > 0) process.exitCode = 1;
     return;
   }
 
-  if (flat.length === 0) {
+  if (flat.length === 0 && failures.length === 0) {
     logger.info('No tracked rule sets to apply.');
     logger.dim('Run `tuck rules track <path>` first.');
     return;
@@ -249,6 +275,9 @@ const applyAction = async (opts: ApplyOpts): Promise<void> => {
           : c.green(a.action);
     console.log(`  ${a.tool.padEnd(11)} ${c.dim(collapsePath(a.target))} — ${label}`);
   }
+  for (const f of failures) {
+    logger.warning(`Set ${f.id} skipped: ${f.error}`);
+  }
   logger.blank();
   const changed = flat.filter((a) => a.action !== 'skipped').length;
   if (opts.dryRun) {
@@ -256,6 +285,12 @@ const applyAction = async (opts: ApplyOpts): Promise<void> => {
   } else {
     logger.success(`Fanned out ${changed} variant${changed !== 1 ? 's' : ''}.`);
     if (changed > 0) logger.dim('To undo: tuck undo --latest');
+  }
+  if (failures.length > 0) {
+    logger.warning(
+      `${failures.length} set${failures.length !== 1 ? 's' : ''} could not be applied (see above).`
+    );
+    process.exitCode = 1;
   }
 };
 
@@ -283,6 +318,7 @@ const untrackAction = async (idArg: string, opts: UntrackOpts): Promise<void> =>
   }
 
   let cleaned: string[] = [];
+  let failed: string[] = [];
   if (opts.clean) {
     // --clean permanently deletes generated files: non-interactive callers
     // must OPT IN with --yes (a redirected stdout or --json alone is not
@@ -309,22 +345,34 @@ const untrackAction = async (idArg: string, opts: UntrackOpts): Promise<void> =>
     if (deletable.length > 0) {
       await createSnapshot(deletable, `Pre rules-untrack clean: ${set.source}`);
     }
-    cleaned = await removeToolVariants(set);
+    const result = await removeToolVariants(set);
+    cleaned = result.removed;
+    failed = result.failed;
     if (cleaned.length > 0 && !isJsonMode()) {
       logger.dim('  Restore them with `tuck undo --latest`');
+    }
+    for (const p of failed) {
+      logger.warning(`Could not remove ${collapsePath(p)}`);
     }
   }
 
   await untrackRuleSet(tuckDir, idArg);
 
   if (isJsonMode()) {
-    emitJsonOk({ id: idArg, removed: true, cleaned: cleaned.map((p) => collapsePath(p)) });
+    emitJsonOk({
+      id: idArg,
+      removed: true,
+      cleaned: cleaned.map((p) => collapsePath(p)),
+      failed: failed.map((p) => collapsePath(p)),
+    });
+    if (failed.length > 0) process.exitCode = 1;
     return;
   }
   logger.success(`Untracked rules source: ${set.source}`);
   if (cleaned.length > 0) {
     logger.dim(`  removed ${cleaned.length} generated variant(s)`);
   }
+  if (failed.length > 0) process.exitCode = 1;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -352,6 +400,7 @@ export const createRulesCommand = (): Command =>
       .option('--symlink', 'Symlink each variant to the source instead of materializing')
       .option('--no-template', 'Do not render the source as a template on apply')
       .option('--var <key=value...>', 'Extra template variable (repeatable)')
+      .option('-y, --yes', 'Auto-confirm deleting variants orphaned by dropped tools')
       .option('--json', 'Emit JSON envelope to stdout')
       .action(trackAction)
   )

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -20,7 +20,9 @@ import { getTuckDir, expandPath, collapsePath, pathExists } from '../lib/paths.j
 import { loadManifest, getAllTrackedFiles } from '../lib/manifest.js';
 import { loadConfig, saveConfig } from '../lib/config.js';
 import { atomicWriteFile } from '../lib/files.js';
-import { createSnapshot } from '../lib/timemachine.js';
+import {
+  createSnapshot,
+} from '../lib/timemachine.js';
 import {
   listSecrets,
   setSecret,
@@ -41,6 +43,9 @@ import {
   listAllowlistEntries,
   getAllowlistPath,
   type AllowlistEntry,
+  encryptFileValues,
+  decryptFileValues,
+  fileHasEncryptedValues,
 } from '../lib/secrets/index.js';
 import {
   createResolver,
@@ -49,9 +54,15 @@ import {
   CONFIGURABLE_BACKEND_NAMES,
   type ConfiguredBackendName,
 } from '../lib/secretBackends/index.js';
-import { NotInitializedError, TuckError, ValidationError } from '../errors.js';
+import {
+  NotInitializedError,
+  TuckError,
+  ValidationError,
+  EncryptionError,
+} from '../errors.js';
 import { logSecretAllowlisted, logSecretAllowlistRemoved } from '../lib/audit.js';
 import { getLog } from '../lib/git.js';
+import { getStoredPassword } from '../lib/crypto/index.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 
 const isConfiguredBackendName = (value: string): value is ConfiguredBackendName => {
@@ -1592,6 +1603,260 @@ const runAllowAdd = async (options: AllowAddOptions = {}): Promise<void> => {
 };
 
 // ============================================================================
+// Value-Level Encryption Commands (SOPS-style)
+// ============================================================================
+
+/**
+ * Resolve the passphrase used for value-level encryption.
+ *
+ * Order: the `TUCK_ENCRYPTION_PASSWORD` env var (so CI never puts it in argv),
+ * then the OS keystore (the same password `tuck encryption setup` stores and
+ * apply/restore use for whole-file decryption), then an interactive prompt.
+ * Throws {@link EncryptionError} when none is available and we cannot prompt.
+ */
+const resolveEncryptionPassphrase = async (interactive: boolean): Promise<string> => {
+  const fromEnv = process.env.TUCK_ENCRYPTION_PASSWORD;
+  if (fromEnv && fromEnv.length > 0) {
+    return fromEnv;
+  }
+
+  const stored = await getStoredPassword();
+  if (stored && stored.length > 0) {
+    return stored;
+  }
+
+  if (!interactive) {
+    throw new EncryptionError('No encryption password available', [
+      'Run `tuck encryption setup` to configure a password in your OS keystore',
+      'Or set TUCK_ENCRYPTION_PASSWORD in the environment for non-interactive use',
+    ]);
+  }
+
+  const entered = await prompts.password('Enter encryption passphrase:');
+  if (!entered || entered.trim().length === 0) {
+    throw new EncryptionError('Encryption passphrase cannot be empty');
+  }
+  return entered;
+};
+
+/** Resolve the target file list: explicit paths, or every tracked file. */
+const resolveTargetFiles = async (paths: string[], tuckDir: string): Promise<string[]> => {
+  if (paths.length > 0) {
+    return paths.map((p) => expandPath(p));
+  }
+  return Array.from(
+    new Set(
+      Object.values(await getAllTrackedFiles(tuckDir)).map((file) => expandPath(file.source))
+    )
+  );
+};
+
+interface ValueEncryptOptions {
+  json?: boolean;
+  yes?: boolean;
+}
+
+export const runSecretsEncryptValues = async (
+  paths: string[],
+  options: ValueEncryptOptions = {}
+): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets encrypt');
+
+  const tuckDir = getTuckDir();
+  try {
+    await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+
+  const interactive = !isJsonMode() && !options.yes && !!process.stdout.isTTY;
+  const targets = await resolveTargetFiles(paths, tuckDir);
+
+  const existing: string[] = [];
+  for (const p of targets) {
+    if (await pathExists(p)) existing.push(p);
+  }
+
+  if (existing.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ filesEncrypted: 0, valuesEncrypted: 0, files: [] });
+      return;
+    }
+    logger.warning('No files to encrypt');
+    logger.dim("Pass file paths, or run 'tuck add <path>' to track files first");
+    return;
+  }
+
+  // Locate secret spans with the configured scanner (built-in or external).
+  const summary = await scanForSecrets(existing, tuckDir);
+  const filesWithSecrets = summary.results.filter((r) => r.hasSecrets && r.matches.length > 0);
+
+  if (filesWithSecrets.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ filesEncrypted: 0, valuesEncrypted: 0, files: [] });
+      return;
+    }
+    logger.success('No secret values detected to encrypt');
+    return;
+  }
+
+  if (!isJsonMode()) {
+    console.log();
+    console.log(c.bold.cyan(`Value-level encryption`));
+    console.log(c.dim('─'.repeat(50)));
+    for (const result of filesWithSecrets) {
+      // SECURITY: never print the secret value — only the count.
+      console.log(`  ${c.cyan(result.collapsedPath)} ${c.dim(`(${result.matches.length} value(s))`)}`);
+    }
+    console.log();
+  }
+
+  // Destructive: rewrites tracked files in place. Confirm + snapshot first.
+  if (interactive) {
+    const confirmed = await prompts.confirm(
+      `Encrypt secret values in ${filesWithSecrets.length} file(s)?`,
+      true
+    );
+    if (!confirmed) {
+      logger.warning('Encryption cancelled');
+      return;
+    }
+  }
+
+  const passphrase = await resolveEncryptionPassphrase(interactive);
+
+  // Safety net: back up every target before mutating it so `tuck undo` can revert.
+  await createSnapshot(
+    filesWithSecrets.map((r) => r.path),
+    'Pre value-encryption backup'
+  );
+
+  let filesEncrypted = 0;
+  let valuesEncrypted = 0;
+  const report: Array<{ path: string; valuesEncrypted: number }> = [];
+
+  for (const result of filesWithSecrets) {
+    const res = await encryptFileValues(result.path, result.matches, passphrase);
+    if (res.changed) {
+      filesEncrypted++;
+      valuesEncrypted += res.encrypted;
+      report.push({ path: result.collapsedPath, valuesEncrypted: res.encrypted });
+      if (!isJsonMode()) {
+        logger.success(`${result.collapsedPath}: encrypted ${res.encrypted} value(s)`);
+      }
+    }
+  }
+
+  if (isJsonMode()) {
+    emitJsonOk({ filesEncrypted, valuesEncrypted, files: report });
+    return;
+  }
+
+  console.log();
+  logger.success(`Encrypted ${valuesEncrypted} value(s) across ${filesEncrypted} file(s)`);
+  // The live file is rewritten in place, but the tracked repo copy still holds
+  // plaintext until a sync captures the encrypted version — committing without
+  // it pushes the plaintext the user just tried to protect.
+  if (valuesEncrypted > 0) {
+    logger.info("Run 'tuck sync' to capture the encrypted version into the repo before committing.");
+  }
+  logger.dim('Keys, structure, and comments stay plaintext — git diff/merge keep working.');
+  logger.dim("Run 'tuck secrets decrypt' to restore plaintext, or 'tuck undo' to revert.");
+};
+
+interface ValueDecryptOptions {
+  json?: boolean;
+  yes?: boolean;
+}
+
+export const runSecretsDecryptValues = async (
+  paths: string[],
+  options: ValueDecryptOptions = {}
+): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets decrypt');
+
+  const tuckDir = getTuckDir();
+  try {
+    await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+
+  const interactive = !isJsonMode() && !options.yes && !!process.stdout.isTTY;
+  const targets = await resolveTargetFiles(paths, tuckDir);
+
+  // Only files that actually carry value tokens.
+  const encryptedFiles: string[] = [];
+  for (const p of targets) {
+    if (await fileHasEncryptedValues(p)) encryptedFiles.push(p);
+  }
+
+  if (encryptedFiles.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ filesDecrypted: 0, valuesDecrypted: 0, valuesFailed: 0, files: [] });
+      return;
+    }
+    logger.info('No encrypted values found');
+    return;
+  }
+
+  if (interactive) {
+    const confirmed = await prompts.confirm(
+      `Decrypt values in ${encryptedFiles.length} file(s) back to plaintext?`,
+      true
+    );
+    if (!confirmed) {
+      logger.warning('Decryption cancelled');
+      return;
+    }
+  }
+
+  const passphrase = await resolveEncryptionPassphrase(interactive);
+
+  // Safety net before rewriting live files with plaintext.
+  await createSnapshot(encryptedFiles, 'Pre value-decryption backup');
+
+  let filesDecrypted = 0;
+  let valuesDecrypted = 0;
+  let valuesFailed = 0;
+  const report: Array<{ path: string; valuesDecrypted: number; valuesFailed: number }> = [];
+
+  for (const p of encryptedFiles) {
+    // throwOnFailure:false so one bad token/wrong-key file never aborts the batch.
+    const res = await decryptFileValues(p, passphrase, { throwOnFailure: false });
+    valuesFailed += res.failed;
+    if (res.changed) {
+      filesDecrypted++;
+      valuesDecrypted += res.decrypted;
+    }
+    report.push({
+      path: collapsePath(p),
+      valuesDecrypted: res.decrypted,
+      valuesFailed: res.failed,
+    });
+    if (!isJsonMode() && res.decrypted > 0) {
+      logger.success(`${collapsePath(p)}: decrypted ${res.decrypted} value(s)`);
+    }
+    if (!isJsonMode() && res.failed > 0) {
+      logger.warning(`${collapsePath(p)}: ${res.failed} value(s) could not be decrypted`);
+    }
+  }
+
+  if (isJsonMode()) {
+    emitJsonOk({ filesDecrypted, valuesDecrypted, valuesFailed, files: report });
+    return;
+  }
+
+  console.log();
+  logger.success(`Decrypted ${valuesDecrypted} value(s) across ${filesDecrypted} file(s)`);
+  if (valuesFailed > 0) {
+    logger.warning(
+      `${valuesFailed} value(s) could not be decrypted — check the encryption passphrase`
+    );
+  }
+};
+
+// ============================================================================
 // Command Definition
 // ============================================================================
 
@@ -1666,6 +1931,26 @@ export const secretsCommand = new Command('secrets')
           .action((fingerprint: string, options: AllowRemoveOptions) =>
             runAllowRemove(fingerprint, options)
           )
+      )
+  )
+  .addCommand(
+    new Command('encrypt')
+      .description('Encrypt secret values in place (keys/structure stay plaintext)')
+      .argument('[paths...]', 'Files to encrypt (defaults to all tracked files)')
+      .option('--json', 'Emit JSON envelope to stdout (values are never included)')
+      .option('-y, --yes', 'Non-interactive: skip confirmation prompts')
+      .action((paths: string[], options: ValueEncryptOptions) =>
+        runSecretsEncryptValues(paths, options)
+      )
+  )
+  .addCommand(
+    new Command('decrypt')
+      .description('Decrypt in-place encrypted values back to plaintext')
+      .argument('[paths...]', 'Files to decrypt (defaults to all tracked files)')
+      .option('--json', 'Emit JSON envelope to stdout')
+      .option('-y, --yes', 'Non-interactive: skip confirmation prompts')
+      .action((paths: string[], options: ValueDecryptOptions) =>
+        runSecretsDecryptValues(paths, options)
       )
   )
   .addCommand(

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -35,6 +35,12 @@ import {
   type ScanSummary,
   type McpExtraction,
   type McpReferenceFormat,
+  computeFingerprint,
+  addAllowlistEntryByFingerprint,
+  removeAllowlistEntries,
+  listAllowlistEntries,
+  getAllowlistPath,
+  type AllowlistEntry,
 } from '../lib/secrets/index.js';
 import {
   createResolver,
@@ -43,7 +49,8 @@ import {
   CONFIGURABLE_BACKEND_NAMES,
   type ConfiguredBackendName,
 } from '../lib/secretBackends/index.js';
-import { NotInitializedError, TuckError } from '../errors.js';
+import { NotInitializedError, TuckError, ValidationError } from '../errors.js';
+import { logSecretAllowlisted, logSecretAllowlistRemoved } from '../lib/audit.js';
 import { getLog } from '../lib/git.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 
@@ -1277,6 +1284,314 @@ const buildRedactedExtractionSummary = (file: FileExtraction) => ({
 });
 
 // ============================================================================
+// Allowlist Commands
+// ============================================================================
+
+const SHORT_FINGERPRINT_LENGTH = 12;
+
+const isFingerprint = (value: string): boolean => /^[a-f0-9]{64}$/i.test(value);
+
+const formatAllowEntry = (entry: AllowlistEntry): void => {
+  console.log(`  ${c.green(entry.fingerprint.slice(0, SHORT_FINGERPRINT_LENGTH))}${c.dim('…')}`);
+  console.log(`    ${c.dim('Reason:')} ${entry.reason}`);
+  if (entry.pattern) console.log(`    ${c.dim('Pattern:')} ${entry.pattern}`);
+  if (entry.path) console.log(`    ${c.dim('Path:')} ${entry.path}`);
+  if (entry.addedBy) console.log(`    ${c.dim('Added by:')} ${entry.addedBy}`);
+  console.log(`    ${c.dim('Added:')} ${new Date(entry.addedAt).toLocaleDateString()}`);
+  console.log();
+};
+
+const requireInitialized = async (tuckDir: string): Promise<void> => {
+  try {
+    await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+};
+
+const runAllowList = async (options: JsonOptions = {}): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets allow list');
+  const tuckDir = getTuckDir();
+  await requireInitialized(tuckDir);
+
+  const entries = await listAllowlistEntries(tuckDir);
+
+  if (isJsonMode()) {
+    // SECURITY: the allowlist already contains only fingerprints (no raw
+    // values), so it is safe to emit verbatim.
+    emitJsonOk({ entries });
+    return;
+  }
+
+  if (entries.length === 0) {
+    logger.info('No allowlisted findings');
+    console.log();
+    logger.dim(`Allowlist file: ${collapsePath(getAllowlistPath(tuckDir))}`);
+    logger.dim('Mark a scanner false-positive as safe with: tuck secrets allow add --file <path>');
+    return;
+  }
+
+  console.log();
+  console.log(c.bold.cyan(`Allowlisted Findings (${entries.length})`));
+  console.log(c.dim('─'.repeat(50)));
+  console.log();
+  for (const entry of entries) {
+    formatAllowEntry(entry);
+  }
+  logger.dim(`Allowlist file: ${collapsePath(getAllowlistPath(tuckDir))} (committed & auditable)`);
+};
+
+interface AllowRemoveOptions extends JsonOptions {}
+
+const runAllowRemove = async (
+  fingerprint: string,
+  options: AllowRemoveOptions = {}
+): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets allow remove');
+  const tuckDir = getTuckDir();
+  await requireInitialized(tuckDir);
+
+  const prefix = fingerprint.trim().toLowerCase();
+  if (prefix.length === 0 || !/^[a-f0-9]+$/.test(prefix)) {
+    throw new ValidationError('fingerprint', 'must be a hex fingerprint (or prefix)');
+  }
+
+  const removed = await removeAllowlistEntries(tuckDir, prefix);
+  if (removed.length > 0) {
+    await logSecretAllowlistRemoved(removed.map((entry) => entry.fingerprint));
+  }
+
+  if (isJsonMode()) {
+    emitJsonOk({ removed: removed.length, fingerprints: removed.map((e) => e.fingerprint) });
+    return;
+  }
+
+  if (removed.length === 0) {
+    logger.warning(`No allowlist entry matching: ${fingerprint}`);
+    logger.dim('Run `tuck secrets allow list` to see fingerprints');
+    return;
+  }
+  logger.success(
+    `Removed ${removed.length} allowlist entr${removed.length === 1 ? 'y' : 'ies'}`
+  );
+};
+
+interface AllowAddOptions extends JsonOptions {
+  reason?: string;
+  file?: string;
+  pattern?: string;
+  fingerprint?: string;
+  yes?: boolean;
+}
+
+/**
+ * Add scanner findings to the centralized allowlist.
+ *
+ * Three input modes (none of which put a raw secret on the command line):
+ *  - `--fingerprint <hash>`: allowlist a known fingerprint directly.
+ *  - `--file <path>` [+ `--pattern <id>`]: re-scan the file and allowlist the
+ *    matching findings by fingerprint (value never leaves the process).
+ *  - interactive (TTY, no --file/--fingerprint): scan tracked files and let the
+ *    user pick which findings to mark safe.
+ */
+const runAllowAdd = async (options: AllowAddOptions = {}): Promise<void> => {
+  if (options.json) setJsonMode(true, 'tuck secrets allow add');
+  const tuckDir = getTuckDir();
+  await requireInitialized(tuckDir);
+
+  const nonInteractive = isJsonMode() || options.yes === true || !process.stdout.isTTY;
+
+  // Unscoped bulk allowlisting (no --file/--pattern/--fingerprint) permanently
+  // disarms the secret gate for EVERY current finding — never do that on the
+  // strength of a redirected stdout alone. Explicit --yes is required.
+  if (
+    nonInteractive &&
+    options.yes !== true &&
+    !options.file &&
+    !options.pattern &&
+    !options.fingerprint
+  ) {
+    throw new TuckError(
+      'Refusing to allowlist ALL findings non-interactively',
+      'ALLOW_ALL_REQUIRES_YES',
+      [
+        'Pass --yes to explicitly allowlist every finding across all tracked files',
+        'Or scope the operation with --file <path>, --pattern <id>, or --fingerprint <fp>',
+      ]
+    );
+  }
+
+  // ---- Resolve a reason (required, keeps the allowlist auditable) ----
+  const resolveReason = async (): Promise<string> => {
+    if (options.reason && options.reason.trim().length > 0) return options.reason.trim();
+    if (nonInteractive) {
+      throw new TuckError('A reason is required', 'ALLOW_REASON_REQUIRED', [
+        'Pass --reason "<why this value is safe>"',
+      ]);
+    }
+    const reason = await prompts.text('Why is this value safe? (recorded in the allowlist)', {
+      placeholder: 'e.g. example value from docs, not a real key',
+    });
+    if (!reason || reason.trim().length === 0) {
+      throw new TuckError('A reason is required', 'ALLOW_REASON_REQUIRED');
+    }
+    return reason.trim();
+  };
+
+  // ---- Mode 1: direct fingerprint ----
+  if (options.fingerprint) {
+    const fp = options.fingerprint.trim().toLowerCase();
+    if (!isFingerprint(fp)) {
+      throw new ValidationError('fingerprint', 'must be a 64-char SHA-256 hex digest');
+    }
+    const reason = await resolveReason();
+    const entry = await addAllowlistEntryByFingerprint(tuckDir, fp, {
+      reason,
+      pattern: options.pattern,
+    });
+    await logSecretAllowlisted(entry.fingerprint, entry.reason, {
+      pattern: entry.pattern,
+      path: entry.path,
+    });
+    if (isJsonMode()) {
+      emitJsonOk({ added: 1, entries: [entry] });
+      return;
+    }
+    logger.success(`Allowlisted ${entry.fingerprint.slice(0, SHORT_FINGERPRINT_LENGTH)}…`);
+    return;
+  }
+
+  // ---- Determine which files to scan ----
+  let scanPaths: string[];
+  if (options.file) {
+    const expanded = expandPath(options.file);
+    if (!(await pathExists(expanded))) {
+      throw new TuckError(`File not found: ${options.file}`, 'FILE_NOT_FOUND', [
+        'Check the path and try again',
+      ]);
+    }
+    scanPaths = [expanded];
+  } else {
+    scanPaths = Array.from(
+      new Set(
+        Object.values(await getAllTrackedFiles(tuckDir)).map((file) => expandPath(file.source))
+      )
+    );
+  }
+
+  if (scanPaths.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ added: 0, entries: [] });
+      return;
+    }
+    logger.warning('No files to scan');
+    return;
+  }
+
+  // Run the SAME config-aware scan the secret gate runs (same scanner choice,
+  // custom patterns, and pattern ids — recorded scopes must match the gate),
+  // but without the allowlist filter, which would hide the very matches the
+  // user wants to add here.
+  const summary = await scanForSecrets(scanPaths, tuckDir, { includeAllowlisted: true });
+
+  if (summary.filesWithSecrets === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ added: 0, entries: [] });
+      return;
+    }
+    logger.info('No findings to allowlist');
+    return;
+  }
+
+  // Flatten to candidate findings (deduped by fingerprint+pattern+path).
+  interface Candidate {
+    value: string;
+    fingerprint: string;
+    patternId: string;
+    patternName: string;
+    collapsedPath: string;
+    line: number;
+    context: string;
+  }
+  const candidates: Candidate[] = [];
+  const seen = new Set<string>();
+  for (const result of summary.results) {
+    for (const match of result.matches) {
+      if (options.pattern && match.patternId !== options.pattern) continue;
+      const fingerprint = computeFingerprint(match.value);
+      const key = `${fingerprint}:${match.patternId}:${result.collapsedPath}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      candidates.push({
+        value: match.value,
+        fingerprint,
+        patternId: match.patternId,
+        patternName: match.patternName,
+        collapsedPath: result.collapsedPath,
+        line: match.line,
+        context: match.context,
+      });
+    }
+  }
+
+  if (candidates.length === 0) {
+    if (isJsonMode()) {
+      emitJsonOk({ added: 0, entries: [] });
+      return;
+    }
+    logger.info('No findings matched the given filters');
+    return;
+  }
+
+  // ---- Choose which candidates to allowlist ----
+  let chosen: Candidate[];
+  if (nonInteractive || options.file || options.pattern) {
+    // Non-interactive / scoped: allowlist every matching finding.
+    chosen = candidates;
+  } else {
+    const selected = await prompts.multiselect<string>(
+      'Select findings to mark as safe (allowlist):',
+      candidates.map((candidate, i) => ({
+        value: String(i),
+        label: `${candidate.patternName} — ${candidate.collapsedPath}:${candidate.line}`,
+        hint: candidate.context,
+      }))
+    );
+    if (!selected || selected.length === 0) {
+      logger.info('Nothing selected');
+      return;
+    }
+    const indices = new Set(selected.map((s) => parseInt(s, 10)));
+    chosen = candidates.filter((_, i) => indices.has(i));
+  }
+
+  const reason = await resolveReason();
+  const added: AllowlistEntry[] = [];
+  for (const candidate of chosen) {
+    const entry = await addAllowlistEntryByFingerprint(tuckDir, candidate.fingerprint, {
+      reason,
+      pattern: candidate.patternId,
+      path: candidate.collapsedPath,
+    });
+    await logSecretAllowlisted(entry.fingerprint, entry.reason, {
+      pattern: entry.pattern,
+      path: entry.path,
+    });
+    added.push(entry);
+  }
+
+  if (isJsonMode()) {
+    emitJsonOk({ added: added.length, entries: added });
+    return;
+  }
+
+  logger.success(
+    `Allowlisted ${added.length} finding${added.length === 1 ? '' : 's'}`
+  );
+  logger.dim(`Allowlist file: ${collapsePath(getAllowlistPath(tuckDir))} (commit it to share)`);
+};
+
+// ============================================================================
 // Command Definition
 // ============================================================================
 
@@ -1319,6 +1634,39 @@ export const secretsCommand = new Command('secrets')
       .argument('[paths...]', 'Files to scan')
       .option('--json', 'Emit JSON envelope to stdout')
       .action(runScanFiles)
+  )
+  // Centralized, auditable allowlist (replaces inline ignore comments)
+  .addCommand(
+    new Command('allow')
+      .description('Manage the centralized secret allowlist (mark findings as safe)')
+      .option('--json', 'Emit JSON envelope to stdout')
+      .action((options: JsonOptions) => runAllowList(options))
+      .addCommand(
+        new Command('list')
+          .description('List allowlisted findings')
+          .option('--json', 'Emit JSON envelope to stdout')
+          .action((options: JsonOptions) => runAllowList(options))
+      )
+      .addCommand(
+        new Command('add')
+          .description('Add scanner finding(s) to the allowlist')
+          .option('--file <path>', 'Scan this file and allowlist its findings')
+          .option('--pattern <id>', 'Only allowlist findings from this pattern id')
+          .option('--fingerprint <hash>', 'Allowlist a known SHA-256 fingerprint directly')
+          .option('--reason <text>', 'Why the value is safe (required non-interactively)')
+          .option('--json', 'Emit JSON envelope to stdout')
+          .option('-y, --yes', 'Non-interactive: allowlist all matching findings')
+          .action((options: AllowAddOptions) => runAllowAdd(options))
+      )
+      .addCommand(
+        new Command('remove')
+          .description('Remove an allowlist entry by fingerprint (or prefix)')
+          .argument('<fingerprint>', 'Fingerprint or unique prefix to remove')
+          .option('--json', 'Emit JSON envelope to stdout')
+          .action((fingerprint: string, options: AllowRemoveOptions) =>
+            runAllowRemove(fingerprint, options)
+          )
+      )
   )
   .addCommand(
     new Command('extract')

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1613,8 +1613,18 @@ const runAllowAdd = async (options: AllowAddOptions = {}): Promise<void> => {
  * then the OS keystore (the same password `tuck encryption setup` stores and
  * apply/restore use for whole-file decryption), then an interactive prompt.
  * Throws {@link EncryptionError} when none is available and we cannot prompt.
+ *
+ * When `confirmNew` is set, the interactive prompt is treated as INTRODUCING a
+ * brand-new passphrase (encryption) rather than supplying an existing one
+ * (decryption): it is entered twice and must match. This guards against a typo
+ * silently encrypting live files under a passphrase nobody knows. Decryption
+ * needs no confirmation — a wrong passphrase simply fails to decrypt existing
+ * tokens, loudly and non-destructively.
  */
-const resolveEncryptionPassphrase = async (interactive: boolean): Promise<string> => {
+const resolveEncryptionPassphrase = async (
+  interactive: boolean,
+  options: { confirmNew?: boolean } = {}
+): Promise<string> => {
   const fromEnv = process.env.TUCK_ENCRYPTION_PASSWORD;
   if (fromEnv && fromEnv.length > 0) {
     return fromEnv;
@@ -1629,6 +1639,26 @@ const resolveEncryptionPassphrase = async (interactive: boolean): Promise<string
     throw new EncryptionError('No encryption password available', [
       'Run `tuck encryption setup` to configure a password in your OS keystore',
       'Or set TUCK_ENCRYPTION_PASSWORD in the environment for non-interactive use',
+    ]);
+  }
+
+  // Introducing a new passphrase (encrypt): confirm it to catch typos before we
+  // rewrite live files under it.
+  if (options.confirmNew) {
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const entered = await prompts.password('Enter a new encryption passphrase:');
+      if (!entered || entered.trim().length === 0) {
+        throw new EncryptionError('Encryption passphrase cannot be empty');
+      }
+      const confirmed = await prompts.password('Confirm encryption passphrase:');
+      if (entered === confirmed) {
+        return entered;
+      }
+      logger.warning('Passphrases did not match — please try again');
+    }
+    throw new EncryptionError('Encryption passphrases did not match', [
+      'Re-run the command and enter the same passphrase both times',
     ]);
   }
 
@@ -1723,7 +1753,9 @@ export const runSecretsEncryptValues = async (
     }
   }
 
-  const passphrase = await resolveEncryptionPassphrase(interactive);
+  // Encryption INTRODUCES the passphrase: confirm it (when prompted) so a typo
+  // never encrypts live files under a passphrase nobody can reproduce.
+  const passphrase = await resolveEncryptionPassphrase(interactive, { confirmNew: true });
 
   // Safety net: back up every target before mutating it so `tuck undo` can revert.
   await createSnapshot(

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -1,0 +1,649 @@
+/**
+ * `tuck settings` — versioned OS settings (macOS `defaults`).
+ *
+ * Solves the "undocumented `.macos` script that silently breaks across OS
+ * versions" problem: instead of hand-writing `defaults write` incantations, you
+ * capture them by changing a setting in the GUI while tuck diffs the affected
+ * domains, then replay them on another machine with per-OS-version guards. Steps
+ * that cannot be automated live in a tracked manual-steps checklist that tuck
+ * reminds you about per machine.
+ *
+ * Subcommands:
+ *   capture   Diff `defaults` domains while you change a GUI setting (or record
+ *             a domain/key/value directly for non-interactive use).
+ *   apply     Replay tracked settings, honoring version guards; restart apps.
+ *   list      Show tracked settings and the manual-steps checklist.
+ *   remove    Untrack a captured setting.
+ *   manual    Manage the manual-steps checklist (add/list/done/reset).
+ *
+ * The design is backend-abstracted (see src/lib/osSettings): only macOS ships in
+ * v1, but a Linux/dconf backend can be added without changing this command.
+ */
+import { Command } from 'commander';
+import { getTuckDir } from '../lib/paths.js';
+import { loadManifest } from '../lib/manifest.js';
+import { collapsePath } from '../lib/paths.js';
+import {
+  NotInitializedError,
+  SettingsError,
+  SettingsUnsupportedOsError,
+  SettingNotFoundError,
+} from '../errors.js';
+import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { logger, prompts, colors as c } from '../ui/index.js';
+import {
+  selectBackend,
+  diffDomains,
+  recordSetting,
+  removeSetting,
+  applySettings,
+  addManualStep,
+  setManualDone,
+  loadOsSettingsManifest,
+  loadOsSettingsState,
+  type OsSettingsBackend,
+  type DomainSnapshot,
+} from '../lib/osSettings/index.js';
+import { settingTypeSchema, type SettingType } from '../schemas/osSettings.schema.js';
+
+const ensureInitialized = async (tuckDir: string): Promise<void> => {
+  try {
+    await loadManifest(tuckDir);
+  } catch {
+    throw new NotInitializedError();
+  }
+};
+
+const requireBackend = (): OsSettingsBackend => {
+  const backend = selectBackend();
+  if (!backend) throw new SettingsUnsupportedOsError(process.platform);
+  return backend;
+};
+
+/** Split a comma-separated option value into a trimmed, non-empty list. */
+const parseList = (raw?: string): string[] =>
+  (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+const collectRepeat = (val: string, acc: string[]): string[] => {
+  acc.push(val);
+  return acc;
+};
+
+const snapshotAll = async (
+  backend: OsSettingsBackend,
+  domains: string[]
+): Promise<DomainSnapshot[]> => {
+  const out: DomainSnapshot[] = [];
+  for (const domain of domains) {
+    out.push(await backend.snapshotDomain(domain));
+  }
+  return out;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// capture
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface CaptureOptions {
+  domain: string[];
+  key?: string;
+  type?: string;
+  value?: string;
+  delete?: boolean;
+  description?: string;
+  minVersion?: string;
+  maxVersion?: string;
+  restart?: string;
+  json?: boolean;
+  yes?: boolean;
+}
+
+const parseSettingType = (raw: string): SettingType => {
+  const parsed = settingTypeSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new SettingsError(`Unsupported setting type "${raw}"`, [
+      'Supported types: boolean, integer, float, string, date',
+    ]);
+  }
+  return parsed.data;
+};
+
+const captureAction = async (
+  descriptionArg: string | undefined,
+  opts: CaptureOptions
+): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck settings capture');
+  const backend = requireBackend();
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const osVersion = await backend.currentOsVersion();
+  const description = opts.description ?? descriptionArg ?? '';
+  const restartApps = parseList(opts.restart);
+  const minVersion = opts.minVersion ?? null;
+  const maxVersion = opts.maxVersion ?? null;
+
+  // ── Direct (non-interactive) mode: record one domain/key without diffing. ──
+  if (opts.key) {
+    const domain = opts.domain[0];
+    if (!domain || opts.domain.length !== 1) {
+      throw new SettingsError('Direct capture (--key) requires exactly one --domain', [
+        'Example: tuck settings capture --domain com.apple.dock --key autohide --type boolean --value true',
+      ]);
+    }
+    const action = opts.delete ? 'delete' : 'write';
+    let type: SettingType | undefined;
+    let value: string | undefined;
+    if (action === 'write') {
+      if (!opts.type || opts.value === undefined) {
+        throw new SettingsError('A write capture requires --type and --value', [
+          'Or pass --delete to record a key deletion',
+        ]);
+      }
+      type = parseSettingType(opts.type);
+      value = opts.value;
+    }
+
+    const { id, entry, created } = await recordSetting(tuckDir, {
+      os: backend.os,
+      domain,
+      key: opts.key,
+      action,
+      type,
+      value,
+      description,
+      capturedOsVersion: osVersion,
+      minVersion,
+      maxVersion,
+      restartApps,
+    });
+
+    if (isJsonMode()) {
+      emitJsonOk({ id, created, entry });
+      return;
+    }
+    logger.success(`${created ? 'Captured' : 'Updated'} setting ${c.cyan(id)}`);
+    logger.dim(`  ${backend.plan(entry).display}`);
+    if (osVersion) logger.dim(`  captured on macOS ${osVersion}`);
+    logger.dim('Commit os-settings.json (e.g. `tuck sync`) to share it.');
+    return;
+  }
+
+  // ── Interactive diff mode. ──
+  if (isJsonMode() || !process.stdout.isTTY) {
+    throw new SettingsError('Interactive capture requires a TTY', [
+      'For non-interactive capture, pass --domain, --key, --type and --value',
+    ]);
+  }
+
+  const domains =
+    opts.domain.length > 0
+      ? opts.domain
+      : await withSpinner('Enumerating settings domains…', () => backend.listDomains());
+
+  const before = await withSpinner('Snapshotting current settings…', () =>
+    snapshotAll(backend, domains)
+  );
+
+  prompts.note(
+    'Now change the setting in System Settings (or the app), then come back here.',
+    'Capture'
+  );
+  const proceed = await prompts.confirm('Have you finished changing the setting?', true);
+  if (!proceed) {
+    logger.info('Capture cancelled — nothing recorded.');
+    return;
+  }
+
+  const after = await withSpinner('Detecting what changed…', () => snapshotAll(backend, domains));
+  const changes = diffDomains(before, after);
+  const supported = changes.filter((ch) => !ch.unsupported);
+  const unsupported = changes.filter((ch) => ch.unsupported);
+
+  if (supported.length === 0) {
+    if (unsupported.length > 0) {
+      logger.warning(
+        `Detected ${unsupported.length} change(s) with a complex value that v1 cannot auto-replay.`
+      );
+      logger.dim('Record them as a manual step: tuck settings manual add "<title>"');
+    } else {
+      logger.info('No setting changes detected. Did the change write to a watched domain?');
+      logger.dim('Tip: pass --domain <domain> to watch a specific domain.');
+    }
+    return;
+  }
+
+  console.log();
+  console.log(c.bold(`Detected ${supported.length} setting change(s):`));
+  for (const ch of supported) {
+    const desc =
+      ch.action === 'delete'
+        ? `delete ${ch.domain} ${ch.key}`
+        : `write ${ch.domain} ${ch.key} = ${ch.value} (${ch.type})`;
+    console.log(`  ${c.dim('•')} ${c.cyan(desc)}`);
+  }
+  console.log();
+
+  if (!opts.yes) {
+    const ok = await prompts.confirm('Record these change(s)?', true);
+    if (!ok) {
+      logger.info('Aborted — nothing recorded.');
+      return;
+    }
+  }
+
+  const recorded: string[] = [];
+  for (const ch of supported) {
+    const { id } = await recordSetting(tuckDir, {
+      os: backend.os,
+      domain: ch.domain,
+      key: ch.key,
+      action: ch.action,
+      type: ch.type,
+      value: ch.value,
+      description,
+      capturedOsVersion: osVersion,
+      minVersion,
+      maxVersion,
+      restartApps,
+    });
+    recorded.push(id);
+  }
+
+  logger.success(`Recorded ${recorded.length} setting(s).`);
+  if (unsupported.length > 0) {
+    logger.warning(
+      `Skipped ${unsupported.length} complex change(s); add them as manual steps if needed.`
+    );
+  }
+  logger.dim('Commit os-settings.json (e.g. `tuck sync`) to share it.');
+};
+
+const withSpinner = async <T>(message: string, fn: () => Promise<T>): Promise<T> => {
+  const spinner = prompts.spinner();
+  spinner.start(message);
+  try {
+    const result = await fn();
+    spinner.stop(message);
+    return result;
+  } catch (error) {
+    spinner.stop(message);
+    throw error;
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apply
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ApplyCliOptions {
+  id?: string[];
+  dryRun?: boolean;
+  restart?: boolean; // false when --no-restart passed
+  json?: boolean;
+  yes?: boolean;
+}
+
+const applyAction = async (opts: ApplyCliOptions): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck settings apply');
+  const backend = requireBackend();
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const currentVersion = await backend.currentOsVersion();
+  const only = opts.id && opts.id.length > 0 ? opts.id : undefined;
+  const dryRun = opts.dryRun === true;
+
+  // Always compute a dry-run preview first for display / confirmation.
+  const preview = await applySettings(backend, tuckDir, {
+    currentVersion,
+    dryRun: true,
+    only,
+  });
+
+  if (isJsonMode()) {
+    // JSON mode is non-interactive; honor --dry-run, otherwise apply directly.
+    if (dryRun) {
+      emitJsonOk({ dryRun: true, ...preview });
+      return;
+    }
+    const result = await applySettings(backend, tuckDir, {
+      currentVersion,
+      dryRun: false,
+      restart: opts.restart !== false,
+      only,
+    });
+    emitJsonOk({ dryRun: false, ...result });
+    return;
+  }
+
+  if (preview.applied.length === 0) {
+    logger.info('No settings to apply.');
+    reportSkippedAndManual(preview.skipped, preview.pendingManual);
+    return;
+  }
+
+  console.log();
+  console.log(
+    c.bold(`${dryRun ? 'Would apply' : 'Will apply'} ${preview.applied.length} setting(s):`)
+  );
+  for (const a of preview.applied) {
+    console.log(`  ${c.dim('•')} ${c.cyan(a.display)}`);
+  }
+  console.log();
+
+  if (dryRun) {
+    reportSkippedAndManual(preview.skipped, preview.pendingManual);
+    logger.dim('Dry run — no changes made. Re-run without --dry-run to apply.');
+    return;
+  }
+
+  if (!opts.yes) {
+    // Never write OS settings on the strength of a redirected stdout or --json
+    // alone: prompts.confirm throws OPERATION_CANCELLED on non-TTY stdin, so a
+    // non-interactive apply without --yes fails fast instead of proceeding.
+    const ok = await prompts.confirm('Apply these settings to this machine?', false);
+    if (!ok) {
+      logger.info('Aborted — no settings changed.');
+      return;
+    }
+  }
+
+  const result = await applySettings(backend, tuckDir, {
+    currentVersion,
+    dryRun: false,
+    restart: opts.restart !== false,
+    only,
+  });
+
+  logger.success(`Applied ${result.applied.length} setting(s).`);
+  if (result.backupDir) logger.dim(`  backup: ${collapsePath(result.backupDir)}`);
+  if (result.restarted.length > 0) {
+    logger.dim(`  restarted: ${result.restarted.join(', ')}`);
+  }
+  reportSkippedAndManual(result.skipped, result.pendingManual);
+};
+
+const reportSkippedAndManual = (
+  skipped: { id: string; reason: string }[],
+  pendingManual: { id: string; title: string }[]
+): void => {
+  if (skipped.length > 0) {
+    console.log();
+    console.log(c.bold(`Skipped ${skipped.length} setting(s):`));
+    for (const s of skipped) {
+      console.log(`  ${c.dim('•')} ${s.id} ${c.dim(`— ${s.reason}`)}`);
+    }
+  }
+  if (pendingManual.length > 0) {
+    console.log();
+    console.log(c.bold(`Manual steps still to do on this machine (${pendingManual.length}):`));
+    for (const m of pendingManual) {
+      console.log(`  ${c.dim('•')} ${m.title} ${c.dim(`(${m.id})`)}`);
+    }
+    logger.dim('Mark done with: tuck settings manual done <id>');
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// list
+// ─────────────────────────────────────────────────────────────────────────────
+
+const listAction = async (opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck settings list');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  const state = await loadOsSettingsState();
+  const settings = Object.values(manifest.settings);
+  const manualSteps = Object.values(manifest.manualSteps).map((m) => ({
+    ...m,
+    done: Boolean(state.manualDone[m.id]),
+  }));
+
+  if (isJsonMode()) {
+    emitJsonOk({
+      settingsCount: settings.length,
+      manualCount: manualSteps.length,
+      settings,
+      manualSteps,
+    });
+    return;
+  }
+
+  if (settings.length === 0 && manualSteps.length === 0) {
+    logger.info('No OS settings tracked yet.');
+    logger.dim('Capture one with: tuck settings capture');
+    return;
+  }
+
+  if (settings.length > 0) {
+    console.log();
+    console.log(c.bold(`Tracked settings (${settings.length}):`));
+    for (const s of settings) {
+      const guard =
+        s.minVersion || s.maxVersion
+          ? c.dim(
+              ` [${s.minVersion ?? ''}${s.minVersion || s.maxVersion ? '..' : ''}${s.maxVersion ?? ''}]`
+            )
+          : '';
+      const val = s.action === 'delete' ? c.dim('(delete)') : `${s.value} ${c.dim(`(${s.type})`)}`;
+      console.log(`  ${c.dim('•')} ${c.cyan(`${s.domain} ${s.key}`)} = ${val}${guard}`);
+      if (s.description) console.log(`    ${c.dim(s.description)}`);
+      console.log(`    ${c.dim(s.id)}`);
+    }
+  }
+
+  if (manualSteps.length > 0) {
+    console.log();
+    console.log(c.bold(`Manual steps (${manualSteps.length}):`));
+    for (const m of manualSteps) {
+      const mark = m.done ? c.green('done') : c.yellow('todo');
+      console.log(`  ${c.dim('•')} [${mark}] ${m.title} ${c.dim(`(${m.id})`)}`);
+      if (m.instructions) console.log(`    ${c.dim(m.instructions)}`);
+    }
+  }
+  console.log();
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// remove
+// ─────────────────────────────────────────────────────────────────────────────
+
+const removeAction = async (id: string, opts: { json?: boolean }): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck settings remove');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const removed = await removeSetting(tuckDir, id);
+  if (!removed) throw new SettingNotFoundError(id);
+
+  if (isJsonMode()) {
+    emitJsonOk({ removed: true, id });
+    return;
+  }
+  logger.success(`Removed setting ${c.cyan(id)}`);
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// manual
+// ─────────────────────────────────────────────────────────────────────────────
+
+const manualAddAction = async (
+  title: string,
+  opts: { instructions?: string; json?: boolean }
+): Promise<void> => {
+  if (opts.json) setJsonMode(true, 'tuck settings manual add');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const { id, step, created } = await addManualStep(tuckDir, {
+    os: 'macos',
+    title,
+    instructions: opts.instructions,
+  });
+
+  if (isJsonMode()) {
+    emitJsonOk({ id, created, step });
+    return;
+  }
+  logger.success(`${created ? 'Added' : 'Updated'} manual step ${c.cyan(id)}`);
+  logger.dim('Commit os-settings.json (e.g. `tuck sync`) to share it.');
+};
+
+const manualListAction = async (opts: { json?: boolean }): Promise<void> => {
+  // Reuse list rendering but only the manual section.
+  if (opts.json) setJsonMode(true, 'tuck settings manual list');
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  const state = await loadOsSettingsState();
+  const manualSteps = Object.values(manifest.manualSteps).map((m) => ({
+    ...m,
+    done: Boolean(state.manualDone[m.id]),
+  }));
+
+  if (isJsonMode()) {
+    emitJsonOk({ count: manualSteps.length, manualSteps });
+    return;
+  }
+
+  if (manualSteps.length === 0) {
+    logger.info('No manual steps yet.');
+    logger.dim('Add one with: tuck settings manual add "<title>"');
+    return;
+  }
+  console.log();
+  console.log(c.bold(`Manual steps (${manualSteps.length}):`));
+  for (const m of manualSteps) {
+    const mark = m.done ? c.green('done') : c.yellow('todo');
+    console.log(`  ${c.dim('•')} [${mark}] ${m.title} ${c.dim(`(${m.id})`)}`);
+    if (m.instructions) console.log(`    ${c.dim(m.instructions)}`);
+  }
+  console.log();
+};
+
+const manualSetDoneAction = async (
+  id: string,
+  done: boolean,
+  opts: { json?: boolean }
+): Promise<void> => {
+  const cmd = done ? 'tuck settings manual done' : 'tuck settings manual reset';
+  if (opts.json) setJsonMode(true, cmd);
+  const tuckDir = getTuckDir();
+  await ensureInitialized(tuckDir);
+
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  if (!manifest.manualSteps[id]) {
+    throw new SettingNotFoundError(id);
+  }
+  await setManualDone(id, done);
+
+  if (isJsonMode()) {
+    emitJsonOk({ id, done });
+    return;
+  }
+  logger.success(
+    `Marked manual step ${c.cyan(id)} as ${done ? 'done' : 'not done'} on this machine.`
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a fresh `settings` command tree. A factory (rather than a shared
+ * singleton) matters because the repeatable `--domain`/`--id` options carry a
+ * mutable default array; constructing a new tree per invocation keeps those from
+ * accumulating across runs (harmless in a one-shot CLI, but a footgun under a
+ * long-lived process such as the test runner).
+ */
+export const createSettingsCommand = (): Command =>
+  new Command('settings')
+    .description('Capture, version, and replay OS settings (macOS defaults)')
+    .addCommand(
+      new Command('capture')
+        .description('Capture an OS setting by diffing defaults domains as you change it')
+        .argument('[description]', 'Human description of the setting')
+        .option(
+          '-d, --domain <domain>',
+          'Domain to watch/record (repeatable); default: all domains',
+          collectRepeat,
+          []
+        )
+        .option('-k, --key <key>', 'Preference key (direct, non-interactive capture)')
+        .option('-t, --type <type>', 'Value type: boolean|integer|float|string|date')
+        .option('--value <value>', 'Value to record (with --key/--type)')
+        .option('--delete', 'Record a key deletion instead of a write')
+        .option('-m, --description <text>', 'Human description of the setting')
+        .option('--min-version <version>', 'Only apply on OS version >= this')
+        .option('--max-version <version>', 'Only apply on OS version <= this')
+        .option('--restart <apps>', 'Comma-separated apps to restart on apply (e.g. Dock,Finder)')
+        .option('-y, --yes', 'Skip confirmation prompts')
+        .option('--json', 'Emit JSON envelope to stdout')
+        .action(captureAction)
+    )
+    .addCommand(
+      new Command('apply')
+        .description('Replay tracked settings on this machine (version-guarded)')
+        .option('--id <id>', 'Only apply this setting id (repeatable)', collectRepeat, [])
+        .option('--dry-run', 'Show what would be applied without changing anything')
+        .option('--no-restart', 'Do not restart affected apps')
+        .option('-y, --yes', 'Skip the confirmation prompt')
+        .option('--json', 'Emit JSON envelope to stdout')
+        .action(applyAction)
+    )
+    .addCommand(
+      new Command('list')
+        .description('List tracked settings and manual steps')
+        .option('--json', 'Emit JSON envelope to stdout')
+        .action(listAction)
+    )
+    .addCommand(
+      new Command('remove')
+        .description('Untrack a captured setting by id')
+        .argument('<id>', 'Setting id (see `tuck settings list`)')
+        .option('--json', 'Emit JSON envelope to stdout')
+        .action(removeAction)
+    )
+    .addCommand(
+      new Command('manual')
+        .description('Manage the manual-steps checklist (non-automatable steps)')
+        .addCommand(
+          new Command('add')
+            .description('Add a manual step')
+            .argument('<title>', 'Short title for the step')
+            .option('-i, --instructions <text>', 'Detailed instructions')
+            .option('--json', 'Emit JSON envelope to stdout')
+            .action(manualAddAction)
+        )
+        .addCommand(
+          new Command('list')
+            .description('List manual steps with per-machine completion')
+            .option('--json', 'Emit JSON envelope to stdout')
+            .action(manualListAction)
+        )
+        .addCommand(
+          new Command('done')
+            .description('Mark a manual step done on this machine')
+            .argument('<id>', 'Manual step id')
+            .option('--json', 'Emit JSON envelope to stdout')
+            .action((id: string, opts: { json?: boolean }) => manualSetDoneAction(id, true, opts))
+        )
+        .addCommand(
+          new Command('reset')
+            .description('Mark a manual step not done on this machine')
+            .argument('<id>', 'Manual step id')
+            .option('--json', 'Emit JSON envelope to stdout')
+            .action((id: string, opts: { json?: boolean }) => manualSetDoneAction(id, false, opts))
+        )
+    );
+
+/** Default command instance registered on the root program. */
+export const settingsCommand = createSettingsCommand();

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -24,12 +24,14 @@ import { getTuckDir } from '../lib/paths.js';
 import { loadManifest } from '../lib/manifest.js';
 import { collapsePath } from '../lib/paths.js';
 import {
+  TuckError,
   NotInitializedError,
   SettingsError,
   SettingsUnsupportedOsError,
   SettingNotFoundError,
 } from '../errors.js';
-import { setJsonMode, isJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
+import { setJsonMode, isJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
+import type { JsonError } from '../lib/jsonOutput.js';
 import { logger, prompts, colors as c } from '../ui/index.js';
 import {
   selectBackend,
@@ -43,6 +45,7 @@ import {
   loadOsSettingsState,
   type OsSettingsBackend,
   type DomainSnapshot,
+  type ApplyResult,
 } from '../lib/osSettings/index.js';
 import { settingTypeSchema, type SettingType } from '../schemas/osSettings.schema.js';
 
@@ -283,8 +286,51 @@ interface ApplyCliOptions {
   id?: string[];
   dryRun?: boolean;
   restart?: boolean; // false when --no-restart passed
+  force?: boolean;
   json?: boolean;
   yes?: boolean;
+}
+
+/** JSON error projection for a partially-failed apply (mirrors RemoteApplyError). */
+interface SettingsApplyJsonError extends JsonError {
+  applied: { id: string; display: string }[];
+  failed: { id: string; display: string; error: string }[];
+  restarted: string[];
+  restartRequired: string[];
+  backupDir: string | null;
+}
+
+/**
+ * Raised when one or more `defaults` commands fail mid-replay. Escalating (vs.
+ * logging and returning) guarantees a non-zero exit for CI/agents, while
+ * {@link toJSON} preserves what was applied, what failed, and the backup dir so
+ * `--json` consumers can still recover — the backups already exist on disk.
+ */
+class SettingsApplyError extends TuckError {
+  constructor(private readonly result: ApplyResult) {
+    super(
+      `Applied ${result.applied.length} setting(s); ${result.failed.length} failed to apply`,
+      'SETTINGS_APPLY_FAILED',
+      [
+        result.backupDir
+          ? `Pre-apply backups are at ${collapsePath(result.backupDir)}`
+          : 'No backup directory was created',
+        'Inspect the failed entries above and re-run once resolved',
+      ]
+    );
+    this.name = 'SettingsApplyError';
+  }
+
+  toJSON(): SettingsApplyJsonError {
+    return {
+      ...super.toJSON(),
+      applied: this.result.applied,
+      failed: this.result.failed,
+      restarted: this.result.restarted,
+      restartRequired: this.result.restartRequired,
+      backupDir: this.result.backupDir,
+    };
+  }
 }
 
 const applyAction = async (opts: ApplyCliOptions): Promise<void> => {
@@ -307,15 +353,32 @@ const applyAction = async (opts: ApplyCliOptions): Promise<void> => {
   if (isJsonMode()) {
     // JSON mode is non-interactive; honor --dry-run, otherwise apply directly.
     if (dryRun) {
+      reportOsVersionMismatchJson(preview.osVersionMismatch);
       emitJsonOk({ dryRun: true, ...preview });
       return;
+    }
+    // Never write OS settings on the strength of a redirected stdout or --json
+    // alone: --json is non-interactive, so a real apply must carry an explicit
+    // --yes. Without it we refuse rather than silently mutating the machine.
+    if (!opts.yes) {
+      throw new SettingsError('Refusing to apply settings in --json mode without --yes', [
+        'Pass --yes to confirm a non-interactive apply (this WRITES OS settings)',
+        'Or add --dry-run to preview the changes without applying them',
+      ]);
     }
     const result = await applySettings(backend, tuckDir, {
       currentVersion,
       dryRun: false,
       restart: opts.restart !== false,
+      force: opts.force === true,
       only,
     });
+    reportOsVersionMismatchJson(result.osVersionMismatch);
+    if (result.failed.length > 0) {
+      // Escalate so the process exits non-zero; the error's JSON envelope
+      // carries the applied/failed/backup report.
+      throw new SettingsApplyError(result);
+    }
     emitJsonOk({ dryRun: false, ...result });
     return;
   }
@@ -335,6 +398,8 @@ const applyAction = async (opts: ApplyCliOptions): Promise<void> => {
   }
   console.log();
 
+  reportOsVersionMismatch(preview.osVersionMismatch);
+
   if (dryRun) {
     reportSkippedAndManual(preview.skipped, preview.pendingManual);
     logger.dim('Dry run — no changes made. Re-run without --dry-run to apply.');
@@ -342,8 +407,8 @@ const applyAction = async (opts: ApplyCliOptions): Promise<void> => {
   }
 
   if (!opts.yes) {
-    // Never write OS settings on the strength of a redirected stdout or --json
-    // alone: prompts.confirm throws OPERATION_CANCELLED on non-TTY stdin, so a
+    // Never write OS settings on the strength of a redirected stdout alone:
+    // prompts.confirm throws OPERATION_CANCELLED on non-TTY stdin, so a
     // non-interactive apply without --yes fails fast instead of proceeding.
     const ok = await prompts.confirm('Apply these settings to this machine?', false);
     if (!ok) {
@@ -356,6 +421,7 @@ const applyAction = async (opts: ApplyCliOptions): Promise<void> => {
     currentVersion,
     dryRun: false,
     restart: opts.restart !== false,
+    force: opts.force === true,
     only,
   });
 
@@ -363,8 +429,47 @@ const applyAction = async (opts: ApplyCliOptions): Promise<void> => {
   if (result.backupDir) logger.dim(`  backup: ${collapsePath(result.backupDir)}`);
   if (result.restarted.length > 0) {
     logger.dim(`  restarted: ${result.restarted.join(', ')}`);
+  } else if (result.restartRequired.length > 0) {
+    // --no-restart (or nothing restarted): tell the user what to restart by hand
+    // rather than falsely claiming apps were restarted.
+    logger.dim(`  restart manually to take effect: ${result.restartRequired.join(', ')}`);
   }
   reportSkippedAndManual(result.skipped, result.pendingManual);
+
+  if (result.failed.length > 0) {
+    console.log();
+    console.log(c.bold(`Failed to apply ${result.failed.length} setting(s):`));
+    for (const f of result.failed) {
+      console.log(`  ${c.dim('•')} ${c.cyan(f.display)} ${c.dim(`— ${f.error}`)}`);
+    }
+    // Exit non-zero so scripts/CI notice; backups already exist on disk.
+    throw new SettingsApplyError(result);
+  }
+};
+
+/** Print a non-blocking warning when applied settings were captured on another OS major. */
+const reportOsVersionMismatch = (
+  mismatches: { id: string; capturedOsVersion: string }[]
+): void => {
+  if (mismatches.length === 0) return;
+  logger.warning(
+    `${mismatches.length} setting(s) were captured on a different macOS major version:`
+  );
+  for (const m of mismatches) {
+    logger.dim(`  • ${m.id} (captured on macOS ${m.capturedOsVersion})`);
+  }
+  logger.dim('These may behave differently here — review after applying.');
+};
+
+/** Queue the same OS-version-mismatch warning into the JSON envelope. */
+const reportOsVersionMismatchJson = (
+  mismatches: { id: string; capturedOsVersion: string }[]
+): void => {
+  for (const m of mismatches) {
+    addJsonWarning(
+      `Setting ${m.id} was captured on macOS ${m.capturedOsVersion}, a different major version than this machine`
+    );
+  }
 };
 
 const reportSkippedAndManual = (
@@ -595,6 +700,7 @@ export const createSettingsCommand = (): Command =>
         .option('--id <id>', 'Only apply this setting id (repeatable)', collectRepeat, [])
         .option('--dry-run', 'Show what would be applied without changing anything')
         .option('--no-restart', 'Do not restart affected apps')
+        .option('--force', 'Apply even if a pre-apply domain backup cannot be taken')
         .option('-y, --yes', 'Skip the confirmation prompt')
         .option('--json', 'Emit JSON envelope to stdout')
         .action(applyAction)

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -21,6 +21,7 @@ import { getStatus, hasRemote, getRemoteUrl, getCurrentBranch } from '../lib/git
 import { computeStateModel, type FileState } from '../lib/stateModel.js';
 import { setJsonMode, emitJsonOk } from '../lib/jsonOutput.js';
 import { loadTuckignore } from '../lib/tuckignore.js';
+import { enterReadOnlyMode } from '../lib/readOnlyMode.js';
 import { NotInitializedError } from '../errors.js';
 import { VERSION } from '../constants.js';
 import type { StatusOptions, FileChange } from '../types.js';
@@ -379,6 +380,9 @@ const printJsonStatus = (status: TuckStatus): void => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const runStatus = async (options: StatusOptions): Promise<void> => {
+  // status is a read-only inspection command: it must never unlock the keystore
+  // or touch a secret backend. This guarantees zero prompts (see lib/readOnlyMode).
+  enterReadOnlyMode();
   const tuckDir = getTuckDir();
 
   try {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -59,10 +59,13 @@ import {
   redactFile,
   getStoredValueMap,
   getRedactedChecksum,
+  addAllowlistEntryByFingerprint,
+  computeFingerprint,
+  getAllowlistPath,
   type SecretMatch,
 } from '../lib/secrets/index.js';
 import { displayScanResults } from './secrets.js';
-import { logForceSecretBypass } from '../lib/audit.js';
+import { logForceSecretBypass, logSecretAllowlisted } from '../lib/audit.js';
 
 interface SyncResult {
   modified: string[];
@@ -745,6 +748,7 @@ const scanAndHandleSecrets = async (
   const action = await prompts.select('What would you like to do?', [
     { value: 'abort', label: 'Abort sync' },
     { value: 'redact', label: 'Redact secrets (placeholders in repo copy; live file untouched)' },
+    { value: 'allow', label: 'Mark as safe (allowlist false positives)' },
     { value: 'ignore', label: 'Add files to .tuckignore and skip them' },
     { value: 'proceed', label: 'Proceed anyway (secrets will be committed)' },
   ]);
@@ -752,6 +756,39 @@ const scanAndHandleSecrets = async (
   if (action === 'abort') {
     prompts.cancel('Sync aborted - secrets detected');
     return { proceed: false, redactionPlans: [] };
+  }
+
+  if (action === 'allow') {
+    const reason = await prompts.text(
+      'Why are these findings safe? (recorded in the allowlist)',
+      { placeholder: 'e.g. example values from docs, not real secrets' }
+    );
+    if (!reason || reason.trim().length === 0) {
+      prompts.cancel('Sync aborted - a reason is required to allowlist');
+      return { proceed: false, redactionPlans: [] };
+    }
+    let allowlisted = 0;
+    for (const result of summary.results) {
+      if (!result.hasSecrets) continue;
+      for (const match of result.matches) {
+        const entry = await addAllowlistEntryByFingerprint(
+          tuckDir,
+          computeFingerprint(match.value),
+          { reason: reason.trim(), pattern: match.patternId, path: result.collapsedPath }
+        );
+        await logSecretAllowlisted(entry.fingerprint, entry.reason, {
+          pattern: entry.pattern,
+          path: entry.path,
+        });
+        allowlisted++;
+      }
+    }
+    prompts.log.success(
+      `Allowlisted ${allowlisted} finding${allowlisted === 1 ? '' : 's'} in ${collapsePath(getAllowlistPath(tuckDir))}`
+    );
+    prompts.note('Commit secrets.allow.json so teammates share the allowlist', 'Tip');
+    // Everything flagged was just allowlisted — proceed with no redactions.
+    return { proceed: true, redactionPlans: [] };
   }
 
   if (action === 'redact') {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -30,6 +30,7 @@ import {
 } from '../lib/mergeConflicts.js';
 import { resolveConflictsInteractively } from '../ui/merge.js';
 import { createSnapshot } from '../lib/timemachine.js';
+import { undoBreadcrumb } from '../lib/undoHint.js';
 import { resolveLiveTarget } from '../lib/repoScope.js';
 import { isJsonMode } from '../lib/jsonOutput.js';
 import {
@@ -1053,13 +1054,19 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
       pullSpinner.stop(`Could not pull: ${pullResult.error}`);
       prompts.log.warning('Continuing with local changes...');
     } else if (pullResult.pulled) {
+      const resolvedCount = pullResult.resolvedConflicts?.length ?? 0;
       const conflictNote =
-        pullResult.resolvedConflicts && pullResult.resolvedConflicts.length > 0
-          ? ` (resolved ${pullResult.resolvedConflicts.length} conflict${pullResult.resolvedConflicts.length === 1 ? '' : 's'})`
+        resolvedCount > 0
+          ? ` (resolved ${resolvedCount} conflict${resolvedCount === 1 ? '' : 's'})`
           : '';
       pullSpinner.stop(
         `Pulled ${pullResult.behind} commit${pullResult.behind > 1 ? 's' : ''} from remote${conflictNote}`
       );
+      // A conflict resolution rewrote tracked files in place; surface the
+      // snapshot taken during resolution as a one-line recovery path (IDEAS 6.5).
+      if (resolvedCount > 0) {
+        logger.info(undoBreadcrumb());
+      }
     } else {
       pullSpinner.stop('Up to date with remote');
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { join, basename, relative, isAbsolute } from 'path';
-import { realpath } from 'fs/promises';
+import { realpath, readFile, writeFile } from 'fs/promises';
 import { prompts, logger, withSpinner, colors as c } from '../ui/index.js';
 import {
   getTuckDir,
@@ -45,7 +45,20 @@ import { checkLocalMode } from '../lib/remoteChecks.js';
 import { loadConfig } from '../lib/config.js';
 import { assertRemoteAvailable } from '../lib/providers/index.js';
 import { runPreSyncHook, runPostSyncHook, type HookOptions } from '../lib/hooks.js';
-import { NotInitializedError, SecretsDetectedError, MergeConflictsError } from '../errors.js';
+import {
+  NotInitializedError,
+  SecretsDetectedError,
+  MergeConflictsError,
+  JsonMergeConflictsError,
+} from '../errors.js';
+import {
+  captureMergeBases,
+  decideFileMerge,
+  persistPendingMergeBases,
+  loadPendingMergeBases,
+  clearPendingMergeBases,
+} from '../lib/jsonMergeSync.js';
+import { resolveMergePolicy, type ConflictResolution } from '../lib/jsonMerge.js';
 import { setJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import type { SyncOptions, FileChange } from '../types.js';
 import { detectDotfiles, DETECTION_CATEGORIES, type DetectedFile } from '../lib/detect.js';
@@ -303,7 +316,18 @@ const resolveConflictsInline = async (
 const pullIfBehind = async (
   tuckDir: string,
   options: SyncOptions = {}
-): Promise<{ pulled: boolean; behind: number; error?: string; resolvedConflicts?: string[] }> => {
+): Promise<{
+  pulled: boolean;
+  behind: number;
+  error?: string;
+  resolvedConflicts?: string[];
+  /**
+   * Repo-copy contents of every merge-policy file, captured immediately BEFORE
+   * the pull. This is the common ancestor for the sync-time structured merge —
+   * see {@link reconcileJsonMerges}. Empty unless a pull actually ran.
+   */
+  mergeBases?: Map<string, string>;
+}> => {
   const hasRemoteRepo = await hasRemote(tuckDir);
   if (!hasRemoteRepo) {
     return { pulled: false, behind: 0 };
@@ -319,6 +343,12 @@ const pullIfBehind = async (
       return { pulled: false, behind: 0 };
     }
 
+    // Capture the repo copy of every merge-policy file BEFORE pulling. On this
+    // machine that copy equals the last-synced state, so it is the correct
+    // common ancestor for a three-way merge once the pull advances the repo
+    // copy to the remote's version.
+    const mergeBases = await captureMergeBases(tuckDir, await getAllTrackedFiles(tuckDir));
+
     // Snapshot tracked sources before a potentially-destructive pull so users
     // can roll back if anything goes sideways during merge.
     await snapshotBeforePull(tuckDir, 'Pre-sync pull backup');
@@ -329,7 +359,7 @@ const pullIfBehind = async (
       // The rebase rewrote .tuckmanifest.json out-of-band; drop the cached copy
       // so the rest of this run (and change detection) sees the pulled state.
       clearManifestCache();
-      return { pulled: true, behind: status.behind };
+      return { pulled: true, behind: status.behind, mergeBases };
     } catch (pullError) {
       // A failed pull --rebase may have left conflicts staged in the index.
       // If it didn't, this is just a regular git error and we re-throw.
@@ -381,6 +411,7 @@ const pullIfBehind = async (
         pulled: true,
         behind: status.behind,
         resolvedConflicts: conflicts.map((c) => c.path),
+        mergeBases,
       };
     }
   } catch (error) {
@@ -868,8 +899,146 @@ const scanAndHandleSecrets = async (
   return { proceed: true, redactionPlans: [] };
 };
 
+/**
+ * Structured three-way merge for tracked JSON files after a pull.
+ *
+ * When a merge-policy file was modified locally AND the pull advanced its repo
+ * copy, a naive live→repo capture would silently discard the incoming changes.
+ * Instead we three-way merge base(pre-pull repo) × local(live) × remote(post-
+ * pull repo), union allowlists/plugin lists, and write the reconciled document
+ * to BOTH the live file and the repo copy so the two machines converge. The
+ * later `syncFiles` copy then captures the already-merged content.
+ *
+ * Returns `false` when the user aborts on an unresolvable conflict (the caller
+ * stops the sync), `true` otherwise.
+ */
+const reconcileJsonMerges = async (
+  tuckDir: string,
+  changes: TrackedFileChange[],
+  mergeBases: Map<string, string>,
+  options: SyncOptions
+): Promise<boolean> => {
+  if (mergeBases.size === 0) return true;
+
+  const trackedFiles = await getAllTrackedFiles(tuckDir);
+  const bySource = new Map<string, (typeof trackedFiles)[string]>();
+  for (const file of Object.values(trackedFiles)) {
+    bySource.set(file.source, file);
+  }
+
+  for (const change of changes) {
+    if (change.status !== 'modified') continue;
+
+    const baseText = mergeBases.get(change.source);
+    if (baseText === undefined) continue;
+
+    const entry = bySource.get(change.source);
+    if (!entry) continue;
+
+    const policy = resolveMergePolicy(entry.source, entry.merge);
+    if (!policy) continue;
+
+    const livePath = await resolveLiveTarget(entry);
+    if (livePath === null) continue;
+
+    const destPath = join(tuckDir, entry.destination);
+    if (!(await pathExists(livePath)) || !(await pathExists(destPath))) continue;
+
+    let liveText: string;
+    let remoteText: string;
+    try {
+      liveText = await readFile(livePath, 'utf-8');
+      remoteText = await readFile(destPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    let decision = decideFileMerge(baseText, liveText, remoteText, policy);
+
+    if (decision.kind === 'skip') continue;
+
+    if (decision.kind === 'unparsable') {
+      logger.warning(
+        `Could not structurally merge ${collapsePath(livePath)} (not valid JSON on one side) — keeping local version`
+      );
+      continue;
+    }
+
+    if (decision.kind === 'conflict') {
+      // Non-interactive callers cannot choose a resolution: surface a structured
+      // error (exit code 3) instead of silently picking a side.
+      const nonInteractive = options.yes === true || options.json === true || isJsonMode();
+      if (nonInteractive) {
+        await persistPendingMergeBases(mergeBases);
+        throw new JsonMergeConflictsError(
+          collapsePath(livePath),
+          decision.conflicts.map((cf) => cf.path)
+        );
+      }
+
+      console.log();
+      console.log(c.yellow(`Merge conflicts in ${collapsePath(livePath)}:`));
+      for (const cf of decision.conflicts) {
+        console.log(c.dim(`  • ${cf.path} — ${cf.reason}`));
+      }
+      console.log();
+
+      const choice = await prompts.select('How should tuck resolve these conflicts?', [
+        { value: 'ours', label: 'Keep local values' },
+        { value: 'theirs', label: 'Take incoming values' },
+        { value: 'abort', label: 'Abort sync and resolve manually' },
+      ]);
+
+      if (choice === 'abort') {
+        // The base lives only in memory this run — persist it so the NEXT sync
+        // can still detect the divergence instead of silently committing local
+        // values over the remote's.
+        await persistPendingMergeBases(mergeBases);
+        prompts.cancel('Sync aborted - unresolved JSON merge conflicts');
+        prompts.log.info(
+          'The merge base was saved; the next `tuck sync` will re-detect these conflicts.'
+        );
+        return false;
+      }
+
+      // Re-run with the chosen strategy so every conflicting leaf resolves.
+      decision = decideFileMerge(baseText, liveText, remoteText, {
+        ...policy,
+        conflict: choice as ConflictResolution,
+      });
+    }
+
+    if (decision.kind !== 'clean' && decision.kind !== 'conflict') continue;
+    const mergedText = decision.text;
+
+    // Snapshot the live file before we rewrite it so `tuck undo` can recover the
+    // pre-merge version even if the union surprises the user.
+    try {
+      await createSnapshot([livePath], `Pre-merge backup: ${change.path}`);
+    } catch (error) {
+      logger.dim(
+        `Pre-merge snapshot skipped: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    await writeFile(livePath, mergedText, 'utf-8');
+    await writeFile(destPath, mergedText, 'utf-8');
+    logger.file('merge', collapsePath(livePath));
+  }
+
+  // Every conflict was reconciled (or none applied) — drop any abort-recovery
+  // bases from a previous run so stale ancestors never resurface.
+  await clearPendingMergeBases();
+  return true;
+};
+
 const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): Promise<void> => {
   prompts.intro('tuck sync');
+
+  // Repo-copy snapshots captured before a pull, used for the structured JSON
+  // merge in STEP 2.6. Seeded from any bases persisted by a previous aborted
+  // run (abort recovery); bases captured by THIS run's pull take precedence.
+  let mergeBases = await loadPendingMergeBases();
 
   // ========== STEP 1: Pull from remote if behind ==========
   if (options.pull !== false && (await hasRemote(tuckDir))) {
@@ -877,6 +1046,9 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
     pullSpinner.start('Checking remote for updates...');
 
     const pullResult = await pullIfBehind(tuckDir, options);
+    if (pullResult.mergeBases) {
+      mergeBases = new Map([...mergeBases, ...pullResult.mergeBases]);
+    }
     if (pullResult.error) {
       pullSpinner.stop(`Could not pull: ${pullResult.error}`);
       prompts.log.warning('Continuing with local changes...');
@@ -898,6 +1070,17 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
   changeSpinner.start('Detecting changes to tracked files...');
   const changes = await detectChanges(tuckDir);
   changeSpinner.stop(`Found ${changes.length} changed file${changes.length !== 1 ? 's' : ''}`);
+
+  // ========== STEP 2.4: Structured three-way merge for JSON policy files ==========
+  // Reconcile locally-modified JSON files against the freshly-pulled repo copy
+  // BEFORE scanning/committing, so an agent-rewritten config never silently
+  // overwrites the incoming changes. Only does work when a pull captured bases.
+  if (changes.length > 0 && mergeBases.size > 0) {
+    const shouldContinue = await reconcileJsonMerges(tuckDir, changes, mergeBases, options);
+    if (!shouldContinue) {
+      return;
+    }
+  }
 
   // ========== STEP 2.5: Scan modified files for secrets ==========
   // When the user picks 'redact', the plans are threaded into syncFiles below,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -34,6 +34,7 @@ import { createSnapshot } from '../lib/timemachine.js';
 import { undoBreadcrumb } from '../lib/undoHint.js';
 import { resolveLiveTarget } from '../lib/repoScope.js';
 import { isJsonMode } from '../lib/jsonOutput.js';
+import { isNonInteractive } from '../lib/agentMode.js';
 import {
   copyFileOrDir,
   getFileChecksum,
@@ -60,8 +61,14 @@ import {
   persistPendingMergeBases,
   loadPendingMergeBases,
   clearPendingMergeBases,
+  combineMergeBases,
+  type MergeDecision,
 } from '../lib/jsonMergeSync.js';
-import { resolveMergePolicy, type ConflictResolution } from '../lib/jsonMerge.js';
+import {
+  resolveMergePolicy,
+  type ConflictResolution,
+  type MergePolicy,
+} from '../lib/jsonMerge.js';
 import { setJsonMode, emitJsonOk, addJsonWarning } from '../lib/jsonOutput.js';
 import type { SyncOptions, FileChange } from '../types.js';
 import { detectDotfiles, DETECTION_CATEGORIES, type DetectedFile } from '../lib/detect.js';
@@ -403,8 +410,12 @@ const pullIfBehind = async (
 
       // Non-interactive / JSON callers cannot drive the resolution UI. Throw
       // a structured error so agents can detect and report it via the JSON
-      // envelope.
-      const nonInteractive = options.json === true || options.yes === true || isJsonMode();
+      // envelope. isNonInteractive() also covers the global `--non-interactive`
+      // flag and a non-TTY stdin — without it, `--non-interactive` alone fell
+      // through to resolveConflictsInline, whose prompt throws mid-rebase and
+      // wedges ~/.tuck (the abort below never ran).
+      const nonInteractive =
+        options.json === true || options.yes === true || isJsonMode() || isNonInteractive();
       if (nonInteractive) {
         // Abort the in-progress rebase BEFORE throwing so ~/.tuck is left in a
         // clean state — an automated/JSON caller cannot resolve conflicts, and
@@ -450,6 +461,16 @@ const pullIfBehind = async (
   } catch (error) {
     if (error instanceof MergeConflictsError) {
       throw error;
+    }
+    // A prompt-cancel or unexpected error may have escaped while a rebase was
+    // still in progress (e.g. a resolve prompt that threw in a non-TTY context).
+    // Never leave a half-finished rebase behind — it wedges every later git op,
+    // and the caller continues into stage/commit. Abort defensively; this is a
+    // no-op when no rebase/merge is in progress.
+    try {
+      await abortRebase(tuckDir);
+    } catch {
+      // Nothing in progress, or abort failed — surface the original error below.
     }
     return {
       pulled: false,
@@ -780,7 +801,15 @@ const scanJsonKeySubtrees = async (
   changes: FileChange[]
 ): Promise<Array<{ source: string; count: number; patterns: string[] }>> => {
   const { scanContent } = await import('../lib/secrets/scanner.js');
+  const { loadAllowlist, isMatchAllowed } = await import('../lib/secrets/allowlist.js');
   const trackedFiles = await getAllTrackedFiles(tuckDir);
+  // Respect the allowlist so findings the user has already marked safe never
+  // re-prompt on every sync. The whole-file scan a few lines up goes through
+  // scanForSecrets (which loads + applies the allowlist); the raw scanContent
+  // used here does not, so we filter its matches with the same allowlist. Load
+  // it lazily on the first raw match so a sync with no --key files (or none with
+  // findings) never touches the allowlist file.
+  let allowlistEntries: Awaited<ReturnType<typeof loadAllowlist>>['entries'] | null = null;
   const findings: Array<{ source: string; count: number; patterns: string[] }> = [];
   for (const change of changes) {
     if (change.status !== 'modified') continue;
@@ -790,7 +819,15 @@ const scanJsonKeySubtrees = async (
     if (live === null || !(await pathExists(live))) continue;
     try {
       const subtree = extractSubtree(await readFile(live, 'utf-8'), entry.jsonKey);
-      const matches = scanContent(subtree);
+      const rawMatches = scanContent(subtree);
+      if (rawMatches.length === 0) continue;
+      if (allowlistEntries === null) {
+        allowlistEntries = (await loadAllowlist(tuckDir)).entries;
+      }
+      const collapsedLive = collapsePath(live);
+      const matches = rawMatches.filter(
+        (m) => !isMatchAllowed(m, collapsedLive, allowlistEntries!)
+      );
       if (matches.length > 0) {
         findings.push({
           source: change.source,
@@ -1012,33 +1049,38 @@ const scanAndHandleSecrets = async (
   return { proceed: true, redactionPlans: [] };
 };
 
+/** A merge-policy file resolved to concrete paths + its three versions. */
+interface MergeItem {
+  source: string;
+  change: TrackedFileChange;
+  livePath: string;
+  destPath: string;
+  baseText: string;
+  liveText: string;
+  remoteText: string;
+  policy: MergePolicy;
+  decision: MergeDecision;
+}
+
 /**
- * Structured three-way merge for tracked JSON files after a pull.
- *
- * When a merge-policy file was modified locally AND the pull advanced its repo
- * copy, a naive live→repo capture would silently discard the incoming changes.
- * Instead we three-way merge base(pre-pull repo) × local(live) × remote(post-
- * pull repo), union allowlists/plugin lists, and write the reconciled document
- * to BOTH the live file and the repo copy so the two machines converge. The
- * later `syncFiles` copy then captures the already-merged content.
- *
- * Returns `false` when the user aborts on an unresolvable conflict (the caller
- * stops the sync), `true` otherwise.
+ * For each modified merge-policy change with a captured base, resolve its paths,
+ * read its three versions and compute a merge decision — WITHOUT writing
+ * anything. jsonKey (`--key`) files are excluded: their repo copy is a subtree
+ * document, not the whole file, so a whole-file three-way merge would corrupt
+ * both copies (they sync via the subtree-aware path instead).
  */
-const reconcileJsonMerges = async (
+const collectMergeItems = async (
   tuckDir: string,
   changes: TrackedFileChange[],
-  mergeBases: Map<string, string>,
-  options: SyncOptions
-): Promise<boolean> => {
-  if (mergeBases.size === 0) return true;
-
+  mergeBases: Map<string, string>
+): Promise<MergeItem[]> => {
   const trackedFiles = await getAllTrackedFiles(tuckDir);
   const bySource = new Map<string, (typeof trackedFiles)[string]>();
   for (const file of Object.values(trackedFiles)) {
     bySource.set(file.source, file);
   }
 
+  const items: MergeItem[] = [];
   for (const change of changes) {
     if (change.status !== 'modified') continue;
 
@@ -1047,6 +1089,9 @@ const reconcileJsonMerges = async (
 
     const entry = bySource.get(change.source);
     if (!entry) continue;
+    // jsonKey files are never whole-file merged (their repo copy is only the
+    // tracked subtree); leave them entirely to the subtree-aware sync path.
+    if (entry.jsonKey) continue;
 
     const policy = resolveMergePolicy(entry.source, entry.merge);
     if (!policy) continue;
@@ -1066,31 +1111,134 @@ const reconcileJsonMerges = async (
       continue;
     }
 
-    let decision = decideFileMerge(baseText, liveText, remoteText, policy);
+    const decision = decideFileMerge(baseText, liveText, remoteText, policy);
+    items.push({
+      source: change.source,
+      change,
+      livePath,
+      destPath,
+      baseText,
+      liveText,
+      remoteText,
+      policy,
+      decision,
+    });
+  }
+  return items;
+};
 
-    if (decision.kind === 'skip') continue;
+/** Write a reconciled document to both the live file and the repo copy. */
+const applyMergedText = async (item: MergeItem, mergedText: string): Promise<void> => {
+  // Snapshot the live file before we rewrite it so `tuck undo` can recover the
+  // pre-merge version even if the union surprises the user.
+  try {
+    await createSnapshot([item.livePath], `Pre-merge backup: ${item.change.path}`);
+  } catch (error) {
+    logger.dim(
+      `Pre-merge snapshot skipped: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  await writeFile(item.livePath, mergedText, 'utf-8');
+  await writeFile(item.destPath, mergedText, 'utf-8');
+  logger.file('merge', collapsePath(item.livePath));
+};
+
+/**
+ * Persist the bases that must survive to the NEXT sync and drop the rest.
+ *
+ * A base is retained only when its file still needs attention — it is
+ * `unparsable` (couldn't be structurally merged) or, interactively, a conflict
+ * the user has not yet resolved. Reconciled/clean, `skip` (remote unchanged),
+ * and files no longer present in this run's changes are all dropped, so a base
+ * left over from an out-of-band resolution never resurfaces as a spurious
+ * conflict against an ancient ancestor.
+ */
+const persistRetainedBases = async (retain: Map<string, string>): Promise<void> => {
+  if (retain.size > 0) {
+    await persistPendingMergeBases(retain);
+  } else {
+    await clearPendingMergeBases();
+  }
+};
+
+/**
+ * Structured three-way merge for tracked JSON files after a pull.
+ *
+ * When a merge-policy file was modified locally AND the pull advanced its repo
+ * copy, a naive live→repo capture would silently discard the incoming changes.
+ * Instead we three-way merge base(pre-pull repo) × local(live) × remote(post-
+ * pull repo), union allowlists/plugin lists, and write the reconciled document
+ * to BOTH the live file and the repo copy so the two machines converge. The
+ * later `syncFiles` copy then captures the already-merged content.
+ *
+ * Non-interactive callers (JSON / --yes / --non-interactive / non-TTY) cannot
+ * choose a resolution. If ANY file conflicts we persist the bases for recovery
+ * and throw {@link JsonMergeConflictsError} (exit 3) BEFORE writing anything —
+ * so the later capture/commit/push can never overwrite the conflicted remote.
+ * Clean merges are still auto-applied when no file conflicts.
+ *
+ * Returns `false` when the user aborts on an unresolvable conflict (the caller
+ * stops the sync), `true` otherwise.
+ */
+const reconcileJsonMerges = async (
+  tuckDir: string,
+  changes: TrackedFileChange[],
+  mergeBases: Map<string, string>,
+  options: SyncOptions,
+  forceNonInteractive = false
+): Promise<boolean> => {
+  // Even with no changes, we may hold stale persisted bases (e.g. an out-of-band
+  // resolution). collectMergeItems returns nothing, retain stays empty, and the
+  // clear below drops them.
+  if (mergeBases.size === 0) return true;
+
+  // `forceNonInteractive` is set by the non-prompting commit paths (`-m msg`,
+  // which throws rather than prompts even on a TTY, mirroring its secret gate).
+  const nonInteractive =
+    forceNonInteractive ||
+    options.yes === true ||
+    options.json === true ||
+    isJsonMode() ||
+    isNonInteractive();
+
+  const items = await collectMergeItems(tuckDir, changes, mergeBases);
+
+  // Non-interactive: a single conflict aborts the whole reconcile up front, so
+  // no clean merge is written before we bail. Persist ALL bases (nothing was
+  // applied this run) so the next sync re-detects and can reconcile the rest.
+  if (nonInteractive) {
+    const conflicted = items.find((i) => i.decision.kind === 'conflict');
+    if (conflicted && conflicted.decision.kind === 'conflict') {
+      await persistPendingMergeBases(mergeBases);
+      throw new JsonMergeConflictsError(
+        collapsePath(conflicted.livePath),
+        conflicted.decision.conflicts.map((cf) => cf.path)
+      );
+    }
+  }
+
+  // Bases to keep for the next run: unparsable files always, plus (interactive)
+  // conflicts the user leaves unresolved on abort.
+  const retain = new Map<string, string>();
+
+  for (const item of items) {
+    let decision = item.decision;
+
+    if (decision.kind === 'skip') continue; // remote unchanged → base no longer needed
 
     if (decision.kind === 'unparsable') {
       logger.warning(
-        `Could not structurally merge ${collapsePath(livePath)} (not valid JSON on one side) — keeping local version`
+        `Could not structurally merge ${collapsePath(item.livePath)} (not valid JSON on one side) — keeping local version`
       );
+      // Never discard a base for a file we could not reconcile.
+      retain.set(item.source, item.baseText);
       continue;
     }
 
     if (decision.kind === 'conflict') {
-      // Non-interactive callers cannot choose a resolution: surface a structured
-      // error (exit code 3) instead of silently picking a side.
-      const nonInteractive = options.yes === true || options.json === true || isJsonMode();
-      if (nonInteractive) {
-        await persistPendingMergeBases(mergeBases);
-        throw new JsonMergeConflictsError(
-          collapsePath(livePath),
-          decision.conflicts.map((cf) => cf.path)
-        );
-      }
-
+      // Non-interactive callers already threw above; only interactive reaches here.
       console.log();
-      console.log(c.yellow(`Merge conflicts in ${collapsePath(livePath)}:`));
+      console.log(c.yellow(`Merge conflicts in ${collapsePath(item.livePath)}:`));
       for (const cf of decision.conflicts) {
         console.log(c.dim(`  • ${cf.path} — ${cf.reason}`));
       }
@@ -1103,10 +1251,15 @@ const reconcileJsonMerges = async (
       ]);
 
       if (choice === 'abort') {
-        // The base lives only in memory this run — persist it so the NEXT sync
-        // can still detect the divergence instead of silently committing local
-        // values over the remote's.
-        await persistPendingMergeBases(mergeBases);
+        // Keep every still-unresolved base (this conflict and any other
+        // conflict/unparsable file) so the NEXT sync can re-detect the
+        // divergence instead of silently committing local values over remote.
+        for (const other of items) {
+          if (other.decision.kind === 'conflict' || other.decision.kind === 'unparsable') {
+            retain.set(other.source, other.baseText);
+          }
+        }
+        await persistPendingMergeBases(retain);
         prompts.cancel('Sync aborted - unresolved JSON merge conflicts');
         prompts.log.info(
           'The merge base was saved; the next `tuck sync` will re-detect these conflicts.'
@@ -1115,33 +1268,20 @@ const reconcileJsonMerges = async (
       }
 
       // Re-run with the chosen strategy so every conflicting leaf resolves.
-      decision = decideFileMerge(baseText, liveText, remoteText, {
-        ...policy,
+      decision = decideFileMerge(item.baseText, item.liveText, item.remoteText, {
+        ...item.policy,
         conflict: choice as ConflictResolution,
       });
     }
 
     if (decision.kind !== 'clean' && decision.kind !== 'conflict') continue;
-    const mergedText = decision.text;
-
-    // Snapshot the live file before we rewrite it so `tuck undo` can recover the
-    // pre-merge version even if the union surprises the user.
-    try {
-      await createSnapshot([livePath], `Pre-merge backup: ${change.path}`);
-    } catch (error) {
-      logger.dim(
-        `Pre-merge snapshot skipped: ${error instanceof Error ? error.message : String(error)}`
-      );
-    }
-
-    await writeFile(livePath, mergedText, 'utf-8');
-    await writeFile(destPath, mergedText, 'utf-8');
-    logger.file('merge', collapsePath(livePath));
+    await applyMergedText(item, decision.text);
+    // Reconciled → its base is no longer needed (not added to retain).
   }
 
-  // Every conflict was reconciled (or none applied) — drop any abort-recovery
-  // bases from a previous run so stale ancestors never resurface.
-  await clearPendingMergeBases();
+  // Drop reconciled/skipped/stale bases; keep only unparsable (and, on abort
+  // above, unresolved conflicts — but that path already returned).
+  await persistRetainedBases(retain);
   return true;
 };
 
@@ -1150,8 +1290,11 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
 
   // Repo-copy snapshots captured before a pull, used for the structured JSON
   // merge in STEP 2.6. Seeded from any bases persisted by a previous aborted
-  // run (abort recovery); bases captured by THIS run's pull take precedence.
-  let mergeBases = await loadPendingMergeBases();
+  // run (abort recovery). PERSISTED pending bases take precedence over bases
+  // captured by THIS run's pull: after an abort the repo copy already holds the
+  // previously-pulled remote, so a "fresh" base would be the wrong ancestor.
+  const pendingBases = await loadPendingMergeBases();
+  let mergeBases = new Map(pendingBases);
 
   // ========== STEP 1: Pull from remote if behind ==========
   if (options.pull !== false && (await hasRemote(tuckDir))) {
@@ -1160,7 +1303,9 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
 
     const pullResult = await pullIfBehind(tuckDir, options);
     if (pullResult.mergeBases) {
-      mergeBases = new Map([...mergeBases, ...pullResult.mergeBases]);
+      // Fresh bases fill in files with no pending base; persisted pending bases
+      // win on collision.
+      mergeBases = combineMergeBases(pullResult.mergeBases, pendingBases);
     }
     if (pullResult.error) {
       pullSpinner.stop(`Could not pull: ${pullResult.error}`);
@@ -1193,8 +1338,10 @@ const runInteractiveSync = async (tuckDir: string, options: SyncOptions = {}): P
   // ========== STEP 2.4: Structured three-way merge for JSON policy files ==========
   // Reconcile locally-modified JSON files against the freshly-pulled repo copy
   // BEFORE scanning/committing, so an agent-rewritten config never silently
-  // overwrites the incoming changes. Only does work when a pull captured bases.
-  if (changes.length > 0 && mergeBases.size > 0) {
+  // overwrites the incoming changes. Runs whenever we hold any base (fresh or
+  // persisted) — even with no changes, so stale persisted bases from an
+  // out-of-band resolution get cleared instead of lingering.
+  if (mergeBases.size > 0) {
     const shouldContinue = await reconcileJsonMerges(tuckDir, changes, mergeBases, options);
     if (!shouldContinue) {
       return;
@@ -1530,6 +1677,48 @@ export const runSync = async (options: SyncOptions = {}): Promise<void> => {
 };
 
 /**
+ * Non-interactive pull + structured JSON reconcile, shared by the `--json` /
+ * `--yes` and message (`-m`) sync paths. Mirrors STEP 1 + STEP 2.4 of the
+ * interactive flow: pull if behind, capture the pre-pull repo copies as merge
+ * bases (persisted pending bases win over freshly-pulled ones), then three-way
+ * merge every diverged JSON-policy file.
+ *
+ * This MUST run before the caller's detectChanges / syncFiles / commit / push.
+ * On an unresolvable conflict {@link reconcileJsonMerges} persists the bases and
+ * throws {@link JsonMergeConflictsError} (exit 3) BEFORE returning — so the
+ * later live→repo capture can never overwrite the conflicted remote (permanent
+ * data loss). Clean merges are auto-applied in place; the caller's own
+ * detectChanges then captures the merged content as an ordinary modification.
+ */
+const pullAndReconcileNonInteractive = async (
+  tuckDir: string,
+  options: SyncOptions
+): Promise<void> => {
+  const pendingBases = await loadPendingMergeBases();
+  let mergeBases = new Map(pendingBases);
+
+  if (options.pull !== false && (await hasRemote(tuckDir))) {
+    const pullResult = await pullIfBehind(tuckDir, options);
+    if (pullResult.mergeBases) {
+      // Fresh bases fill in files with no pending base; persisted bases win.
+      mergeBases = combineMergeBases(pullResult.mergeBases, pendingBases);
+    }
+    if (pullResult.error) {
+      const msg = `Could not pull: ${pullResult.error} — continuing with local changes`;
+      if (options.json) addJsonWarning(msg);
+      else logger.warning(msg);
+    }
+  }
+
+  if (mergeBases.size > 0) {
+    const changes = await detectChanges(tuckDir);
+    // forceNonInteractive: throw JsonMergeConflictsError on any conflict (after
+    // persisting bases) rather than prompt — these paths never present prompts.
+    await reconcileJsonMerges(tuckDir, changes, mergeBases, options, true);
+  }
+};
+
+/**
  * Scan the about-to-be-synced changes for secrets and either block or warn,
  * honoring `security.blockOnSecrets`. This is the SINGLE secret gate shared by
  * every non-interactive sync path (`--json`, `--yes`, and the message path) so
@@ -1631,6 +1820,11 @@ export const runSyncCommand = async (
 
   // If JSON or auto-yes mode and we have a path through, use non-interactive flow.
   if (options.json || options.yes) {
+    // Pull + structured-merge BEFORE detecting/committing so an incoming remote
+    // change is unioned into the live file rather than silently overwritten. On
+    // an unresolvable conflict this throws JsonMergeConflictsError (exit 3) with
+    // the bases persisted for recovery — before anything is committed/pushed.
+    await pullAndReconcileNonInteractive(tuckDir, options);
     const changes = await detectChanges(tuckDir);
     if (changes.length === 0) {
       // No tracked-file DRIFT — but the working tree may still hold uncommitted
@@ -1723,6 +1917,11 @@ export const runSyncCommand = async (
     await runInteractiveSync(tuckDir, options);
     return;
   }
+
+  // Pull + structured-merge BEFORE detecting/committing (same contract as the
+  // JSON/--yes path): union incoming remote changes into the live file, or throw
+  // JsonMergeConflictsError (exit 3) with bases persisted, before any commit/push.
+  await pullAndReconcileNonInteractive(tuckDir, options);
 
   // Detect changes
   const changes = await detectChanges(tuckDir);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { join, basename, relative, isAbsolute } from 'path';
 import { realpath, readFile, writeFile } from 'fs/promises';
+import { createHash } from 'node:crypto';
 import { prompts, logger, withSpinner, colors as c } from '../ui/index.js';
 import {
   getTuckDir,
@@ -46,6 +47,7 @@ import { checkLocalMode } from '../lib/remoteChecks.js';
 import { loadConfig } from '../lib/config.js';
 import { assertRemoteAvailable } from '../lib/providers/index.js';
 import { runPreSyncHook, runPostSyncHook, type HookOptions } from '../lib/hooks.js';
+import { extractSubtree, hasSubtree } from '../lib/jsonKey.js';
 import {
   NotInitializedError,
   SecretsDetectedError,
@@ -187,6 +189,30 @@ export const detectChanges = async (tuckDir: string): Promise<TrackedFileChange[
       continue;
     }
 
+    // JSON-key files: compare only the SUBTREE extracted from the live file to
+    // the recorded checksum (which is of the repo's canonical subtree). A raw
+    // whole-file checksum would always differ — the live file also holds tokens/
+    // caches we deliberately never track — and would make sync capture the whole
+    // file back into the repo, leaking those keys. If the key was removed from
+    // the live file, SKIP (never wipe the tracked subtree from the repo).
+    if (file.jsonKey) {
+      try {
+        const content = await readFile(sourcePath, 'utf8');
+        if (!hasSubtree(content, file.jsonKey)) {
+          continue;
+        }
+        const subtree = extractSubtree(content, file.jsonKey);
+        const subtreeChecksum = createHash('sha256').update(Buffer.from(subtree, 'utf8')).digest('hex');
+        if (subtreeChecksum !== file.checksum) {
+          changes.push({ path: file.source, status: 'modified', source: file.source, destination: file.destination, id });
+        }
+      } catch {
+        // Live file unreadable / not valid JSON — skip rather than capture a
+        // malformed whole file into the repo.
+      }
+      continue;
+    }
+
     // Check if file has changed compared to stored checksum
     try {
       const sourceChecksum = await getFileChecksum(sourcePath);
@@ -240,6 +266,12 @@ const resolveModifiedChangeTargets = async (
   for (const change of changes) {
     if (change.status !== 'modified') continue;
     const entry = Object.values(trackedFiles).find((f) => f.source === change.source);
+    // JSON-key files are deliberately EXCLUDED from the whole-file secret scan:
+    // the live file (e.g. ~/.claude.json) mixes the tracked subtree with OAuth
+    // tokens and history that tuck never captures, so scanning the whole file
+    // would false-positive on secrets that can never reach the repo. Their
+    // subtree is secret-scanned at `tuck add` time instead.
+    if (entry?.jsonKey) continue;
     const live = entry ? await resolveLiveTarget(entry) : expandPath(change.source);
     if (live !== null) targets.push({ change, live });
   }
@@ -572,6 +604,25 @@ const syncFiles = async (
     validatePathWithinRoot(destPath, tuckDir, 'sync destination');
 
     if (change.status === 'modified') {
+      // JSON-key files re-extract ONLY the tracked subtree from the live file
+      // into the repo copy — never the whole file — so machine state/tokens that
+      // live alongside the tracked key are never captured or committed.
+      if (trackedEntry?.jsonKey) {
+        await withSpinner(`Syncing ${change.path}...`, async () => {
+          const content = await readFile(sourcePath, 'utf8');
+          const subtree = extractSubtree(content, trackedEntry.jsonKey as string);
+          await writeFile(destPath, subtree);
+          const newChecksum = await getFileChecksum(destPath);
+          if (fileId) {
+            await updateFileInManifest(tuckDir, fileId, {
+              checksum: newChecksum,
+              modified: new Date().toISOString(),
+            });
+          }
+        });
+        result.modified.push(basename(change.path) || change.path);
+        continue;
+      }
       // Redaction plans whose live file is this change's source, or lies inside
       // it (a tracked DIRECTORY whose inner file holds the secret). Compared on
       // expanded absolute paths.
@@ -715,6 +766,45 @@ const syncFiles = async (
   return result;
 };
 
+
+/**
+ * Secret-scan the extracted SUBTREE of every modified JSON-key entry — the
+ * exact bytes sync would capture into the repo. Whole-file scanning is wrong
+ * for these files (machine tokens outside the subtree would false-positive),
+ * but skipping them entirely made --key files strictly weaker than whole-file
+ * tracking: a secret added INSIDE the subtree after `tuck add` flowed into the
+ * repo unwarned.
+ */
+const scanJsonKeySubtrees = async (
+  tuckDir: string,
+  changes: FileChange[]
+): Promise<Array<{ source: string; count: number; patterns: string[] }>> => {
+  const { scanContent } = await import('../lib/secrets/scanner.js');
+  const trackedFiles = await getAllTrackedFiles(tuckDir);
+  const findings: Array<{ source: string; count: number; patterns: string[] }> = [];
+  for (const change of changes) {
+    if (change.status !== 'modified') continue;
+    const entry = Object.values(trackedFiles).find((f) => f.source === change.source);
+    if (!entry?.jsonKey) continue;
+    const live = await resolveLiveTarget(entry);
+    if (live === null || !(await pathExists(live))) continue;
+    try {
+      const subtree = extractSubtree(await readFile(live, 'utf-8'), entry.jsonKey);
+      const matches = scanContent(subtree);
+      if (matches.length > 0) {
+        findings.push({
+          source: change.source,
+          count: matches.length,
+          patterns: [...new Set(matches.map((m) => m.patternName))],
+        });
+      }
+    } catch {
+      // Corrupt live JSON / missing key path is surfaced by the capture step.
+    }
+  }
+  return findings;
+};
+
 /**
  * Scan modified files for secrets and handle user interaction.
  *
@@ -767,7 +857,29 @@ const scanAndHandleSecrets = async (
   const spinner = prompts.spinner();
   spinner.start('Scanning for secrets...');
   const summary = await scanForSecrets(modifiedPaths, tuckDir);
+  const subtreeFindings = await scanJsonKeySubtrees(tuckDir, changes);
   spinner.stop('Scan complete');
+
+  if (subtreeFindings.length > 0) {
+    console.log();
+    console.log(c.yellow('Potential secrets inside tracked JSON subtrees:'));
+    for (const f of subtreeFindings) {
+      console.log(c.dim(`  • ${f.source} — ${f.count} finding(s): ${f.patterns.join(', ')}`));
+    }
+    console.log();
+    const choice = await prompts.select(
+      'These values WOULD be captured into the repo. Continue?',
+      [
+        { value: 'abort', label: 'Abort sync (remove or extract the secret first)' },
+        { value: 'proceed', label: 'Proceed anyway (the secret will be committed)' },
+      ]
+    );
+    if (choice !== 'proceed') {
+      prompts.cancel('Sync aborted - secrets detected in a tracked JSON subtree');
+      return { proceed: false, redactionPlans: [] };
+    }
+    await logForceSecretBypass('tuck sync (proceed past jsonKey subtree findings)', subtreeFindings.length);
+  }
 
   if (summary.totalSecrets === 0) {
     return { proceed: true, redactionPlans: [] };
@@ -1447,6 +1559,20 @@ const scanChangesForSecretsOrThrow = async (
   if (!(await isSecretScanningEnabled(tuckDir))) return;
 
   const modifiedPaths = await resolveModifiedLivePaths(tuckDir, changes);
+  const subtreeFindings = await scanJsonKeySubtrees(tuckDir, changes);
+
+  if (subtreeFindings.length > 0 && (await shouldBlockOnSecrets(tuckDir))) {
+    throw new SecretsDetectedError(
+      subtreeFindings.reduce((n, f) => n + f.count, 0),
+      subtreeFindings.map((f) => f.source)
+    );
+  }
+  if (subtreeFindings.length > 0) {
+    const msg = `${subtreeFindings.length} tracked JSON subtree(s) contain potential secrets but blockOnSecrets is disabled — proceeding`;
+    if (options.json) addJsonWarning(msg);
+    else logger.warning(msg);
+  }
+
   if (modifiedPaths.length === 0) return;
 
   const summary = await scanForSecrets(modifiedPaths, tuckDir);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -82,8 +82,23 @@ export class FileAlreadyTrackedError extends TuckError {
 }
 
 export class GitError extends TuckError {
-  constructor(message: string, gitError?: string) {
-    super(`Git operation failed: ${message}`, 'GIT_ERROR', gitError ? [gitError] : undefined);
+  /** Raw git stderr/stdout, preserved for debugging even when tailored suggestions are supplied. */
+  public readonly gitOutput?: string;
+
+  constructor(message: string, gitError?: string, suggestions?: string[]) {
+    // When callers provide contextual `suggestions` (see `describeGitError` in
+    // lib/git.ts), use them as the actionable next steps. Otherwise fall back to
+    // surfacing the raw git output as a single suggestion (legacy behavior).
+    super(`Git operation failed: ${message}`, 'GIT_ERROR', suggestions ?? (gitError ? [gitError] : undefined));
+    this.gitOutput = gitError;
+  }
+
+  override toJSON(): JsonError {
+    const json = super.toJSON();
+    if (this.gitOutput) {
+      json.git_output = this.gitOutput;
+    }
+    return json;
   }
 }
 
@@ -502,6 +517,11 @@ export const handleError = (error: unknown): never => {
       console.error();
       console.error(chalk.dim('Suggestions:'));
       error.suggestions.forEach((s) => console.error(chalk.dim(`  → ${s}`)));
+    }
+    if (error instanceof GitError && error.gitOutput && process.env.DEBUG) {
+      console.error();
+      console.error(chalk.dim('Raw git output:'));
+      console.error(chalk.dim(error.gitOutput.trim()));
     }
     process.exit(error.exitCode);
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -421,6 +421,16 @@ export class ScanLimitError extends TuckError {
   }
 }
 
+export class JsonKeyError extends TuckError {
+  constructor(message: string, suggestions?: string[]) {
+    super(message, 'JSON_KEY_ERROR', suggestions || [
+      'Pass a dot-delimited key path present in the file (e.g. --key mcpServers)',
+      'JSON-key tracking requires a strict-JSON file with a top-level object',
+      'Run `tuck list` to see how a file is tracked',
+    ]);
+  }
+}
+
 export class ValidationError extends TuckError {
   constructor(field: string, message: string) {
     super(`Invalid ${field}: ${message}`, 'VALIDATION_ERROR', ['Check your input and try again']);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -124,6 +124,31 @@ export class MergeConflictsError extends TuckError {
   }
 }
 
+export class JsonMergeConflictsError extends TuckError {
+  /** JSON paths (e.g. `permissions.allow`, `env.TOKEN`) that could not be auto-merged. */
+  public readonly paths: string[];
+  /** The file the conflicts belong to (collapsed for display). */
+  public readonly file: string;
+
+  constructor(file: string, paths: string[]) {
+    const sample = paths.slice(0, 3).join(', ');
+    const summary = paths.length > 3 ? `${sample} and ${paths.length - 3} more` : sample;
+    super(
+      `Structured merge of ${file} left ${paths.length} unresolved conflict${paths.length === 1 ? '' : 's'}: ${summary}`,
+      'JSON_MERGE_CONFLICTS',
+      [
+        'Run `tuck sync` in an interactive terminal to resolve the conflicts',
+        'Set a merge policy with `tuck merge set <file> --conflict ours|theirs`',
+        'Edit the file directly to reconcile the conflicting keys, then re-run sync',
+      ]
+    );
+    this.file = file;
+    this.paths = paths;
+    // Reuse the dedicated conflict exit code so agents branch on it uniformly.
+    this.exitCode = 3;
+  }
+}
+
 export class ConfigError extends TuckError {
   constructor(message: string) {
     super(`Configuration error: ${message}`, 'CONFIG_ERROR', [

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -501,6 +501,25 @@ export class SettingNotFoundError extends TuckError {
 }
 
 /**
+ * Raised when a read-only inspection command (status/diff/list) attempts an
+ * operation that would touch a secret backend or unlock the OS keystore. These
+ * commands guarantee zero prompts and zero backend access; hitting this error
+ * means that guarantee was about to be broken (a bug), not a user misconfig.
+ */
+export class ReadOnlyViolationError extends TuckError {
+  constructor(operation: string) {
+    super(
+      `Read-only command attempted a secret operation: ${operation}`,
+      'READ_ONLY_VIOLATION',
+      [
+        'status, diff, and list never unlock secrets — this indicates a bug',
+        'Run `tuck apply`, `tuck sync`, or `tuck verify` for operations that need secrets',
+      ]
+    );
+  }
+}
+
+/**
  * The JSON error projection for a partially- or fully-failed remote apply.
  *
  * Extends the base {@link JsonError} with the structured push outcome so a

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -390,15 +390,11 @@ export class InvalidManifestError extends TuckError {
 
 export class PathTraversalError extends TuckError {
   constructor(path: string, reason?: string) {
-    super(
-      `Unsafe path detected: ${path}${reason ? ` - ${reason}` : ''}`,
-      'PATH_TRAVERSAL_ERROR',
-      [
-        'Paths must be within your home directory',
-        'Path traversal (..) is not allowed',
-        'Use absolute paths starting with ~/ or $HOME/',
-      ]
-    );
+    super(`Unsafe path detected: ${path}${reason ? ` - ${reason}` : ''}`, 'PATH_TRAVERSAL_ERROR', [
+      'Paths must be within your home directory',
+      'Path traversal (..) is not allowed',
+      'Use absolute paths starting with ~/ or $HOME/',
+    ]);
   }
 }
 
@@ -427,9 +423,7 @@ export class ScanLimitError extends TuckError {
 
 export class ValidationError extends TuckError {
   constructor(field: string, message: string) {
-    super(`Invalid ${field}: ${message}`, 'VALIDATION_ERROR', [
-      'Check your input and try again',
-    ]);
+    super(`Invalid ${field}: ${message}`, 'VALIDATION_ERROR', ['Check your input and try again']);
   }
 }
 
@@ -464,9 +458,44 @@ export class BootstrapError extends TuckError {
 
 export class KeystoreError extends TuckError {
   constructor(keystore: string, message: string, suggestions?: string[]) {
-    super(`${keystore} error: ${message}`, 'KEYSTORE_ERROR', suggestions || [
-      'Check your system keychain/credential manager is accessible',
-      'Try running without encryption or use the fallback keystore',
+    super(
+      `${keystore} error: ${message}`,
+      'KEYSTORE_ERROR',
+      suggestions || [
+        'Check your system keychain/credential manager is accessible',
+        'Try running without encryption or use the fallback keystore',
+      ]
+    );
+  }
+}
+
+// ============================================================================
+// OS Settings Errors
+// ============================================================================
+
+export class SettingsUnsupportedOsError extends TuckError {
+  constructor(platform: string) {
+    super(
+      `\`tuck settings\` is not supported on this platform yet (${platform})`,
+      'SETTINGS_UNSUPPORTED_OS',
+      [
+        'macOS is supported today; Linux (dconf) support is planned',
+        'Existing captured settings still apply on their original OS',
+      ]
+    );
+  }
+}
+
+export class SettingsError extends TuckError {
+  constructor(message: string, suggestions?: string[]) {
+    super(message, 'SETTINGS_ERROR', suggestions);
+  }
+}
+
+export class SettingNotFoundError extends TuckError {
+  constructor(id: string) {
+    super(`No tracked setting with id "${id}"`, 'SETTING_NOT_FOUND', [
+      'Run `tuck settings list` to see tracked settings',
     ]);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { contextCommand } from './commands/context.js';
 import { mcpCommand } from './commands/mcp.js';
 import { presetCommand } from './commands/preset.js';
 import { repoCommand } from './commands/repo.js';
+import { rulesCommand } from './commands/rules.js';
 import { settingsCommand } from './commands/settings.js';
 
 const program = new Command();
@@ -94,6 +95,7 @@ program.addCommand(contextCommand);
 program.addCommand(mcpCommand);
 program.addCommand(presetCommand);
 program.addCommand(repoCommand);
+program.addCommand(rulesCommand);
 program.addCommand(settingsCommand);
 
 // Best-effort EARLY detection so the error handler can emit JSON even for

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { contextCommand } from './commands/context.js';
 import { mcpCommand } from './commands/mcp.js';
 import { presetCommand } from './commands/preset.js';
 import { repoCommand } from './commands/repo.js';
+import { settingsCommand } from './commands/settings.js';
 
 const program = new Command();
 
@@ -93,6 +94,7 @@ program.addCommand(contextCommand);
 program.addCommand(mcpCommand);
 program.addCommand(presetCommand);
 program.addCommand(repoCommand);
+program.addCommand(settingsCommand);
 
 // Best-effort EARLY detection so the error handler can emit JSON even for
 // failures that occur before any command action runs (e.g. during parsing).

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { getTuckDir, pathExists } from './lib/paths.js';
 import { loadManifest } from './lib/manifest.js';
 import { getStatus } from './lib/git.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from './lib/jsonOutput.js';
-import { setNonInteractive, configureColor } from './lib/agentMode.js';
+import { setNonInteractive, isNonInteractive, configureColor } from './lib/agentMode.js';
 import { buildCommandPath } from './lib/commandPath.js';
 import { setWriteContext } from './lib/writeContext.js';
 import { expandPath as expandTuckPath } from './lib/paths.js';
@@ -279,8 +279,11 @@ const isMcpCommand = process.argv.slice(2).includes('mcp');
 // Main execution
 const main = async (): Promise<void> => {
   // Check for updates (skipped for help/version, MCP, and JSON/agent mode — the
-  // update banner is human-only and would corrupt structured output).
-  if (!isHelpOrVersion && !isMcpCommand && !process.argv.includes('--json')) {
+  // update banner is human-only and its raw-readline prompt would block an agent
+  // and corrupt structured output). `isNonInteractive()` covers --non-interactive
+  // (set by the early argv scan above), --json, and a non-TTY stdin; the explicit
+  // --json check is kept as a defensive mirror of the early detection.
+  if (!isHelpOrVersion && !isMcpCommand && !process.argv.includes('--json') && !isNonInteractive()) {
     await checkForUpdates();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   encryptionCommand,
   doctorCommand,
   bundleCommand,
+  mergeCommand,
   profileCommand,
   verifyCommand,
   bootstrapCommand,
@@ -85,6 +86,7 @@ program.addCommand(secretsCommand);
 program.addCommand(encryptionCommand);
 program.addCommand(doctorCommand);
 program.addCommand(bundleCommand);
+program.addCommand(mergeCommand);
 program.addCommand(profileCommand);
 program.addCommand(verifyCommand);
 program.addCommand(contextCommand);

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { getTuckDir, pathExists } from './lib/paths.js';
 import { loadManifest } from './lib/manifest.js';
 import { getStatus } from './lib/git.js';
 import { setJsonMode, isJsonMode, emitJsonOk } from './lib/jsonOutput.js';
+import { setNonInteractive, configureColor } from './lib/agentMode.js';
 import { buildCommandPath } from './lib/commandPath.js';
 import { setWriteContext } from './lib/writeContext.js';
 import { expandPath as expandTuckPath } from './lib/paths.js';
@@ -51,6 +52,11 @@ program
     '--root <dir>',
     'Confine ALL writes under this directory (sandbox / dry-home mode). ' +
       'Also settable via TUCK_TARGET_ROOT. Use to run tuck without touching your real ~.'
+  )
+  .option(
+    '--non-interactive',
+    'Never prompt; fail fast with a typed error if a prompt would be required. ' +
+      'Implied by --json and by a non-TTY stdin. Pair with --yes to auto-confirm.'
   )
   .configureOutput({
     outputError: (str, write) => write(chalk.red(str)),
@@ -96,12 +102,28 @@ program.addCommand(repoCommand);
 if (process.argv.slice(2).includes('--json')) {
   setJsonMode(true);
 }
+// The `--non-interactive` global is a bare flag (no value), so a plain argv scan
+// is unambiguous — mirroring the early `--json` detection above. This ensures the
+// prompt gate and color suppression are honored even for failures that occur
+// before any command action runs (e.g. during parsing).
+if (process.argv.slice(2).includes('--non-interactive')) {
+  setNonInteractive(true);
+}
+// Suppress ANSI for machine consumers / non-TTY stdout as early as possible so
+// even pre-action diagnostics come out clean. Re-run authoritatively in preAction.
+configureColor();
 
 // Authoritative resolution of JSON mode AND the write sandbox: runs after
-// parsing, before the action. Global --root lives on the root program.
+// parsing, before the action. Global --root / --non-interactive live on the root program.
 program.hook('preAction', (_thisCommand, actionCommand) => {
   const opts = actionCommand.opts() as { json?: boolean };
   setJsonMode(opts.json === true, buildCommandPath(actionCommand as { name(): string }));
+
+  const globalOpts = program.opts() as { nonInteractive?: boolean };
+  if (globalOpts.nonInteractive === true) setNonInteractive(true);
+  // Options are now authoritative (JSON mode may have been set by opts above),
+  // so recompute color suppression.
+  configureColor();
 
   const rootOpt = (program.opts() as { root?: string }).root ?? process.env.TUCK_TARGET_ROOT;
   if (rootOpt && rootOpt.trim()) {

--- a/src/lib/agentMode.ts
+++ b/src/lib/agentMode.ts
@@ -1,0 +1,75 @@
+/**
+ * Agent / non-interactive mode control.
+ *
+ * tuck is `@clack/prompts`-heavy, which is a hazard for agents and CI: a command
+ * that hits a prompt with no human present would block forever (or read EOF and
+ * silently "succeed"). This module centralizes the two orthogonal signals an
+ * agent-native CLI needs:
+ *
+ *   1. Non-interactive mode — the CLI must NEVER prompt. Any code that would
+ *      prompt must instead fail fast with a typed error. This is true when the
+ *      caller passes `--non-interactive`, when `--json` is set (a prompt would
+ *      corrupt the single-object stdout contract), or when stdin is not a TTY
+ *      (no human to answer).
+ *
+ *   2. Color / ANSI suppression — machine consumers want clean, ANSI-free text.
+ *      We force `chalk.level = 0` for JSON mode, non-interactive mode, an
+ *      explicit `NO_COLOR`, or a non-TTY stdout, while still honoring an explicit
+ *      `FORCE_COLOR` from the operator.
+ *
+ * `--yes` is deliberately NOT part of non-interactive detection: it means
+ * "auto-confirm prompts" (answer yes) rather than "never prompt". Commands read
+ * their own `--yes` flag to skip a specific confirmation.
+ */
+
+import chalk from 'chalk';
+import { isJsonMode } from './jsonOutput.js';
+
+// Set from the parsed `--non-interactive` global option (see src/index.ts). We
+// keep this as module state — mirroring jsonOutput — because the prompts layer
+// needs to read it without threading options through every call site.
+let nonInteractiveFlag = false;
+
+/** Set by the CLI entrypoint once the global `--non-interactive` flag is parsed. */
+export const setNonInteractive = (enabled: boolean): void => {
+  nonInteractiveFlag = enabled;
+};
+
+/** True only when the explicit `--non-interactive` flag was passed. */
+export const isNonInteractiveFlagSet = (): boolean => nonInteractiveFlag;
+
+/**
+ * True when the CLI must never present an interactive prompt: an explicit
+ * `--non-interactive`, JSON mode (prompting would corrupt the envelope), or a
+ * non-TTY stdin (no human to answer). Callers that would prompt should throw a
+ * typed error instead when this returns true.
+ */
+export const isNonInteractive = (): boolean =>
+  nonInteractiveFlag || isJsonMode() || !process.stdin.isTTY;
+
+/**
+ * Configure ANSI color output for the current run. Idempotent; safe to call
+ * multiple times (e.g. once from the early argv scan and again from preAction
+ * once options are authoritatively parsed).
+ *
+ * Precedence:
+ *   1. An explicit truthy `FORCE_COLOR` always wins (operator opted in).
+ *   2. Otherwise color is suppressed for JSON mode, `--non-interactive`,
+ *      `NO_COLOR`, or a non-TTY stdout.
+ */
+export const configureColor = (): void => {
+  const forceColor = process.env.FORCE_COLOR;
+  const forceColorEnabled =
+    forceColor !== undefined && forceColor !== '' && forceColor !== '0' && forceColor !== 'false';
+  if (forceColorEnabled) return;
+
+  const suppress =
+    isJsonMode() ||
+    nonInteractiveFlag ||
+    (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') ||
+    !process.stdout.isTTY;
+
+  if (suppress) {
+    chalk.level = 0;
+  }
+};

--- a/src/lib/applyDiff.ts
+++ b/src/lib/applyDiff.ts
@@ -1,0 +1,62 @@
+/**
+ * Diff-summary helpers for `tuck apply`.
+ *
+ * "Safe first apply" (IDEAS 2.4) requires that apply ALWAYS shows a full diff
+ * summary before it touches anything, so a user on a fresh machine can see
+ * exactly which live files are about to be created vs overwritten — and pair it
+ * with the auto-snapshot for a trustworthy, reversible first run.
+ *
+ * These functions are intentionally pure (no filesystem, no UI) so the summary
+ * logic is unit-testable; the command layer resolves file existence and renders
+ * the returned data.
+ */
+
+/** Whether a live destination will be newly created or overwritten in place. */
+export type ApplyDiffStatus = 'new' | 'modify';
+
+export interface ApplyDiffItem {
+  /** Collapsed (display) live destination path. */
+  destination: string;
+  /** Detection category (shell, git, editors, ...). */
+  category: string;
+  status: ApplyDiffStatus;
+}
+
+export interface ApplyDiffSummary {
+  items: ApplyDiffItem[];
+  /** Count of destinations that do not yet exist on this machine. */
+  newCount: number;
+  /** Count of destinations that already exist and will be overwritten/merged. */
+  modifyCount: number;
+  /** Total number of files that will be applied. */
+  total: number;
+}
+
+/**
+ * Fold a list of diff items into a counted summary. Pure — callers pass items
+ * already annotated with their new/modify status (resolved from the live FS).
+ */
+export const summarizeApplyDiff = (items: ApplyDiffItem[]): ApplyDiffSummary => {
+  let newCount = 0;
+  let modifyCount = 0;
+  for (const item of items) {
+    if (item.status === 'new') newCount += 1;
+    else modifyCount += 1;
+  }
+  return { items, newCount, modifyCount, total: items.length };
+};
+
+/**
+ * One-line human summary of an apply diff, e.g. "3 new, 2 to update".
+ * Returns "No changes" for an empty diff.
+ */
+export const formatApplyDiffLine = (summary: ApplyDiffSummary): string => {
+  const parts: string[] = [];
+  if (summary.newCount > 0) {
+    parts.push(`${summary.newCount} new`);
+  }
+  if (summary.modifyCount > 0) {
+    parts.push(`${summary.modifyCount} to update`);
+  }
+  return parts.length > 0 ? parts.join(', ') : 'No changes';
+};

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -32,6 +32,8 @@ export type AuditAction =
   | 'FORCE_PUSH' // --force used for git push
   | 'FORCE_OVERWRITE' // --force used to overwrite files
   | 'SECRETS_COMMITTED' // User chose to commit files with detected secrets
+  | 'SECRET_ALLOWLISTED' // User added a scanner finding to the secret allowlist
+  | 'SECRET_ALLOWLIST_REMOVED' // User removed an entry from the secret allowlist
   | 'DANGEROUS_CONFIRMED'; // User confirmed a dangerous operation
 
 // ============================================================================
@@ -115,6 +117,41 @@ export async function logSecretsCommitted(files: string[]): Promise<void> {
  */
 export async function logDangerousConfirmed(operation: string, details?: string): Promise<void> {
   await logAuditEntry('DANGEROUS_CONFIRMED', operation, details);
+}
+
+/**
+ * Log when a scanner finding is added to the secret allowlist.
+ *
+ * SECURITY: only the (non-reversible) fingerprint and reason are recorded — the
+ * raw secret value never touches the audit log.
+ */
+export async function logSecretAllowlisted(
+  fingerprint: string,
+  reason: string,
+  scope?: { pattern?: string; path?: string }
+): Promise<void> {
+  const scopeParts = [
+    scope?.pattern ? `pattern=${scope.pattern}` : undefined,
+    scope?.path ? `path=${scope.path}` : undefined,
+  ].filter(Boolean);
+  const scopeText = scopeParts.length > 0 ? ` (${scopeParts.join(', ')})` : '';
+  await logAuditEntry(
+    'SECRET_ALLOWLISTED',
+    'tuck secrets allow',
+    `Allowlisted ${fingerprint.slice(0, 12)}…${scopeText}: ${reason}`
+  );
+}
+
+/**
+ * Log when an entry is removed from the secret allowlist.
+ */
+export async function logSecretAllowlistRemoved(fingerprints: string[]): Promise<void> {
+  const summary = fingerprints.map((fp) => fp.slice(0, 12)).join(', ');
+  await logAuditEntry(
+    'SECRET_ALLOWLIST_REMOVED',
+    'tuck secrets allow remove',
+    `Removed ${fingerprints.length} allowlist entr${fingerprints.length === 1 ? 'y' : 'ies'}: ${summary}`
+  );
 }
 
 // ============================================================================

--- a/src/lib/crypto/driftCache.ts
+++ b/src/lib/crypto/driftCache.ts
@@ -1,0 +1,250 @@
+/**
+ * Machine-local keyed-HMAC drift cache — how read-only commands detect drift in
+ * encrypted files WITHOUT decrypting anything.
+ *
+ * The problem: an encrypted tracked file holds CIPHERTEXT in the repo and
+ * PLAINTEXT on the live system. To tell whether the user edited the live copy,
+ * the naive approach decrypts the repo copy and compares — which unlocks the
+ * keystore and can pop a prompt on every `tuck status`.
+ *
+ * The fix: whenever a NON-read-only command already holds the plaintext (verify,
+ * apply, restore, sync), it records a keyed HMAC of that plaintext here, pinned
+ * to the repo copy's checksum. Then a read-only command computes the HMAC of the
+ * CURRENT live bytes and compares — no decryption, no keystore, no prompt.
+ *
+ *   live HMAC == cached HMAC  → live matches last-known-good → no local drift
+ *   live HMAC != cached HMAC  → user edited the live file    → drift-local
+ *   no fresh cache entry      → unknown (read-only degrades to "ok"; a full
+ *                               command such as `tuck verify` warms the cache)
+ *
+ * Why keyed (HMAC) rather than a plain checksum: a bare SHA-256 of a secret's
+ * plaintext would let anyone who reads the cache confirm a guessed secret value
+ * offline. Keying with a machine-local random key defeats that — the cache is
+ * useless without the key, and the key never leaves this machine and is never
+ * committed to the repo.
+ *
+ * Both the key and the cache live in tuck's per-machine state directory, NOT in
+ * the repo, because a fingerprint keyed by machine A's key is meaningless on
+ * machine B. Nothing here is ever pushed to git.
+ */
+
+import { createHmac, randomBytes } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { getStateDir } from '../state.js';
+import { pathExists } from '../paths.js';
+import { driftCacheSchema, type DriftCache, type DriftEntry } from '../../schemas/driftCache.schema.js';
+
+/** Result of comparing a live file against its cached fingerprint. */
+export type DriftComparison =
+  /** Live bytes match the last-known-good plaintext — no local drift. */
+  | 'match'
+  /** Live bytes differ from the last-known-good plaintext — local drift. */
+  | 'mismatch'
+  /** No usable fingerprint (no key, no entry, or the repo copy moved on). */
+  | 'unknown';
+
+const getDriftKeyPath = (): string => join(getStateDir(), 'drift.key');
+const getDriftCachePath = (): string => join(getStateDir(), 'drift-cache.json');
+
+/**
+ * In-process cache of the machine-local HMAC key so we read the key file at most
+ * once per run. `undefined` = not yet loaded; `null` = loaded and absent.
+ */
+let keyCache: Buffer | null | undefined;
+
+const writeFileSecure = async (filePath: string, data: Buffer | string): Promise<void> => {
+  await mkdir(dirname(filePath), { recursive: true });
+  // 0600: the drift key and cache are per-machine secrets-adjacent state.
+  await writeFile(filePath, data, { mode: 0o600 });
+};
+
+/**
+ * Load the machine-local HMAC key.
+ *
+ * @param create When true, generate and persist a fresh 32-byte key if none
+ *   exists. Read-only callers pass `false` so an inspection command never writes
+ *   to disk; write callers (recordDriftEntry) pass `true`.
+ * @returns The key, or null when absent and `create` is false.
+ */
+export const getDriftKey = async (create = false): Promise<Buffer | null> => {
+  if (keyCache !== undefined) {
+    if (keyCache !== null) return keyCache;
+    if (!create) return null;
+    // keyCache === null but caller wants to create — fall through to generate.
+  }
+
+  const keyPath = getDriftKeyPath();
+  if (await pathExists(keyPath)) {
+    try {
+      const raw = (await readFile(keyPath, 'utf-8')).trim();
+      const buf = Buffer.from(raw, 'base64');
+      if (buf.length >= 32) {
+        keyCache = buf;
+        return buf;
+      }
+    } catch {
+      // Unreadable/corrupt key — regenerate below if allowed.
+    }
+  }
+
+  if (!create) {
+    keyCache = null;
+    return null;
+  }
+
+  // Single-flight: concurrent first-warm callers (computeStateModel records
+  // entries via Promise.all) must all receive the SAME key — two generated
+  // keys would leave some entries HMAC'd under a lost key, which later compare
+  // as 'mismatch' and emit the false drift signal this module promises never
+  // to produce.
+  if (!keyCreationInFlight) {
+    keyCreationInFlight = (async (): Promise<Buffer | null> => {
+      const freshKey = randomBytes(32);
+      try {
+        await mkdir(dirname(keyPath), { recursive: true });
+        // 'wx' (O_EXCL): lose the cross-process race gracefully — whoever
+        // creates the file wins, everyone else re-reads it.
+        await writeFile(keyPath, freshKey.toString('base64'), { mode: 0o600, flag: 'wx' });
+        // A brand-new key invalidates every existing entry (they were HMAC'd
+        // under a key that no longer exists — e.g. the corrupt-key path).
+        await clearDriftEntries();
+        keyCache = freshKey;
+        return freshKey;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          try {
+            const raw = (await readFile(keyPath, 'utf-8')).trim();
+            const buf = Buffer.from(raw, 'base64');
+            if (buf.length >= 32) {
+              keyCache = buf;
+              return buf;
+            }
+          } catch {
+            // fall through
+          }
+        }
+        keyCache = null;
+        return null;
+      } finally {
+        keyCreationInFlight = null;
+      }
+    })();
+  }
+  return keyCreationInFlight;
+};
+
+/** In-flight key generation, shared by concurrent callers (single-flight). */
+let keyCreationInFlight: Promise<Buffer | null> | null = null;
+
+/** Drop every cache entry (the key changed; old HMACs are meaningless). */
+const clearDriftEntries = async (): Promise<void> => {
+  try {
+    await writeFileSecure(getDriftCachePath(), JSON.stringify(emptyCache(), null, 2));
+  } catch {
+    // Best-effort.
+  }
+};
+
+/**
+ * Serialize read-modify-write cycles on the cache file: concurrent
+ * recordDriftEntry calls would otherwise lose each other's entries.
+ */
+let cacheWriteQueue: Promise<void> = Promise.resolve();
+
+/** Keyed HMAC-SHA256 (hex) of `plaintext` under the given key. */
+export const computePlaintextHmac = (plaintext: Buffer | string, key: Buffer): string =>
+  createHmac('sha256', key).update(plaintext).digest('hex');
+
+const emptyCache = (): DriftCache => ({ version: 1, entries: {} });
+
+/** Read and validate the drift cache. Returns an empty cache on missing/corrupt. */
+export const readDriftCache = async (): Promise<DriftCache> => {
+  const cachePath = getDriftCachePath();
+  if (!(await pathExists(cachePath))) return emptyCache();
+  try {
+    const parsed: unknown = JSON.parse(await readFile(cachePath, 'utf-8'));
+    const result = driftCacheSchema.safeParse(parsed);
+    return result.success ? result.data : emptyCache();
+  } catch {
+    return emptyCache();
+  }
+};
+
+/** Look up a single file's fingerprint, or null if none is recorded. */
+export const getDriftEntry = async (fileId: string): Promise<DriftEntry | null> => {
+  const cache = await readDriftCache();
+  return cache.entries[fileId] ?? null;
+};
+
+/**
+ * Record (or refresh) a file's last-known-good plaintext fingerprint.
+ *
+ * Called by NON-read-only commands that already hold the plaintext. Generates
+ * the machine-local key on first use. Never throws to the caller — a drift-cache
+ * write failure must not break apply/verify (it only means the next read-only
+ * status degrades to "unknown" for this file).
+ *
+ * @param fileId Manifest file id.
+ * @param plaintext The plaintext that belongs on the live system.
+ * @param repoChecksum Checksum of the repo copy this plaintext was derived from.
+ */
+export const recordDriftEntry = async (
+  fileId: string,
+  plaintext: Buffer | string,
+  repoChecksum: string
+): Promise<void> => {
+  try {
+    const key = await getDriftKey(true);
+    if (!key) return;
+    const hmac = computePlaintextHmac(plaintext, key);
+    // Queue the read-modify-write so concurrent recorders (Promise.all in
+    // computeStateModel) never clobber each other's entries.
+    const task = cacheWriteQueue.then(async () => {
+      const cache = await readDriftCache();
+      cache.entries[fileId] = {
+        plaintextHmac: hmac,
+        repoChecksum,
+        updated: new Date().toISOString(),
+      };
+      await writeFileSecure(getDriftCachePath(), JSON.stringify(cache, null, 2));
+    });
+    cacheWriteQueue = task.catch(() => undefined);
+    await task;
+  } catch {
+    // Best-effort cache; never surface to the caller.
+  }
+};
+
+/**
+ * Compare live bytes against the cached fingerprint WITHOUT any decryption.
+ *
+ * Returns `'unknown'` (never a false drift signal) when there is no key, no
+ * entry, or the entry was derived from a different repo copy than the one now on
+ * disk. Read-only commands treat `'unknown'` as "no reportable drift".
+ *
+ * @param fileId Manifest file id.
+ * @param liveBytes Current bytes of the live file.
+ * @param repoChecksum Checksum of the current repo copy.
+ */
+export const compareLiveToCache = async (
+  fileId: string,
+  liveBytes: Buffer | string,
+  repoChecksum: string
+): Promise<DriftComparison> => {
+  const key = await getDriftKey(false);
+  if (!key) return 'unknown';
+
+  const entry = await getDriftEntry(fileId);
+  if (!entry) return 'unknown';
+  // Pinned to a stale repo copy (e.g. after `git pull`): can't trust it.
+  if (entry.repoChecksum !== repoChecksum) return 'unknown';
+
+  return computePlaintextHmac(liveBytes, key) === entry.plaintextHmac ? 'match' : 'mismatch';
+};
+
+/** Reset the in-process key cache. For tests. */
+export const resetDriftKeyCache = (): void => {
+  keyCache = undefined;
+  keyCreationInFlight = null;
+};

--- a/src/lib/crypto/sessionKeyCache.ts
+++ b/src/lib/crypto/sessionKeyCache.ts
@@ -1,0 +1,96 @@
+/**
+ * Session cache for the unlocked file-encryption passphrase.
+ *
+ * tuck encrypts tracked files at rest with a single per-machine passphrase held
+ * in the OS keystore (macOS Keychain / libsecret / Windows fallback). Retrieving
+ * it can pop an interactive unlock prompt. Commands like `tuck apply` decrypt
+ * MANY files in one run — without caching, that is one keystore round-trip (and
+ * potentially one prompt) PER FILE.
+ *
+ * This module unlocks the keystore AT MOST ONCE per process and memoizes the
+ * result with a TTL, so a whole apply/restore run costs a single prompt. It is
+ * also the enforcement point for the read-only guarantee: when a read-only
+ * command (status/diff/list) is running, this cache NEVER reaches out to the
+ * keystore — it returns a value already cached in this process or `null`, so no
+ * prompt can appear.
+ *
+ * "Unlocked key" here means the passphrase string in process memory; it is never
+ * written to disk. The cache lives only for the lifetime of the process (plus
+ * the TTL, which matters for long-lived hosts such as the MCP server).
+ */
+
+import { isReadOnlyMode } from '../readOnlyMode.js';
+
+/** Default session TTL: 15 minutes. */
+export const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
+
+interface CachedPassphrase {
+  /** The passphrase, or null if the keystore held nothing (a real "no key" answer). */
+  value: string | null;
+  /** Epoch ms after which this entry is considered stale. */
+  expiresAt: number;
+}
+
+let cached: CachedPassphrase | null = null;
+let ttlMs = DEFAULT_SESSION_TTL_MS;
+
+/** How the caller should fetch the passphrase on a cache miss. */
+export type PassphraseFetcher = () => Promise<string | null>;
+
+const isFresh = (entry: CachedPassphrase | null): entry is CachedPassphrase =>
+  entry !== null && Date.now() < entry.expiresAt;
+
+/**
+ * Return the keystore passphrase, unlocking the keystore at most once per
+ * session.
+ *
+ *   - If a fresh value is cached, it is returned WITHOUT calling `fetch` — so no
+ *     keystore access and no prompt.
+ *   - In read-only mode, the keystore is NEVER touched: a fresh cached value is
+ *     returned if present, otherwise `null`. `fetch` is not invoked.
+ *   - Otherwise `fetch` runs exactly once, and its result (including `null`) is
+ *     cached for the TTL so repeated calls in the same run reuse it.
+ *
+ * @param fetch Retrieves the passphrase from the keystore. Called at most once
+ *   per TTL window, and never in read-only mode.
+ */
+export const getCachedKeystorePassphrase = async (
+  fetch: PassphraseFetcher
+): Promise<string | null> => {
+  if (isFresh(cached)) {
+    return cached.value;
+  }
+
+  // Read-only commands must never trigger a keystore unlock. With no fresh
+  // cache entry there is nothing to return but null — and crucially we do NOT
+  // call `fetch`, so no prompt can appear.
+  if (isReadOnlyMode()) {
+    return null;
+  }
+
+  const value = await fetch();
+  cached = { value, expiresAt: Date.now() + ttlMs };
+  return value;
+};
+
+/**
+ * Seed the cache directly (tests, or a command that already unlocked the key by
+ * other means). Marks the value fresh for the current TTL.
+ */
+export const primeSessionKeyCache = (value: string | null): void => {
+  cached = { value, expiresAt: Date.now() + ttlMs };
+};
+
+/** Whether a fresh passphrase is currently cached in this process. */
+export const hasSessionKey = (): boolean => isFresh(cached);
+
+/** Override the session TTL (milliseconds). Affects entries cached afterwards. */
+export const setSessionKeyTtl = (ms: number): void => {
+  ttlMs = ms;
+};
+
+/** Clear the cached passphrase and restore the default TTL. For tests / logout. */
+export const clearSessionKeyCache = (): void => {
+  cached = null;
+  ttlMs = DEFAULT_SESSION_TTL_MS;
+};

--- a/src/lib/fileTracking.ts
+++ b/src/lib/fileTracking.ts
@@ -33,6 +33,7 @@ import { encryptFileContent } from './crypto/fileEncryption.js';
 import { keystorePassphrase } from './materialize.js';
 import { EncryptionError } from '../errors.js';
 import { isJsonMode } from './jsonOutput.js';
+import { extractSubtree } from './jsonKey.js';
 
 export interface FileToTrack {
   path: string;
@@ -71,6 +72,12 @@ export interface FileToTrack {
   source?: string;
   /** Relative manifest destination to store verbatim (repo scope only). */
   destination?: string;
+  /**
+   * Dot-delimited JSON key path when tracking only a subtree of a JSON file
+   * (e.g. `mcpServers`). The repo copy holds the extracted subtree — NOT the
+   * whole file — and apply/restore deep-merge it back into the live file.
+   */
+  jsonKey?: string;
   /**
    * Declarative dependencies to record on this entry (IDEAS 2.3): validated
    * `<manager>:<package>` specs installed before this file is applied. Omitted
@@ -200,6 +207,18 @@ export const trackFilesWithProgress = async (
       'The symlink strategy cannot be combined with --encrypt/--template: these files are copied (and decrypted/rendered on apply), not linked.'
     );
   }
+
+  // JSON-key files store only an extracted subtree in the repo and are
+  // deep-merged back on apply/restore — they can never be symlinked (a symlink
+  // would expose the subtree AS the whole live file) or encrypted (the repo copy
+  // must stay plain JSON for merging). Reject the combinations up front.
+  const hasJsonKey = files.some((f) => f.jsonKey);
+  if (hasJsonKey && strategy === 'symlink') {
+    throw new Error('The symlink strategy cannot be combined with --key: JSON-subtree files are copied and deep-merged, not linked.');
+  }
+  if (hasJsonKey && encrypt) {
+    throw new Error('--encrypt cannot be combined with --key: the repo copy of a JSON subtree must stay plain JSON.');
+  }
   const total = files.length;
   const errors: Array<{ path: string; error: Error }> = [];
   const sensitiveFiles: string[] = [];
@@ -320,6 +339,12 @@ export const trackFilesWithProgress = async (
           // caller records it and the user is never told this silently "worked".
           throw symlinkError;
         }
+      } else if (file.jsonKey) {
+        // JSON-key: store ONLY the extracted subtree in the repo (never the whole
+        // file). extractSubtree canonicalizes (sorted keys) so the repo copy —
+        // and its checksum — is stable regardless of the live file's ordering.
+        const content = await readFile(expandedPath, 'utf8');
+        await writeFile(destination, extractSubtree(content, file.jsonKey));
       } else if (encrypt) {
         // Encrypt at rest: store TCKE1 ciphertext in the repo (decrypted on apply).
         const passphrase = await keystorePassphrase();
@@ -405,8 +430,13 @@ export const trackFilesWithProgress = async (
         added: now,
         modified: now,
         checksum,
-        ...statCache,
+        // The recorded checksum for a JSON-key file is of the extracted SUBTREE,
+        // not the whole live file, so the live-file mtime+size short-circuit must
+        // NOT be recorded (it would let a stale whole-file stat mask real subtree
+        // drift). Whole-file entries keep the git/make short-circuit cache.
+        ...(file.jsonKey ? {} : statCache),
         bundle: file.bundle ?? 'default',
+        ...(file.jsonKey ? { jsonKey: file.jsonKey } : {}),
         tags: file.tags && file.tags.length > 0 ? [...file.tags].sort() : [],
         // Only serialize `requires` when non-empty so entries without declared
         // dependencies stay byte-identical to legacy manifests.

--- a/src/lib/fileTracking.ts
+++ b/src/lib/fileTracking.ts
@@ -75,7 +75,8 @@ export interface FileToTrack {
   /**
    * Dot-delimited JSON key path when tracking only a subtree of a JSON file
    * (e.g. `mcpServers`). The repo copy holds the extracted subtree — NOT the
-   * whole file — and apply/restore deep-merge it back into the live file.
+   * whole file — and apply/restore write it back into the live file by REPLACING
+   * the value at that path, leaving every other key untouched.
    */
   jsonKey?: string;
   /**
@@ -218,6 +219,12 @@ export const trackFilesWithProgress = async (
   }
   if (hasJsonKey && encrypt) {
     throw new Error('--encrypt cannot be combined with --key: the repo copy of a JSON subtree must stay plain JSON.');
+  }
+  if (hasJsonKey && template) {
+    // Guarded up front (not just at manifest-save time): the subtree is written
+    // to the repo at :347 before addFileToManifest's zod validation rejects the
+    // template+jsonKey combo, which would otherwise leave an orphan repo file.
+    throw new Error('--template cannot be combined with --key: the repo copy of a JSON subtree must stay plain JSON, not an un-rendered template.');
   }
   const total = files.length;
   const errors: Array<{ path: string; error: Error }> = [];

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -522,8 +522,14 @@ export const createSymlink = async (
   // Ensure link parent directory exists
   await ensureDir(dirname(expandedLink));
 
-  // Remove existing file/symlink if overwrite is true
-  if (options?.overwrite && (await pathExists(expandedLink))) {
+  // Remove existing file/symlink if overwrite is true. Existence must be
+  // link-aware (lstat): pathExists FOLLOWS links, so a dangling symlink at the
+  // link path read as missing and the symlink() call crashed with EEXIST.
+  const linkEntryExists = await lstat(expandedLink).then(
+    () => true,
+    () => false
+  );
+  if (options?.overwrite && linkEntryExists) {
     try {
       const linkStats = await lstat(expandedLink);
       if (linkStats.isDirectory()) {

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -7,6 +7,8 @@ import { join } from 'path';
 import { readdir } from 'fs/promises';
 import { REPO_STAGE_BLOCKLIST } from './state.js';
 import { GIT_OPERATION_TIMEOUTS } from './validation.js';
+import { isNonInteractive } from './agentMode.js';
+import { isJsonMode } from './jsonOutput.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -37,12 +39,47 @@ export interface GitCommit {
   author: string;
 }
 
+/**
+ * When tuck is driven non-interactively (an agent, CI, JSON mode, or a piped
+ * stdin) a child git process must NEVER be allowed to open its own credential
+ * or SSH prompt on /dev/tty — that bypasses every clack gate and blocks the
+ * caller forever. This returns an env that hard-disables those prompts, or
+ * `undefined` in interactive mode so a human's normal credential flow is left
+ * untouched. Computed at call time because the mode can flip in a preAction
+ * hook after module load.
+ */
+const buildNonInteractiveGitEnv = (): NodeJS.ProcessEnv | undefined => {
+  if (!isNonInteractive() && !isJsonMode()) return undefined;
+  // Append -oBatchMode=yes to any operator-supplied GIT_SSH_COMMAND rather than
+  // clobbering it, so custom ssh options / identity files are preserved.
+  const existingSsh = process.env.GIT_SSH_COMMAND?.trim();
+  const sshCommand = existingSsh ? `${existingSsh} -oBatchMode=yes` : 'ssh -oBatchMode=yes';
+  return {
+    ...process.env,
+    // Refuse to prompt on the terminal for username/password.
+    GIT_TERMINAL_PROMPT: '0',
+    // A no-op askpass helper: git invokes it instead of prompting, and `echo`
+    // returns an empty credential so the operation fails fast instead of hanging.
+    GIT_ASKPASS: 'echo',
+    // Disable interactive SSH auth (host-key / passphrase prompts) for git-over-ssh.
+    GIT_SSH_COMMAND: sshCommand,
+  };
+};
+
 const createGit = (dir: string): SimpleGit => {
-  return simpleGit(dir, {
+  const git = simpleGit(dir, {
     binary: 'git',
     maxConcurrentProcesses: 6,
     trimmed: true,
   });
+  const env = buildNonInteractiveGitEnv();
+  // `.env()` is always present on a real simple-git instance; the typeof guard
+  // keeps partial test doubles (which stub only the methods they exercise) from
+  // throwing here.
+  if (env && typeof git.env === 'function') {
+    git.env(env);
+  }
+  return git;
 };
 
 export const isGitRepo = async (dir: string): Promise<boolean> => {
@@ -69,12 +106,21 @@ export const cloneRepo = async (url: string, dir: string): Promise<void> => {
     // does NOT forward `maxBuffer` to the underlying child process — only its
     // `timeout.block` is honored, so the memory bound would silently be a no-op.
     // `execFile`'s own `timeout` kills the process and `maxBuffer` caps output.
+    const env = buildNonInteractiveGitEnv();
     await execFileAsync('git', ['clone', url, dir], {
       timeout: GIT_OPERATION_TIMEOUTS.CLONE,
       maxBuffer: CLONE_MAX_BUFFER,
+      // In non-interactive mode a clone against a private remote must fail fast
+      // rather than block on a credential/SSH prompt on /dev/tty.
+      ...(env ? { env } : {}),
     });
   } catch (error) {
-    throw new GitError(`Failed to clone repository from ${url}`, String(error));
+    // A remote URL can embed a token (https://user:token@host); scrub both the
+    // URL we echo and the raw error before they reach GitError.gitOutput.
+    throw new GitError(
+      `Failed to clone repository from ${scrubCredentials(url)}`,
+      scrubCredentials(String(error))
+    );
   }
 };
 
@@ -247,6 +293,30 @@ const ensureGitCredentials = async (): Promise<void> => {
 };
 
 /**
+ * Redact credentials from raw git output before it is stored on a
+ * {@link GitError} (and thereby serialized into the JSON envelope as
+ * `git_output`, echoed under DEBUG=1, or copied into a suggestion/hint line).
+ *
+ * A remote URL of the form `https://user:ghp_xxx@github.com/...` — or a bare
+ * token git happens to echo — would otherwise leak a live credential into
+ * machine-parsed output. This is the single choke point: every raw-output sink
+ * routes through {@link describeGitError}, which scrubs here first.
+ *
+ * Exported for unit testing.
+ */
+export const scrubCredentials = (text: string): string => {
+  return text
+    // userinfo in URLs: https://user:token@host / https://token@host → https://***@host
+    .replace(/(https?:\/\/)[^/@\s]+@/g, '$1***@')
+    // GitHub classic personal access tokens.
+    .replace(/ghp_[A-Za-z0-9]+/g, 'ghp_***')
+    // GitHub fine-grained personal access tokens.
+    .replace(/github_pat_[A-Za-z0-9_]+/g, 'github_pat_***')
+    // GitLab personal access tokens.
+    .replace(/glpat-[A-Za-z0-9-]+/g, 'glpat-***');
+};
+
+/**
  * First meaningful line of raw git output, as a suggestion entry. Only the
  * generic fallback branches use this: when classification failed, the raw
  * evidence is the most actionable thing we can show (the full output is on
@@ -272,8 +342,12 @@ const rawFirstLine = (raw: string): string[] => {
  */
 export const describeGitError = (
   operation: 'push' | 'pull' | 'fetch',
-  raw: string
+  rawInput: string
 ): GitError => {
+  // Scrub once, up front: `raw` feeds the classified message, every suggestion
+  // (via rawFirstLine), and `GitError.gitOutput`, so redacting here guarantees
+  // no credential reaches any downstream sink.
+  const raw = scrubCredentials(rawInput);
   const text = raw.toLowerCase();
   const has = (...needles: string[]): boolean => needles.some((n) => text.includes(n));
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -246,6 +246,126 @@ const ensureGitCredentials = async (): Promise<void> => {
   }
 };
 
+/**
+ * First meaningful line of raw git output, as a suggestion entry. Only the
+ * generic fallback branches use this: when classification failed, the raw
+ * evidence is the most actionable thing we can show (the full output is on
+ * `GitError.gitOutput`, serialized as `git_output` in JSON mode and printed
+ * under DEBUG=1).
+ */
+const rawFirstLine = (raw: string): string[] => {
+  const line = raw
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  return line ? [`git said: ${line.slice(0, 200)}`] : [];
+};
+
+/**
+ * Turn a raw git failure into a {@link GitError} with context and actionable
+ * suggestions (issue #52). Git's stderr is terse and inconsistent; agents and
+ * humans both benefit from tuck naming the likely cause and the fix. Falls back
+ * to a generic message (with the raw output as the suggestion) when nothing
+ * recognizable matches, so behavior never regresses.
+ *
+ * Exported for unit testing of the classification logic.
+ */
+export const describeGitError = (
+  operation: 'push' | 'pull' | 'fetch',
+  raw: string
+): GitError => {
+  const text = raw.toLowerCase();
+  const has = (...needles: string[]): boolean => needles.some((n) => text.includes(n));
+
+  // Authentication / permission problems affect every network operation.
+  if (
+    has(
+      'authentication failed',
+      'could not read username',
+      'could not read password',
+      'permission denied (publickey)',
+      'invalid username or password',
+      'terminal prompts disabled',
+      'http basic: access denied',
+      'remote: invalid credentials',
+      'error: 403',
+      'error: 401'
+    )
+  ) {
+    return new GitError(`${operation} failed: authentication with the remote was rejected`, raw, [
+      'Verify your credentials for the git remote',
+      'For GitHub over HTTPS, run `gh auth login` (or `gh auth setup-git`)',
+      'For SSH, confirm your key is added: `ssh -T git@github.com`',
+      'Check the remote URL with `tuck config get` or `git remote -v`',
+    ]);
+  }
+
+  // Host unreachable / offline.
+  if (has('could not resolve host', 'unable to access', 'connection timed out', 'network is unreachable', 'failed to connect')) {
+    return new GitError(`${operation} failed: could not reach the remote`, raw, [
+      'Check your network connection',
+      'Verify the remote URL is correct and reachable',
+      'Retry once connectivity is restored',
+    ]);
+  }
+
+  if (operation === 'push') {
+    if (has('[rejected]', 'non-fast-forward', 'fetch first', 'tip of your current branch is behind', 'updates were rejected')) {
+      return new GitError('push rejected: the remote has commits you do not have locally', raw, [
+        'Run `tuck pull` first to integrate the remote changes, then push again',
+        'Or use `tuck push --force` to overwrite the remote (use with caution — this can discard remote history)',
+      ]);
+    }
+    if (has('has no upstream branch', 'set-upstream', 'no upstream configured')) {
+      return new GitError('push failed: the current branch has no upstream configured', raw, [
+        'Run `tuck push` again — tuck sets the upstream automatically on first push',
+        'Or set it manually with `git push --set-upstream origin <branch>`',
+      ]);
+    }
+    return new GitError('Failed to push', raw, [
+    ...rawFirstLine(raw),
+      'Run `tuck pull` to sync with the remote, then retry',
+      'Inspect the repo with `git status` to see what changed',
+    ]);
+  }
+
+  if (operation === 'pull') {
+    // Check uncommitted-local-changes before conflicts: git phrases it as
+    // "...would be overwritten by merge", which also contains the word "merge".
+    if (has('local changes', 'would be overwritten', 'commit your changes or stash')) {
+      return new GitError('pull failed: you have uncommitted local changes', raw, [
+        'Run `tuck sync` to commit your changes first, then pull',
+        'Or stash them with `git stash` before pulling',
+      ]);
+    }
+    if (has('merge conflict', 'conflict (', 'fix conflicts', 'needs merge', 'automatic merge failed')) {
+      return new GitError('pull produced merge conflicts', raw, [
+        'Run `tuck sync` in an interactive terminal to resolve the conflicts',
+        'Inspect the conflicting files with `git status`',
+        'Use `git merge --abort` (or `git rebase --abort`) to back out',
+      ]);
+    }
+    if (has('divergent branches', 'need to specify how to reconcile', 'not possible to fast-forward')) {
+      return new GitError('pull failed: local and remote branches have diverged', raw, [
+        'Run `tuck pull` with rebase, or resolve the divergence with `git pull --rebase`',
+        'Inspect both histories with `git log --oneline --graph`',
+      ]);
+    }
+    return new GitError('Failed to pull', raw, [
+    ...rawFirstLine(raw),
+      'Inspect the repo with `git status`',
+      'Retry after resolving any local changes',
+    ]);
+  }
+
+  // fetch
+  return new GitError('Failed to fetch', raw, [
+    ...rawFirstLine(raw),
+    'Verify the remote is configured with `git remote -v`',
+    'Check your network connection and credentials',
+  ]);
+};
+
 export const push = async (
   dir: string,
   options?: { remote?: string; branch?: string; force?: boolean; setUpstream?: boolean }
@@ -279,7 +399,7 @@ export const push = async (
       await git.push([...args, remote]);
     }
   } catch (error) {
-    throw new GitError('Failed to push', String(error));
+    throw describeGitError('push', String(error));
   }
 };
 
@@ -304,7 +424,7 @@ export const pull = async (
       await git.pull(remote, undefined, args);
     }
   } catch (error) {
-    throw new GitError('Failed to pull', String(error));
+    throw describeGitError('pull', String(error));
   }
 };
 
@@ -313,7 +433,7 @@ export const fetch = async (dir: string, remote = 'origin'): Promise<void> => {
     const git = createGit(dir);
     await git.fetch(remote);
   } catch (error) {
-    throw new GitError('Failed to fetch', String(error));
+    throw describeGitError('fetch', String(error));
   }
 };
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -6,6 +6,7 @@ import { logger } from '../ui/logger.js';
 import { prompts } from '../ui/prompts.js';
 import { IS_WINDOWS } from './platform.js';
 import { isJsonMode, addJsonWarning } from './jsonOutput.js';
+import { isNonInteractive } from './agentMode.js';
 
 const execAsync = promisify(exec);
 
@@ -99,7 +100,10 @@ export const runHook = async (
   // Include stdin: the trust prompt reads from stdin, so a non-TTY stdin
   // (e.g. `tuck sync < /dev/null`) must take the skip path, not attempt a
   // prompt that ensureInteractive() would throw on and abort the command.
-  const nonInteractive = isJsonMode() || !process.stdout.isTTY || !process.stdin.isTTY;
+  // isNonInteractive() also covers the explicit `--non-interactive` flag (and
+  // JSON mode / non-TTY stdin) so a PTY run of `--non-interactive` skips the
+  // hook with a warning instead of dying on a confirm it can never answer.
+  const nonInteractive = isNonInteractive() || !process.stdout.isTTY || !process.stdin.isTTY;
   const decision = decideHookExecution({
     skipHooks: options?.skipHooks,
     hasCommand: true,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,6 +9,8 @@ export * from './hooks.js';
 export * from './github.js';
 export * from './timemachine.js';
 export * from './merge.js';
+export * from './jsonMerge.js';
+export * from './jsonMergeSync.js';
 export * from './detect.js';
 export * from './remoteChecks.js';
 export * from './agentPresets.js';

--- a/src/lib/jsonKey.ts
+++ b/src/lib/jsonKey.ts
@@ -1,0 +1,255 @@
+/**
+ * JSON-path-scoped tracking primitives.
+ *
+ * tuck can track a *subtree* of a JSON file rather than the whole file:
+ * `tuck add ~/.claude.json --key mcpServers` extracts only the `mcpServers`
+ * value into the repo copy, and on apply/restore that subtree is deep-merged
+ * back into the live file — leaving every other key (machine state, OAuth
+ * tokens, session caches, conversation history) untouched.
+ *
+ * This module is the pure, dependency-free core of that behavior:
+ *   - {@link extractSubtree}       live file text → canonical JSON of the subtree
+ *     (what lands in the repo)
+ *   - {@link mergeSubtreeIntoLive} repo subtree + live file text → full live file
+ *     text with the subtree deep-merged back in
+ *   - {@link deepMergeJson}        the recursive object merge both rely on
+ *
+ * All extraction is serialized with sorted keys ({@link canonicalJson}) so the
+ * repo copy — and therefore its checksum — is stable regardless of the live
+ * file's key order or whitespace. That lets status/sync detect real subtree
+ * drift by comparing checksums, exactly like the rest of tuck's state model.
+ *
+ * v1 scope (documented limitations):
+ *   - Strict JSON only. Files with comments/trailing commas (JSONC, e.g. some
+ *     VS Code settings.json) are rejected rather than silently corrupted.
+ *   - Key paths address object properties via dots (`a.b.c`). Array indices are
+ *     not addressable; the leaf VALUE may be any JSON type (object/array/scalar).
+ */
+
+import { JsonKeyError } from '../errors.js';
+
+/** A JSON value with no functions/undefined — what `JSON.parse` yields. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** True for a non-null, non-array plain object (the only mergeable/navigable shape). */
+export const isPlainObject = (value: unknown): value is Record<string, JsonValue> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Split a dot-delimited key path into its segments, rejecting empty input and
+ * empty segments (`a..b`, leading/trailing dots) so a malformed path fails
+ * loudly at parse time rather than silently matching nothing.
+ */
+export const parseJsonKeyPath = (key: string): string[] => {
+  if (typeof key !== 'string' || key.trim() === '') {
+    throw new JsonKeyError('A JSON key path is required (e.g. --key mcpServers)');
+  }
+  const segments = key.split('.');
+  if (segments.some((segment) => segment === '')) {
+    throw new JsonKeyError(
+      `Invalid JSON key path "${key}": segments must be non-empty (no leading, trailing, or doubled dots)`
+    );
+  }
+  // Prototype-named segments would match inherited properties during
+  // navigation ('constructor' "exists" on every object) and writing to
+  // __proto__ mutates Object.prototype — reject them outright.
+  const dangerous = segments.find((segment) =>
+    ['__proto__', 'prototype', 'constructor'].includes(segment)
+  );
+  if (dangerous !== undefined) {
+    throw new JsonKeyError(
+      `Invalid JSON key path "${key}": "${dangerous}" is a reserved property name`
+    );
+  }
+  return segments;
+};
+
+/** Recursively sort object keys so serialization is deterministic. */
+const sortValue = (value: JsonValue): JsonValue => {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (isPlainObject(value)) {
+    const out: Record<string, JsonValue> = {};
+    for (const k of Object.keys(value).sort()) {
+      out[k] = sortValue(value[k]);
+    }
+    return out;
+  }
+  return value;
+};
+
+/**
+ * Serialize a JSON value canonically: keys sorted, 2-space indented, trailing
+ * newline. Used for the repo copy of a subtree so its bytes (and checksum) are
+ * identical for identical content regardless of the source file's ordering.
+ */
+export const canonicalJson = (value: JsonValue): string =>
+  `${JSON.stringify(sortValue(value), null, 2)}\n`;
+
+/** Parse text as strict JSON, raising a {@link JsonKeyError} with context on failure. */
+const parseJsonOrThrow = (content: string, label: string): JsonValue => {
+  try {
+    return JSON.parse(content) as JsonValue;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new JsonKeyError(`${label} is not valid JSON: ${reason}`);
+  }
+};
+
+/**
+ * Navigate `root` along `segments`. Intermediate nodes must be plain objects;
+ * the leaf value may be any JSON type. Returns `{ found: false }` if any segment
+ * is missing or an intermediate node is not an object.
+ */
+const getValueAtPath = (
+  root: JsonValue,
+  segments: string[]
+): { found: true; value: JsonValue } | { found: false } => {
+  let current: JsonValue = root;
+  for (const segment of segments) {
+    if (!isPlainObject(current) || !Object.prototype.hasOwnProperty.call(current, segment)) {
+      return { found: false };
+    }
+    current = current[segment];
+  }
+  return { found: true, value: current };
+};
+
+/**
+ * Deep-merge `patch` onto `base`. When BOTH are plain objects the merge is
+ * recursive and key-wise (base keys absent from patch are preserved); otherwise
+ * `patch` replaces `base` wholesale. Arrays are treated as opaque values and
+ * replaced, never element-merged (element identity is undefined for config
+ * arrays, so a union/index-merge would corrupt them).
+ */
+export const deepMergeJson = (base: JsonValue, patch: JsonValue): JsonValue => {
+  if (isPlainObject(base) && isPlainObject(patch)) {
+    // Null-prototype accumulator: a legitimate "__proto__" data key parsed
+    // from JSON must never hit Object.prototype through plain assignment.
+    const out: Record<string, JsonValue> = Object.create(null) as Record<string, JsonValue>;
+    for (const key of Object.keys(base)) {
+      out[key] = base[key];
+    }
+    for (const key of Object.keys(patch)) {
+      out[key] = Object.prototype.hasOwnProperty.call(base, key)
+        ? deepMergeJson(base[key], patch[key])
+        : patch[key];
+    }
+    return out;
+  }
+  return patch;
+};
+
+/**
+ * Return a copy of `obj` with `value` REPLACING whatever sits at `segments`,
+ * creating intermediate objects as needed. Everything OUTSIDE the tracked path
+ * is preserved; everything AT the path is tuck-managed by definition, so the
+ * repo subtree replaces it wholesale — a deep-merge here would resurrect keys
+ * deleted from the repo copy on every apply (and the next sync would capture
+ * the resurrected key back into the repo, reverting the deletion globally).
+ */
+const mergeAtPath = (
+  obj: Record<string, JsonValue>,
+  segments: string[],
+  value: JsonValue
+): Record<string, JsonValue> => {
+  const [head, ...rest] = segments;
+  const clone: Record<string, JsonValue> = Object.create(null) as Record<string, JsonValue>;
+  for (const key of Object.keys(obj)) {
+    clone[key] = obj[key];
+  }
+  if (rest.length === 0) {
+    clone[head] = value;
+  } else {
+    const existing: JsonValue | undefined = Object.prototype.hasOwnProperty.call(clone, head)
+      ? clone[head]
+      : undefined;
+    const child = isPlainObject(existing) ? existing : {};
+    clone[head] = mergeAtPath(child, rest, value);
+  }
+  return clone;
+};
+
+/**
+ * Extract the subtree at `key` from a JSON file's text and return it as
+ * canonical JSON (the exact bytes stored as the repo copy).
+ *
+ * @throws {@link JsonKeyError} when the content is not a JSON object, the key
+ *   path is malformed, or the key path is not present.
+ */
+export const extractSubtree = (content: string, key: string): string => {
+  const parsed = parseJsonOrThrow(content, 'File');
+  if (!isPlainObject(parsed)) {
+    throw new JsonKeyError('JSON-key tracking requires a top-level JSON object');
+  }
+  const segments = parseJsonKeyPath(key);
+  const result = getValueAtPath(parsed, segments);
+  if (!result.found) {
+    throw new JsonKeyError(`Key path "${key}" was not found in the file`);
+  }
+  return canonicalJson(result.value);
+};
+
+/**
+ * True when `content` is a JSON object that contains the given key path. Used
+ * for non-throwing drift checks (sync/status) where an absent key means "the
+ * tracked subtree is missing from the live file", not an error.
+ */
+export const hasSubtree = (content: string, key: string): boolean => {
+  let parsed: JsonValue;
+  try {
+    parsed = JSON.parse(content) as JsonValue;
+  } catch {
+    return false;
+  }
+  if (!isPlainObject(parsed)) return false;
+  let segments: string[];
+  try {
+    segments = parseJsonKeyPath(key);
+  } catch {
+    return false;
+  }
+  return getValueAtPath(parsed, segments).found;
+};
+
+/**
+ * Write a repo-stored subtree back into a live file's text at `key`, returning
+ * the full updated file text (2-space indented, trailing newline).
+ *
+ * Every key outside the tracked path is preserved byte-for-value; the value AT
+ * the tracked path is REPLACED by the repo subtree (it is tuck-managed by
+ * definition — replacing is what lets deletions inside the subtree propagate
+ * across machines). When the live file is absent/empty the result is a new
+ * object holding just the subtree.
+ *
+ * @throws {@link JsonKeyError} when the repo subtree or a non-empty live file is
+ *   not valid JSON, or the live top level is not a JSON object.
+ */
+export const mergeSubtreeIntoLive = (
+  liveContent: string | null,
+  repoSubtree: string,
+  key: string
+): string => {
+  const subtreeValue = parseJsonOrThrow(repoSubtree, 'Repo subtree');
+  const segments = parseJsonKeyPath(key);
+
+  let live: JsonValue;
+  if (liveContent === null || liveContent.trim() === '') {
+    live = {};
+  } else {
+    live = parseJsonOrThrow(liveContent, 'Live file');
+  }
+  if (!isPlainObject(live)) {
+    throw new JsonKeyError('JSON-key tracking requires the live file to be a JSON object');
+  }
+
+  const merged = mergeAtPath(live, segments, subtreeValue);
+  return `${JSON.stringify(merged, null, 2)}\n`;
+};

--- a/src/lib/jsonKey.ts
+++ b/src/lib/jsonKey.ts
@@ -3,27 +3,38 @@
  *
  * tuck can track a *subtree* of a JSON file rather than the whole file:
  * `tuck add ~/.claude.json --key mcpServers` extracts only the `mcpServers`
- * value into the repo copy, and on apply/restore that subtree is deep-merged
- * back into the live file — leaving every other key (machine state, OAuth
- * tokens, session caches, conversation history) untouched.
+ * value into the repo copy, and on apply/restore that subtree is written back
+ * into the live file at that exact path — leaving every other key (machine
+ * state, OAuth tokens, session caches, conversation history) untouched.
  *
  * This module is the pure, dependency-free core of that behavior:
  *   - {@link extractSubtree}       live file text → canonical JSON of the subtree
  *     (what lands in the repo)
  *   - {@link mergeSubtreeIntoLive} repo subtree + live file text → full live file
- *     text with the subtree deep-merged back in
- *   - {@link deepMergeJson}        the recursive object merge both rely on
+ *     text with the subtree REPLACED at the tracked path (a span-splice that
+ *     rewrites ONLY the tracked value's byte range, so every other byte — big
+ *     integers, key order, indentation, trailing whitespace — is preserved
+ *     verbatim)
  *
- * All extraction is serialized with sorted keys ({@link canonicalJson}) so the
- * repo copy — and therefore its checksum — is stable regardless of the live
- * file's key order or whitespace. That lets status/sync detect real subtree
- * drift by comparing checksums, exactly like the rest of tuck's state model.
+ * Extraction is serialized with sorted keys ({@link canonicalJson}) so the repo
+ * copy — and therefore its checksum — is stable regardless of the live file's
+ * key order or whitespace. That lets status/sync detect real subtree drift by
+ * comparing checksums, exactly like the rest of tuck's state model.
+ *
+ * WHY replace-at-path and not deep-merge: everything AT the tracked path is
+ * tuck-managed by definition. A deep-merge would resurrect keys the user
+ * deleted from the repo copy on every apply, and the next sync would recapture
+ * the resurrected key — reverting the deletion globally. So the tracked value is
+ * replaced wholesale while everything outside it is left byte-for-byte intact.
+ *
+ * Key paths address object properties via dots (`a.b.c`); a literal dot inside a
+ * single key name is escaped with a backslash (`--key 'servers.github\.copilot'`
+ * addresses `servers` → `github.copilot`). Array indices are not addressable;
+ * the leaf VALUE may be any JSON type (object/array/scalar).
  *
  * v1 scope (documented limitations):
  *   - Strict JSON only. Files with comments/trailing commas (JSONC, e.g. some
  *     VS Code settings.json) are rejected rather than silently corrupted.
- *   - Key paths address object properties via dots (`a.b.c`). Array indices are
- *     not addressable; the leaf VALUE may be any JSON type (object/array/scalar).
  */
 
 import { JsonKeyError } from '../errors.js';
@@ -42,23 +53,56 @@ export const isPlainObject = (value: unknown): value is Record<string, JsonValue
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
 /**
- * Split a dot-delimited key path into its segments, rejecting empty input and
- * empty segments (`a..b`, leading/trailing dots) so a malformed path fails
- * loudly at parse time rather than silently matching nothing.
+ * Split a dot-delimited key path into its (unescaped) segments.
+ *
+ * Dots separate segments; a backslash escapes the following character so a key
+ * name that itself contains a dot is addressable: `servers.github\.copilot`
+ * yields `['servers', 'github.copilot']`. `\\` produces a literal backslash; a
+ * backslash before any other character is preserved literally.
+ *
+ * Empty input and empty segments (`a..b`, leading/trailing dots) are rejected so
+ * a malformed path fails loudly at parse time rather than silently matching
+ * nothing. The prototype-pollution guard is applied to the UNESCAPED segment
+ * names (the actual property names that will be navigated/created).
  */
 export const parseJsonKeyPath = (key: string): string[] => {
   if (typeof key !== 'string' || key.trim() === '') {
     throw new JsonKeyError('A JSON key path is required (e.g. --key mcpServers)');
   }
-  const segments = key.split('.');
+
+  // Split on UNESCAPED dots only, unescaping `\.`/`\\` as we go.
+  const segments: string[] = [];
+  let current = '';
+  for (let i = 0; i < key.length; i++) {
+    const ch = key[i];
+    if (ch === '\\') {
+      const next = key[i + 1];
+      if (next === '.' || next === '\\') {
+        current += next;
+        i++;
+        continue;
+      }
+      // Lone backslash (not escaping a dot/backslash): keep it literally.
+      current += ch;
+      continue;
+    }
+    if (ch === '.') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  segments.push(current);
+
   if (segments.some((segment) => segment === '')) {
     throw new JsonKeyError(
       `Invalid JSON key path "${key}": segments must be non-empty (no leading, trailing, or doubled dots)`
     );
   }
-  // Prototype-named segments would match inherited properties during
-  // navigation ('constructor' "exists" on every object) and writing to
-  // __proto__ mutates Object.prototype — reject them outright.
+  // Prototype-named segments would match inherited properties during navigation
+  // ('constructor' "exists" on every object) and writing to __proto__ mutates
+  // Object.prototype — reject them outright. Checked on the UNESCAPED names.
   const dangerous = segments.find((segment) =>
     ['__proto__', 'prototype', 'constructor'].includes(segment)
   );
@@ -128,6 +172,11 @@ const getValueAtPath = (
  * `patch` replaces `base` wholesale. Arrays are treated as opaque values and
  * replaced, never element-merged (element identity is undefined for config
  * arrays, so a union/index-merge would corrupt them).
+ *
+ * NOTE: this is a standalone utility. The subtree write-back
+ * ({@link mergeSubtreeIntoLive}) deliberately does NOT deep-merge — it replaces
+ * the tracked value at its path (see the module header) — so this helper is not
+ * on the write-back path. It is retained as a general JSON merge primitive.
  */
 export const deepMergeJson = (base: JsonValue, patch: JsonValue): JsonValue => {
   if (isPlainObject(base) && isPlainObject(patch)) {
@@ -145,36 +194,6 @@ export const deepMergeJson = (base: JsonValue, patch: JsonValue): JsonValue => {
     return out;
   }
   return patch;
-};
-
-/**
- * Return a copy of `obj` with `value` REPLACING whatever sits at `segments`,
- * creating intermediate objects as needed. Everything OUTSIDE the tracked path
- * is preserved; everything AT the path is tuck-managed by definition, so the
- * repo subtree replaces it wholesale — a deep-merge here would resurrect keys
- * deleted from the repo copy on every apply (and the next sync would capture
- * the resurrected key back into the repo, reverting the deletion globally).
- */
-const mergeAtPath = (
-  obj: Record<string, JsonValue>,
-  segments: string[],
-  value: JsonValue
-): Record<string, JsonValue> => {
-  const [head, ...rest] = segments;
-  const clone: Record<string, JsonValue> = Object.create(null) as Record<string, JsonValue>;
-  for (const key of Object.keys(obj)) {
-    clone[key] = obj[key];
-  }
-  if (rest.length === 0) {
-    clone[head] = value;
-  } else {
-    const existing: JsonValue | undefined = Object.prototype.hasOwnProperty.call(clone, head)
-      ? clone[head]
-      : undefined;
-    const child = isPlainObject(existing) ? existing : {};
-    clone[head] = mergeAtPath(child, rest, value);
-  }
-  return clone;
 };
 
 /**
@@ -219,18 +238,358 @@ export const hasSubtree = (content: string, key: string): boolean => {
   return getValueAtPath(parsed, segments).found;
 };
 
+// ---------------------------------------------------------------------------
+// Span-splice write-back
+//
+// mergeSubtreeIntoLive must preserve every byte OUTSIDE the tracked path exactly
+// — round-tripping the whole file through JSON.parse/JSON.stringify would corrupt
+// large integers (1234567890123456789 → …800), reorder integer-like keys, and
+// normalize indentation. So instead of re-serializing the whole object, we
+// tokenize the live JSON text to find the byte range of the value at the tracked
+// path and replace ONLY that range.
+// ---------------------------------------------------------------------------
+
+interface ObjectMember {
+  /** UNESCAPED key name (JSON escapes decoded). */
+  key: string;
+  /** Offset of the opening quote of this member's key. */
+  keyStart: number;
+  /** The member's value node (carries its own byte span). */
+  value: ValueNode;
+}
+
+interface ObjectNode {
+  kind: 'object';
+  start: number;
+  end: number;
+  /** Offset just after the opening `{`. */
+  bodyStart: number;
+  /** Offset of the closing `}`. */
+  bodyEnd: number;
+  members: ObjectMember[];
+}
+
+interface ScalarNode {
+  kind: 'array' | 'string' | 'number' | 'literal';
+  start: number;
+  end: number;
+}
+
+type ValueNode = ObjectNode | ScalarNode;
+
+/**
+ * A minimal recursive-descent JSON parser that records the byte span of every
+ * value (and, for objects, of every member). It exists so we can splice a single
+ * value in place without touching any other byte. String scanning honors escape
+ * sequences so braces/brackets inside strings never confuse nesting.
+ */
+class JsonSpanParser {
+  private i = 0;
+  constructor(private readonly s: string) {}
+
+  parse(): ValueNode {
+    this.skipWs();
+    const node = this.parseValue();
+    this.skipWs();
+    if (this.i !== this.s.length) {
+      this.fail('unexpected trailing content');
+    }
+    return node;
+  }
+
+  private skipWs(): void {
+    while (this.i < this.s.length) {
+      const c = this.s[this.i];
+      if (c === ' ' || c === '\t' || c === '\n' || c === '\r') this.i++;
+      else break;
+    }
+  }
+
+  private fail(msg: string): never {
+    throw new JsonKeyError(`Live file is not valid JSON: ${msg} at position ${this.i}`);
+  }
+
+  private parseValue(): ValueNode {
+    const c = this.s[this.i];
+    if (c === '{') return this.parseObject();
+    if (c === '[') return this.parseArray();
+    if (c === '"') {
+      const str = this.parseString();
+      return { kind: 'string', start: str.start, end: str.end };
+    }
+    if (c === '-' || (c >= '0' && c <= '9')) return this.parseNumber();
+    if (this.s.startsWith('true', this.i)) {
+      const start = this.i;
+      this.i += 4;
+      return { kind: 'literal', start, end: this.i };
+    }
+    if (this.s.startsWith('false', this.i)) {
+      const start = this.i;
+      this.i += 5;
+      return { kind: 'literal', start, end: this.i };
+    }
+    if (this.s.startsWith('null', this.i)) {
+      const start = this.i;
+      this.i += 4;
+      return { kind: 'literal', start, end: this.i };
+    }
+    this.fail(`unexpected character ${JSON.stringify(c ?? '<eof>')}`);
+  }
+
+  private parseObject(): ObjectNode {
+    const start = this.i;
+    this.i++; // consume '{'
+    const bodyStart = this.i;
+    const members: ObjectMember[] = [];
+    this.skipWs();
+    if (this.s[this.i] === '}') {
+      const bodyEnd = this.i;
+      this.i++;
+      return { kind: 'object', start, end: this.i, bodyStart, bodyEnd, members };
+    }
+    for (;;) {
+      this.skipWs();
+      if (this.s[this.i] !== '"') this.fail('expected string key');
+      const keyStart = this.i;
+      const keyStr = this.parseString();
+      this.skipWs();
+      if (this.s[this.i] !== ':') this.fail("expected ':'");
+      this.i++;
+      this.skipWs();
+      const value = this.parseValue();
+      members.push({ key: keyStr.decoded, keyStart, value });
+      this.skipWs();
+      const ch = this.s[this.i];
+      if (ch === ',') {
+        this.i++;
+        continue;
+      }
+      if (ch === '}') {
+        const bodyEnd = this.i;
+        this.i++;
+        return { kind: 'object', start, end: this.i, bodyStart, bodyEnd, members };
+      }
+      this.fail("expected ',' or '}'");
+    }
+  }
+
+  private parseArray(): ScalarNode {
+    const start = this.i;
+    this.i++; // consume '['
+    this.skipWs();
+    if (this.s[this.i] === ']') {
+      this.i++;
+      return { kind: 'array', start, end: this.i };
+    }
+    for (;;) {
+      this.skipWs();
+      this.parseValue();
+      this.skipWs();
+      const ch = this.s[this.i];
+      if (ch === ',') {
+        this.i++;
+        continue;
+      }
+      if (ch === ']') {
+        this.i++;
+        return { kind: 'array', start, end: this.i };
+      }
+      this.fail("expected ',' or ']'");
+    }
+  }
+
+  private parseString(): { start: number; end: number; decoded: string } {
+    const start = this.i;
+    this.i++; // opening quote
+    let decoded = '';
+    for (;;) {
+      if (this.i >= this.s.length) this.fail('unterminated string');
+      const c = this.s[this.i];
+      if (c === '"') {
+        this.i++;
+        break;
+      }
+      if (c === '\\') {
+        const esc = this.s[this.i + 1];
+        switch (esc) {
+          case '"':
+            decoded += '"';
+            this.i += 2;
+            break;
+          case '\\':
+            decoded += '\\';
+            this.i += 2;
+            break;
+          case '/':
+            decoded += '/';
+            this.i += 2;
+            break;
+          case 'b':
+            decoded += '\b';
+            this.i += 2;
+            break;
+          case 'f':
+            decoded += '\f';
+            this.i += 2;
+            break;
+          case 'n':
+            decoded += '\n';
+            this.i += 2;
+            break;
+          case 'r':
+            decoded += '\r';
+            this.i += 2;
+            break;
+          case 't':
+            decoded += '\t';
+            this.i += 2;
+            break;
+          case 'u': {
+            const hex = this.s.slice(this.i + 2, this.i + 6);
+            if (!/^[0-9a-fA-F]{4}$/.test(hex)) this.fail('invalid \\u escape');
+            decoded += String.fromCharCode(parseInt(hex, 16));
+            this.i += 6;
+            break;
+          }
+          default:
+            this.fail('invalid escape sequence');
+        }
+        continue;
+      }
+      decoded += c;
+      this.i++;
+    }
+    return { start, end: this.i, decoded };
+  }
+
+  private parseNumber(): ScalarNode {
+    const start = this.i;
+    const isDigit = (ch: string | undefined): boolean => ch !== undefined && ch >= '0' && ch <= '9';
+    if (this.s[this.i] === '-') this.i++;
+    while (isDigit(this.s[this.i])) this.i++;
+    if (this.s[this.i] === '.') {
+      this.i++;
+      while (isDigit(this.s[this.i])) this.i++;
+    }
+    if (this.s[this.i] === 'e' || this.s[this.i] === 'E') {
+      this.i++;
+      if (this.s[this.i] === '+' || this.s[this.i] === '-') this.i++;
+      while (isDigit(this.s[this.i])) this.i++;
+    }
+    return { kind: 'number', start, end: this.i };
+  }
+}
+
+/** Leading whitespace of the line containing `offset` (its indentation prefix). */
+const lineIndent = (text: string, offset: number): string => {
+  let lineStart = offset;
+  while (lineStart > 0 && text[lineStart - 1] !== '\n') lineStart--;
+  let j = lineStart;
+  while (j < text.length && (text[j] === ' ' || text[j] === '\t')) j++;
+  return text.slice(lineStart, j);
+};
+
+/**
+ * Best-effort detection of the file's indent unit (one indentation level). Reads
+ * the whitespace of the first indented line — in a pretty-printed object that is
+ * a depth-1 key, i.e. exactly one unit. Falls back to two spaces for single-line
+ * or unindented files (only consulted when re-serializing a multi-line value).
+ */
+const detectIndentUnit = (text: string): string => {
+  const m = text.match(/\n([ \t]+)\S/);
+  return m ? m[1] : '  ';
+};
+
+/** Wrap `leaf` in nested objects for `segments` (`['a','b'], v` → `{a:{b:v}}`). */
+const buildNested = (segments: string[], leaf: JsonValue): JsonValue => {
+  let value = leaf;
+  for (let k = segments.length - 1; k >= 0; k--) {
+    value = { [segments[k]]: value };
+  }
+  return value;
+};
+
+/**
+ * Serialize a value for splicing into the live text. When `multiline`, pretty-
+ * print with the file's indent unit and re-indent every line after the first by
+ * `continuationIndent` so the value sits correctly at its depth; when not,
+ * emit compact JSON (single-line files stay single-line). Keys are sorted so the
+ * spliced value matches the canonical repo copy's ordering.
+ */
+const serializeSpliceValue = (
+  value: JsonValue,
+  indentUnit: string,
+  multiline: boolean,
+  continuationIndent: string
+): string => {
+  const sorted = sortValue(value);
+  if (!multiline) return JSON.stringify(sorted);
+  const raw = JSON.stringify(sorted, null, indentUnit);
+  return raw
+    .split('\n')
+    .map((line, idx) => (idx === 0 ? line : continuationIndent + line))
+    .join('\n');
+};
+
+/** Splice a brand-new `"key": value` member into `container`, preserving layout. */
+const insertMember = (
+  text: string,
+  container: ObjectNode,
+  key: string,
+  value: JsonValue,
+  indentUnit: string,
+  multiline: boolean
+): string => {
+  const keyJson = JSON.stringify(key);
+
+  if (container.members.length === 0) {
+    // Empty object: replace the whitespace between the braces with one member.
+    const baseIndent = lineIndent(text, container.start);
+    const memberIndent = baseIndent + indentUnit;
+    if (!multiline) {
+      const valueStr = serializeSpliceValue(value, indentUnit, false, '');
+      return (
+        text.slice(0, container.bodyStart) +
+        `${keyJson}:${valueStr}` +
+        text.slice(container.bodyEnd)
+      );
+    }
+    const valueStr = serializeSpliceValue(value, indentUnit, true, memberIndent);
+    const inserted = `\n${memberIndent}${keyJson}: ${valueStr}\n${baseIndent}`;
+    return text.slice(0, container.bodyStart) + inserted + text.slice(container.bodyEnd);
+  }
+
+  // Non-empty object: append after the last member's value (which carries no
+  // trailing comma), inserting the comma ourselves.
+  const last = container.members[container.members.length - 1];
+  const insertAt = last.value.end;
+  if (!multiline) {
+    const valueStr = serializeSpliceValue(value, indentUnit, false, '');
+    return text.slice(0, insertAt) + `,${keyJson}:${valueStr}` + text.slice(insertAt);
+  }
+  const memberIndent = lineIndent(text, last.keyStart);
+  const valueStr = serializeSpliceValue(value, indentUnit, true, memberIndent);
+  const inserted = `,\n${memberIndent}${keyJson}: ${valueStr}`;
+  return text.slice(0, insertAt) + inserted + text.slice(insertAt);
+};
+
 /**
  * Write a repo-stored subtree back into a live file's text at `key`, returning
- * the full updated file text (2-space indented, trailing newline).
+ * the full updated file text.
  *
- * Every key outside the tracked path is preserved byte-for-value; the value AT
- * the tracked path is REPLACED by the repo subtree (it is tuck-managed by
- * definition — replacing is what lets deletions inside the subtree propagate
- * across machines). When the live file is absent/empty the result is a new
- * object holding just the subtree.
+ * The value AT the tracked path is REPLACED by the repo subtree (it is
+ * tuck-managed by definition — replacing is what lets deletions inside the
+ * subtree propagate across machines). Every byte OUTSIDE that path is preserved
+ * verbatim via a span-splice: large integers, key order, indentation style, and
+ * trailing whitespace of the untracked remainder are all left exactly as-is.
+ * When the tracked path is absent it is inserted into the nearest existing
+ * ancestor object (creating intermediate objects as needed). When the live file
+ * is absent/empty the result is a new object holding just the subtree.
  *
  * @throws {@link JsonKeyError} when the repo subtree or a non-empty live file is
- *   not valid JSON, or the live top level is not a JSON object.
+ *   not valid JSON, the live top level is not a JSON object, or an INTERMEDIATE
+ *   node on the path exists but is not an object (descending into it would
+ *   discard that data).
  */
 export const mergeSubtreeIntoLive = (
   liveContent: string | null,
@@ -240,16 +599,63 @@ export const mergeSubtreeIntoLive = (
   const subtreeValue = parseJsonOrThrow(repoSubtree, 'Repo subtree');
   const segments = parseJsonKeyPath(key);
 
-  let live: JsonValue;
+  // Empty/absent live file: no bytes to preserve — synthesize a fresh object.
   if (liveContent === null || liveContent.trim() === '') {
-    live = {};
-  } else {
-    live = parseJsonOrThrow(liveContent, 'Live file');
+    return `${JSON.stringify(buildNested(segments, subtreeValue), null, 2)}\n`;
   }
-  if (!isPlainObject(live)) {
+
+  let root: ValueNode;
+  try {
+    root = new JsonSpanParser(liveContent).parse();
+  } catch (error) {
+    if (error instanceof JsonKeyError) throw error;
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new JsonKeyError(`Live file is not valid JSON: ${reason}`);
+  }
+  if (root.kind !== 'object') {
     throw new JsonKeyError('JSON-key tracking requires the live file to be a JSON object');
   }
 
-  const merged = mergeAtPath(live, segments, subtreeValue);
-  return `${JSON.stringify(merged, null, 2)}\n`;
+  const indentUnit = detectIndentUnit(liveContent);
+  const multiline = liveContent.includes('\n');
+
+  let container: ObjectNode = root;
+  for (let idx = 0; idx < segments.length; idx++) {
+    const seg = segments[idx];
+    const member = container.members.find((m) => m.key === seg);
+    const isLast = idx === segments.length - 1;
+
+    if (member) {
+      if (isLast) {
+        // Replace the tracked value's byte span in place.
+        const keyIndent = lineIndent(liveContent, member.keyStart);
+        const replacement = serializeSpliceValue(subtreeValue, indentUnit, multiline, keyIndent);
+        return (
+          liveContent.slice(0, member.value.start) +
+          replacement +
+          liveContent.slice(member.value.end)
+        );
+      }
+      if (member.value.kind !== 'object') {
+        // An intermediate node exists but is not an object: overwriting it would
+        // discard whatever it holds (an array, scalar, …). Fail loudly — callers
+        // catch JsonKeyError and skip this file rather than corrupt it.
+        throw new JsonKeyError(
+          `Cannot write JSON key path "${key}": "${segments.slice(0, idx + 1).join('.')}" ` +
+            `in the live file is a ${member.value.kind}, not an object — refusing to overwrite it`
+        );
+      }
+      container = member.value;
+      continue;
+    }
+
+    // Missing segment: insert into the nearest existing ancestor object, wrapping
+    // the subtree in any intermediate objects the remaining path still needs.
+    const newValue = buildNested(segments.slice(idx + 1), subtreeValue);
+    return insertMember(liveContent, container, seg, newValue, indentUnit, multiline);
+  }
+
+  // Unreachable: `segments` is always non-empty, so the loop returns above.
+  /* istanbul ignore next */
+  throw new JsonKeyError(`Key path "${key}" could not be resolved`);
 };

--- a/src/lib/jsonMerge.ts
+++ b/src/lib/jsonMerge.ts
@@ -1,0 +1,344 @@
+import { basename } from 'path';
+import type {
+  arrayMergeStrategySchema,
+  conflictResolutionSchema,
+  mergePolicySchema,
+} from '../schemas/manifest.schema.js';
+import type { z } from 'zod';
+
+/**
+ * Structured three-way JSON merge.
+ *
+ * This module is intentionally **pure** — no filesystem, no git, no logging —
+ * so it is trivially unit-testable and safe to reuse from `tuck sync`,
+ * `tuck apply`, or the MCP server. The filesystem/git orchestration lives in
+ * the callers (see {@link file:./jsonMergeSync.ts}).
+ *
+ * The classic merge problem: an agent tool (Claude Code, etc.) rewrites its own
+ * JSON config on two machines. Naive push/pull captures whichever side synced
+ * last and silently drops the other side's edits. A three-way merge with the
+ * last-synced version as the common ancestor recovers BOTH sides' changes and
+ * only surfaces a genuine conflict when the same leaf was changed two different
+ * ways.
+ */
+
+export type ArrayMergeStrategy = z.infer<typeof arrayMergeStrategySchema>;
+export type ConflictResolution = z.infer<typeof conflictResolutionSchema>;
+export type MergePolicy = z.infer<typeof mergePolicySchema>;
+
+/** The default policy applied to auto-detected agent config files. */
+export const DEFAULT_JSON_MERGE_POLICY: MergePolicy = {
+  format: 'json',
+  arrays: 'union',
+  conflict: 'manual',
+};
+
+/**
+ * A JSON value. We deliberately avoid `any`: everything flowing through the
+ * merge is a well-typed JSON node.
+ */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Sentinel meaning "this key does not exist on this side". Distinguishing
+ * absence from an explicit `null`/`undefined` value is what lets the merge tell
+ * a deletion apart from a value change.
+ */
+const MISSING = Symbol('tuck.jsonMerge.MISSING');
+type Missing = typeof MISSING;
+type Slot = JsonValue | Missing;
+
+/** A single unresolved conflict, addressed by a dotted/bracketed JSON path. */
+export interface JsonMergeConflict {
+  /** Human-readable path to the conflicting node, e.g. `permissions.allow` or `env.TOKEN`. */
+  path: string;
+  /** The local (ours) value, or `undefined` when the key was deleted locally. */
+  ours: JsonValue | undefined;
+  /** The incoming (theirs) value, or `undefined` when the key was deleted remotely. */
+  theirs: JsonValue | undefined;
+  /** The common-ancestor value, or `undefined` when the key did not exist in the base. */
+  base: JsonValue | undefined;
+  /** Short description of why this could not be auto-merged. */
+  reason: string;
+}
+
+/** Result of merging parsed JSON values. */
+export interface JsonMergeResult {
+  merged: JsonValue;
+  conflicts: JsonMergeConflict[];
+}
+
+/** Result of merging JSON *text* (parse → merge → serialize). */
+export interface JsonTextMergeResult {
+  /** Serialized merged JSON (indentation inferred from `ours`), or null on hard failure. */
+  text: string | null;
+  conflicts: JsonMergeConflict[];
+  /** True when a side could not be parsed as JSON — smart merge is impossible. */
+  unparsable: boolean;
+}
+
+const isPlainObject = (value: Slot): value is { [key: string]: JsonValue } =>
+  value !== MISSING &&
+  value !== null &&
+  typeof value === 'object' &&
+  !Array.isArray(value);
+
+const isArray = (value: Slot): value is JsonValue[] =>
+  value !== MISSING && Array.isArray(value);
+
+/**
+ * Canonical, order-independent serialization used for deep equality and for
+ * array de-duplication. Object keys are sorted so `{a:1,b:2}` and `{b:2,a:1}`
+ * hash identically; array order is preserved (arrays are ordered values).
+ */
+export const canonicalize = (value: JsonValue): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalize(value[k])}`).join(',')}}`;
+};
+
+/** Deep structural equality via canonical serialization. */
+const deepEqual = (a: Slot, b: Slot): boolean => {
+  if (a === MISSING || b === MISSING) return a === b;
+  return canonicalize(a) === canonicalize(b);
+};
+
+const asValue = (slot: Slot): JsonValue | undefined => (slot === MISSING ? undefined : slot);
+
+/**
+ * Merge two arrays that have both diverged from their common ancestor.
+ * `replace` is handled by the caller (it degrades to a scalar conflict).
+ */
+const mergeArrays = (
+  ours: JsonValue[],
+  theirs: JsonValue[],
+  strategy: ArrayMergeStrategy
+): JsonValue[] => {
+  if (strategy === 'concat') {
+    return [...ours, ...theirs];
+  }
+  // union: keep ours in order, then append theirs entries not already present.
+  const seen = new Set<string>();
+  const result: JsonValue[] = [];
+  for (const item of [...ours, ...theirs]) {
+    const key = canonicalize(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+};
+
+/**
+ * Recursively merge one slot from each side, given the common-ancestor slot.
+ * Pushes any unresolved conflicts onto `conflicts` (addressed by `path`).
+ */
+const mergeSlot = (
+  base: Slot,
+  ours: Slot,
+  theirs: Slot,
+  policy: MergePolicy,
+  path: string,
+  conflicts: JsonMergeConflict[]
+): Slot => {
+  // Fast paths: no divergence to reconcile.
+  if (deepEqual(ours, theirs)) return ours; // both sides identical
+  if (deepEqual(ours, base)) return theirs; // only theirs changed → take theirs
+  if (deepEqual(theirs, base)) return ours; // only ours changed → keep ours
+
+  // Both sides changed, differently. Recurse structurally when shapes align.
+  if (isPlainObject(ours) && isPlainObject(theirs)) {
+    return mergeObjects(base, ours, theirs, policy, path, conflicts);
+  }
+
+  if (isArray(ours) && isArray(theirs) && policy.arrays !== 'replace') {
+    return mergeArrays(ours, theirs, policy.arrays);
+  }
+
+  // Irreconcilable leaf (scalar/type mismatch, or array under `replace`).
+  return resolveConflict(base, ours, theirs, policy, path, conflicts);
+};
+
+const mergeObjects = (
+  base: Slot,
+  ours: { [key: string]: JsonValue },
+  theirs: { [key: string]: JsonValue },
+  policy: MergePolicy,
+  path: string,
+  conflicts: JsonMergeConflict[]
+): { [key: string]: JsonValue } => {
+  const baseObj = isPlainObject(base) ? base : undefined;
+  const result: { [key: string]: JsonValue } = {};
+
+  const keys = new Set<string>([...Object.keys(ours), ...Object.keys(theirs)]);
+  // Iterate ours-first, then theirs-only keys, for stable, intuitive ordering.
+  const orderedKeys = [
+    ...Object.keys(ours),
+    ...Object.keys(theirs).filter((k) => !(k in ours)),
+  ];
+
+  for (const key of orderedKeys) {
+    if (!keys.has(key)) continue;
+    keys.delete(key);
+
+    const childPath = path ? `${path}.${key}` : key;
+    const ourSlot: Slot = key in ours ? ours[key] : MISSING;
+    const theirSlot: Slot = key in theirs ? theirs[key] : MISSING;
+    const baseSlot: Slot = baseObj && key in baseObj ? baseObj[key] : MISSING;
+
+    const merged = mergeSlot(baseSlot, ourSlot, theirSlot, policy, childPath, conflicts);
+    if (merged !== MISSING) {
+      result[key] = merged;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Resolve an irreconcilable slot per the policy. `manual` records a conflict
+ * and leaves `ours` in place so the serialized file stays valid JSON; the
+ * caller decides whether to block on recorded conflicts.
+ */
+const resolveConflict = (
+  base: Slot,
+  ours: Slot,
+  theirs: Slot,
+  policy: MergePolicy,
+  path: string,
+  conflicts: JsonMergeConflict[]
+): Slot => {
+  if (policy.conflict === 'ours') return ours;
+  if (policy.conflict === 'theirs') return theirs;
+
+  conflicts.push({
+    path,
+    ours: asValue(ours),
+    theirs: asValue(theirs),
+    base: asValue(base),
+    reason:
+      ours === MISSING
+        ? 'deleted locally but modified in the incoming copy'
+        : theirs === MISSING
+          ? 'modified locally but deleted in the incoming copy'
+          : 'changed to different values on both sides',
+  });
+  // Keep a valid document: prefer ours, or theirs if ours was deleted.
+  return ours === MISSING ? theirs : ours;
+};
+
+/**
+ * Three-way merge of already-parsed JSON values.
+ *
+ * @param base   Common ancestor (the last-synced version).
+ * @param ours   Local value.
+ * @param theirs Incoming value.
+ */
+export const mergeJsonValues = (
+  base: JsonValue,
+  ours: JsonValue,
+  theirs: JsonValue,
+  policy: MergePolicy = DEFAULT_JSON_MERGE_POLICY
+): JsonMergeResult => {
+  const conflicts: JsonMergeConflict[] = [];
+  const merged = mergeSlot(base, ours, theirs, policy, '', conflicts);
+  // The top-level slot is always present (callers pass real values, not MISSING).
+  return { merged: merged === MISSING ? null : merged, conflicts };
+};
+
+/**
+ * Detect the indentation used by a JSON document so the merged output matches
+ * the local file's style. Defaults to two spaces.
+ */
+export const detectJsonIndent = (text: string): number | string => {
+  const match = text.match(/^\{\s*\n(\s+)/);
+  if (match) {
+    const ws = match[1].replace(/\n/g, '');
+    if (ws.includes('\t')) return '\t';
+    if (ws.length > 0) return ws.length;
+  }
+  return 2;
+};
+
+const tryParse = (text: string): { ok: true; value: JsonValue } | { ok: false } => {
+  try {
+    return { ok: true, value: JSON.parse(text) as JsonValue };
+  } catch {
+    return { ok: false };
+  }
+};
+
+/**
+ * Three-way merge of JSON *text*. Parses each side, merges structurally, and
+ * re-serializes using the indentation inferred from `oursText`. When any side
+ * is not valid JSON the merge is impossible and `unparsable` is set so the
+ * caller can fall back to git's textual conflict handling.
+ */
+export const threeWayMergeJsonText = (
+  baseText: string,
+  oursText: string,
+  theirsText: string,
+  policy: MergePolicy = DEFAULT_JSON_MERGE_POLICY
+): JsonTextMergeResult => {
+  const base = tryParse(baseText);
+  const ours = tryParse(oursText);
+  const theirs = tryParse(theirsText);
+
+  if (!base.ok || !ours.ok || !theirs.ok) {
+    return { text: null, conflicts: [], unparsable: true };
+  }
+
+  const { merged, conflicts } = mergeJsonValues(base.value, ours.value, theirs.value, policy);
+  const indent = detectJsonIndent(oursText);
+  const serialized = JSON.stringify(merged, null, indent);
+  // Preserve a trailing newline when the local file had one (POSIX convention).
+  const text = oursText.endsWith('\n') ? `${serialized}\n` : serialized;
+  return { text, conflicts, unparsable: false };
+};
+
+/**
+ * Filenames (basename) that get a structured JSON merge policy automatically,
+ * even when the manifest carries no explicit policy. These are the high-churn,
+ * agent-rewritten configs the feature targets. Everything else is opt-in via
+ * `tuck merge set`.
+ */
+const AGENT_JSON_FILENAMES = new Set<string>([
+  'settings.json', // Claude Code / VS Code settings
+  'settings.local.json', // Claude Code local overrides
+  '.mcp.json', // Model Context Protocol servers
+  'mcp.json',
+  '.claude.json',
+]);
+
+/**
+ * Resolve the effective merge policy for a tracked file. An explicit manifest
+ * policy always wins; otherwise a curated allowlist of agent config filenames
+ * gets the safe union default. Returns null when the file should use plain
+ * copy semantics (the default for everything else).
+ */
+export const resolveMergePolicy = (
+  source: string,
+  manifestPolicy?: MergePolicy
+): MergePolicy | null => {
+  if (manifestPolicy) return manifestPolicy;
+  const name = basename(source);
+  if (AGENT_JSON_FILENAMES.has(name)) {
+    return DEFAULT_JSON_MERGE_POLICY;
+  }
+  return null;
+};
+
+/** True when the file has a structured merge policy (explicit or auto-detected). */
+export const hasMergePolicy = (source: string, manifestPolicy?: MergePolicy): boolean =>
+  resolveMergePolicy(source, manifestPolicy) !== null;

--- a/src/lib/jsonMerge.ts
+++ b/src/lib/jsonMerge.ts
@@ -119,8 +119,24 @@ const asValue = (slot: Slot): JsonValue | undefined => (slot === MISSING ? undef
 /**
  * Merge two arrays that have both diverged from their common ancestor.
  * `replace` is handled by the caller (it degrades to a scalar conflict).
+ *
+ * `union` is **base-aware**: an item present in `base` but dropped by one side
+ * was deliberately deleted, and that deletion is honored even if the other side
+ * still carries it (e.g. a locally-revoked `permissions.allow` entry is not
+ * silently re-granted just because the incoming copy still lists it). Concretely
+ * an item is kept iff either:
+ *   - it is a genuine addition — absent from `base` and present on at least one
+ *     side (unioned), or
+ *   - it survived on **both** sides — present in `base`, `ours`, and `theirs`.
+ * An item in `base` that is missing from either side is treated as deleted.
+ *
+ * Because union arrays have no element identity beyond canonical value equality,
+ * a "modification" of a base item reads as delete-old + add-new: the old value
+ * (gone from both sides) drops out and the new value (absent from base) is added.
+ * Ordering is stable — `ours` order first, then new `theirs` additions.
  */
 const mergeArrays = (
+  base: Slot,
   ours: JsonValue[],
   theirs: JsonValue[],
   strategy: ArrayMergeStrategy
@@ -128,13 +144,27 @@ const mergeArrays = (
   if (strategy === 'concat') {
     return [...ours, ...theirs];
   }
-  // union: keep ours in order, then append theirs entries not already present.
-  const seen = new Set<string>();
+  // union: three-way set merge keyed by canonical value.
+  const baseKeys = new Set<string>(
+    (isArray(base) ? base : []).map(canonicalize)
+  );
+  const oursKeys = new Set<string>(ours.map(canonicalize));
+  const theirsKeys = new Set<string>(theirs.map(canonicalize));
+
+  const keep = (key: string): boolean =>
+    baseKeys.has(key)
+      ? // Present in base: retained only if neither side deleted it.
+        oursKeys.has(key) && theirsKeys.has(key)
+      : // Absent from base: a genuine addition from whichever side has it.
+        true;
+
+  const emitted = new Set<string>();
   const result: JsonValue[] = [];
   for (const item of [...ours, ...theirs]) {
     const key = canonicalize(item);
-    if (seen.has(key)) continue;
-    seen.add(key);
+    if (emitted.has(key)) continue;
+    if (!keep(key)) continue;
+    emitted.add(key);
     result.push(item);
   }
   return result;
@@ -163,7 +193,7 @@ const mergeSlot = (
   }
 
   if (isArray(ours) && isArray(theirs) && policy.arrays !== 'replace') {
-    return mergeArrays(ours, theirs, policy.arrays);
+    return mergeArrays(base, ours, theirs, policy.arrays);
   }
 
   // Irreconcilable leaf (scalar/type mismatch, or array under `replace`).
@@ -179,13 +209,22 @@ const mergeObjects = (
   conflicts: JsonMergeConflict[]
 ): { [key: string]: JsonValue } => {
   const baseObj = isPlainObject(base) ? base : undefined;
-  const result: { [key: string]: JsonValue } = {};
+  // Null-prototype result so a merged "__proto__" key is stored as a plain own
+  // data property instead of tripping the Object.prototype setter (which would
+  // hijack the prototype and drop the key from serialization). JSON.stringify
+  // still serializes every own enumerable key, "__proto__" included.
+  const result: { [key: string]: JsonValue } = Object.create(null) as {
+    [key: string]: JsonValue;
+  };
 
+  // Object.hasOwn (never the inherited `in`) so keys shadowing Object.prototype
+  // members — toString, constructor, valueOf, hasOwnProperty, __proto__ — are
+  // classified by their real presence and never silently dropped.
   const keys = new Set<string>([...Object.keys(ours), ...Object.keys(theirs)]);
   // Iterate ours-first, then theirs-only keys, for stable, intuitive ordering.
   const orderedKeys = [
     ...Object.keys(ours),
-    ...Object.keys(theirs).filter((k) => !(k in ours)),
+    ...Object.keys(theirs).filter((k) => !Object.hasOwn(ours, k)),
   ];
 
   for (const key of orderedKeys) {
@@ -193,9 +232,9 @@ const mergeObjects = (
     keys.delete(key);
 
     const childPath = path ? `${path}.${key}` : key;
-    const ourSlot: Slot = key in ours ? ours[key] : MISSING;
-    const theirSlot: Slot = key in theirs ? theirs[key] : MISSING;
-    const baseSlot: Slot = baseObj && key in baseObj ? baseObj[key] : MISSING;
+    const ourSlot: Slot = Object.hasOwn(ours, key) ? ours[key] : MISSING;
+    const theirSlot: Slot = Object.hasOwn(theirs, key) ? theirs[key] : MISSING;
+    const baseSlot: Slot = baseObj && Object.hasOwn(baseObj, key) ? baseObj[key] : MISSING;
 
     const merged = mergeSlot(baseSlot, ourSlot, theirSlot, policy, childPath, conflicts);
     if (merged !== MISSING) {

--- a/src/lib/jsonMergeSync.ts
+++ b/src/lib/jsonMergeSync.ts
@@ -40,6 +40,12 @@ export type MergeDecision =
  * pull so the captured contents are the common ancestor for the three-way
  * merge. Keyed by the manifest `source` identity. Template/encrypted files are
  * one-directional and never merged, so they are skipped.
+ *
+ * jsonKey (`--key`) files are ALSO skipped: their repo copy is only the tracked
+ * subtree document while the live file is the whole config, so the whole-file
+ * three-way merge here would splice subtree keys into the live root and
+ * transiently write the whole live file (tokens included) back into the repo.
+ * They have their own subtree-aware sync path instead.
  */
 export const captureMergeBases = async (
   tuckDir: string,
@@ -47,7 +53,7 @@ export const captureMergeBases = async (
 ): Promise<Map<string, string>> => {
   const bases = new Map<string, string>();
   for (const file of Object.values(files)) {
-    if (file.template || file.encrypted) continue;
+    if (file.template || file.encrypted || file.jsonKey) continue;
     if (!hasMergePolicy(file.source, file.merge)) continue;
     const destPath = join(tuckDir, file.destination);
     if (await pathExists(destPath)) {
@@ -105,10 +111,23 @@ export const decideFileMerge = (
  * the branch no longer behind, capture no bases, and silently commit local
  * values over the remote's. To keep the conflict recoverable, an aborted run
  * persists its bases to the machine-local state dir and the next sync seeds
- * from them (freshly-pulled bases always win). Cleared after a run that
- * reconciles successfully.
+ * from them. Persisted pending bases take PRECEDENCE over freshly-pulled ones:
+ * after an abort the repo copy already holds the previously-pulled remote, so a
+ * "fresh" base captured this run would be the wrong (post-pull) ancestor.
+ * Cleared per-file once that file is reconciled (or no longer diverges).
  */
 const PENDING_MERGE_BASES_FILE = 'pending-json-merge-bases.json';
+
+/**
+ * Combine freshly-captured merge bases with persisted pending bases. Persisted
+ * bases WIN on collision: after an abort the repo copy already holds the
+ * previously-pulled remote, so a base captured fresh this run would be the wrong
+ * (post-pull) ancestor. Fresh bases only fill in files that have no pending base.
+ */
+export const combineMergeBases = (
+  fresh: Map<string, string>,
+  persisted: Map<string, string>
+): Map<string, string> => new Map([...fresh, ...persisted]);
 
 export const getPendingMergeBasesPath = (): string =>
   join(getStateDir(), PENDING_MERGE_BASES_FILE);

--- a/src/lib/jsonMergeSync.ts
+++ b/src/lib/jsonMergeSync.ts
@@ -1,0 +1,154 @@
+import { readFile, writeFile, mkdir, rm } from 'fs/promises';
+import { join } from 'path';
+import { pathExists } from './paths.js';
+import { getStateDir } from './state.js';
+import {
+  threeWayMergeJsonText,
+  hasMergePolicy,
+  type JsonMergeConflict,
+  type MergePolicy,
+} from './jsonMerge.js';
+import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
+
+/**
+ * Sync-time orchestration for {@link file:./jsonMerge.ts}. Everything that
+ * touches the filesystem lives here; the pure merge math stays in jsonMerge.ts.
+ *
+ * The flow `tuck sync` drives:
+ *   1. BEFORE pulling, snapshot the repo copy of every merge-policy file. That
+ *      copy equals the local machine's last-synced state, so it is the correct
+ *      common ancestor ({@link captureMergeBases}).
+ *   2. Pull. Git may advance the repo copy to the remote's version.
+ *   3. For each locally-modified policy file, three-way merge
+ *      base(pre-pull repo) × local(live file) × remote(post-pull repo) and
+ *      decide what to write ({@link decideFileMerge}).
+ */
+
+/** Per-file merge decision produced by {@link decideFileMerge}. */
+export type MergeDecision =
+  /** Remote did not change this file — nothing to reconcile; normal copy applies. */
+  | { kind: 'skip' }
+  /** A side is not valid JSON — smart merge impossible; caller falls back to overwrite. */
+  | { kind: 'unparsable' }
+  /** Merged cleanly; `text` is the reconciled document to write to live + repo. */
+  | { kind: 'clean'; text: string }
+  /** Merged but with unresolved conflicts; `text` keeps the document valid. */
+  | { kind: 'conflict'; text: string; conflicts: JsonMergeConflict[] };
+
+/**
+ * Read the repo copy of every merge-policy tracked file. Call this BEFORE a
+ * pull so the captured contents are the common ancestor for the three-way
+ * merge. Keyed by the manifest `source` identity. Template/encrypted files are
+ * one-directional and never merged, so they are skipped.
+ */
+export const captureMergeBases = async (
+  tuckDir: string,
+  files: Record<string, TrackedFileOutput>
+): Promise<Map<string, string>> => {
+  const bases = new Map<string, string>();
+  for (const file of Object.values(files)) {
+    if (file.template || file.encrypted) continue;
+    if (!hasMergePolicy(file.source, file.merge)) continue;
+    const destPath = join(tuckDir, file.destination);
+    if (await pathExists(destPath)) {
+      try {
+        bases.set(file.source, await readFile(destPath, 'utf-8'));
+      } catch {
+        // Unreadable base → we simply can't three-way merge this file; the
+        // caller treats a missing base as "skip" and falls back to plain copy.
+      }
+    }
+  }
+  return bases;
+};
+
+/**
+ * Decide how a single tracked file reconciles, given its three versions.
+ *
+ * Pure and fully deterministic — this is the unit-testable heart of the
+ * sync-time merge.
+ *
+ * @param baseText   Repo copy captured before pull (common ancestor).
+ * @param liveText   Current live file on this machine (ours).
+ * @param remoteText Repo copy after pull (theirs).
+ */
+export const decideFileMerge = (
+  baseText: string,
+  liveText: string,
+  remoteText: string,
+  policy: MergePolicy
+): MergeDecision => {
+  // Remote is byte-identical to the ancestor → the pull brought no change to
+  // this file, so there is nothing to merge. The normal live→repo copy will
+  // faithfully capture the local edits.
+  if (remoteText === baseText) {
+    return { kind: 'skip' };
+  }
+
+  const result = threeWayMergeJsonText(baseText, liveText, remoteText, policy);
+  if (result.unparsable || result.text === null) {
+    return { kind: 'unparsable' };
+  }
+  if (result.conflicts.length === 0) {
+    return { kind: 'clean', text: result.text };
+  }
+  return { kind: 'conflict', text: result.text, conflicts: result.conflicts };
+};
+
+// ============================================================================
+// Pending merge-base persistence (abort recovery)
+// ============================================================================
+
+/**
+ * The merge base normally exists only in memory during the sync run that
+ * pulled. If the user aborts on a surfaced conflict, the next sync would find
+ * the branch no longer behind, capture no bases, and silently commit local
+ * values over the remote's. To keep the conflict recoverable, an aborted run
+ * persists its bases to the machine-local state dir and the next sync seeds
+ * from them (freshly-pulled bases always win). Cleared after a run that
+ * reconciles successfully.
+ */
+const PENDING_MERGE_BASES_FILE = 'pending-json-merge-bases.json';
+
+export const getPendingMergeBasesPath = (): string =>
+  join(getStateDir(), PENDING_MERGE_BASES_FILE);
+
+export const persistPendingMergeBases = async (bases: Map<string, string>): Promise<void> => {
+  if (bases.size === 0) return;
+  const path = getPendingMergeBasesPath();
+  await mkdir(getStateDir(), { recursive: true });
+  await writeFile(
+    path,
+    JSON.stringify({ version: 1, bases: Object.fromEntries(bases) }, null, 2) + '\n',
+    'utf-8'
+  );
+};
+
+export const loadPendingMergeBases = async (): Promise<Map<string, string>> => {
+  const path = getPendingMergeBasesPath();
+  if (!(await pathExists(path))) return new Map();
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, 'utf-8'));
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('bases' in parsed) ||
+      typeof (parsed as { bases: unknown }).bases !== 'object' ||
+      (parsed as { bases: unknown }).bases === null
+    ) {
+      return new Map();
+    }
+    const entries = Object.entries((parsed as { bases: Record<string, unknown> }).bases).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    );
+    return new Map(entries);
+  } catch {
+    // Corrupt state must never block a sync; the worst case is the pre-fix
+    // behavior (no recovered base).
+    return new Map();
+  }
+};
+
+export const clearPendingMergeBases = async (): Promise<void> => {
+  await rm(getPendingMergeBasesPath(), { force: true });
+};

--- a/src/lib/jsonOutput.ts
+++ b/src/lib/jsonOutput.ts
@@ -19,6 +19,8 @@ export interface JsonError {
   hint?: string;
   suggestions?: string[];
   exit_code: number;
+  /** Raw git stderr/stdout for GIT_ERROR failures — the unclassified evidence. */
+  git_output?: string;
 }
 
 export interface JsonEnvelopeOk<T> {

--- a/src/lib/materialize.ts
+++ b/src/lib/materialize.ts
@@ -69,10 +69,19 @@ export const materializeForLive = async (
  * The single per-OS keystore "encryption password" used for TCKE1 file
  * encryption. Returns null when none is set (the caller decides whether that is
  * fatal — it is for an encrypted file, harmless otherwise).
+ *
+ * Access is routed through the session key cache so the keystore is unlocked AT
+ * MOST ONCE per process (one prompt per session, even when apply/restore decrypt
+ * many files), and so read-only commands (status/diff/list) never trigger a
+ * keystore unlock: in read-only mode this returns a value already cached in the
+ * process, or null, without ever touching the keystore.
  */
 export const keystorePassphrase = async (): Promise<string | null> => {
-  const { getKeystore, TUCK_SERVICE, TUCK_ACCOUNT } = await import('./crypto/keystore/index.js');
-  return (await getKeystore()).retrieve(TUCK_SERVICE, TUCK_ACCOUNT);
+  const { getCachedKeystorePassphrase } = await import('./crypto/sessionKeyCache.js');
+  return getCachedKeystorePassphrase(async () => {
+    const { getKeystore, TUCK_SERVICE, TUCK_ACCOUNT } = await import('./crypto/keystore/index.js');
+    return (await getKeystore()).retrieve(TUCK_SERVICE, TUCK_ACCOUNT);
+  });
 };
 
 /**

--- a/src/lib/osSettings/capture.ts
+++ b/src/lib/osSettings/capture.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure capture logic: given two snapshots of the same domain (before and after
+ * the user changed a setting in the GUI), determine what changed and turn each
+ * change into a replayable `defaults` command.
+ *
+ * Keeping this free of any I/O makes the heart of capture mode unit-testable
+ * without spawning `defaults`: the backend feeds it parsed snapshots, and it
+ * returns typed CapturedChange records.
+ */
+import type { PlistValue } from './plist.js';
+import { stableStringify } from './plist.js';
+import type { DomainSnapshot, CapturedChange } from './types.js';
+import type { SettingType } from '../../schemas/osSettings.schema.js';
+
+/**
+ * Infer a supported scalar `defaults` type and its string form from a parsed
+ * plist value. Returns null for containers (dict/array) and opaque data, which
+ * v1 does not auto-replay.
+ */
+export const inferWriteFromValue = (
+  value: PlistValue
+): { type: SettingType; value: string } | null => {
+  switch (value.kind) {
+    case 'boolean':
+      return { type: 'boolean', value: value.value ? 'true' : 'false' };
+    case 'integer':
+      return { type: 'integer', value: String(value.value) };
+    case 'real':
+      return { type: 'float', value: String(value.value) };
+    case 'string':
+      return { type: 'string', value: value.value };
+    case 'date':
+      return { type: 'date', value: value.value };
+    default:
+      // data / dict / array — recorded as a change but not auto-applyable.
+      return null;
+  }
+};
+
+/**
+ * Diff two snapshots of the same domain. A key that appears/changes yields a
+ * `write` change; a key that disappears yields a `delete` change. Order is
+ * deterministic (sorted by key) so capture output and tests are stable.
+ */
+export const diffSnapshots = (before: DomainSnapshot, after: DomainSnapshot): CapturedChange[] => {
+  if (before.domain !== after.domain) {
+    throw new Error(`diffSnapshots: domain mismatch ("${before.domain}" vs "${after.domain}")`);
+  }
+  const domain = after.domain;
+  const changes: CapturedChange[] = [];
+  const keys = new Set<string>([...before.entries.keys(), ...after.entries.keys()]);
+
+  for (const key of [...keys].sort()) {
+    const prev = before.entries.get(key);
+    const next = after.entries.get(key);
+
+    if (next === undefined) {
+      // Key removed → deletion.
+      changes.push({ domain, key, action: 'delete' });
+      continue;
+    }
+    if (prev !== undefined && stableStringify(prev) === stableStringify(next)) {
+      continue; // unchanged
+    }
+
+    // Added or modified.
+    const inferred = inferWriteFromValue(next);
+    if (inferred) {
+      changes.push({ domain, key, action: 'write', type: inferred.type, value: inferred.value });
+    } else {
+      changes.push({ domain, key, action: 'write', unsupported: true });
+    }
+  }
+
+  return changes;
+};
+
+/** Diff many domain snapshot pairs and flatten the results. */
+export const diffDomains = (
+  before: DomainSnapshot[],
+  after: DomainSnapshot[]
+): CapturedChange[] => {
+  const beforeByDomain = new Map(before.map((s) => [s.domain, s]));
+  const changes: CapturedChange[] = [];
+  for (const afterSnap of after) {
+    const beforeSnap =
+      beforeByDomain.get(afterSnap.domain) ??
+      ({ domain: afterSnap.domain, entries: new Map() } satisfies DomainSnapshot);
+    changes.push(...diffSnapshots(beforeSnap, afterSnap));
+  }
+  return changes;
+};
+
+/** A stable id for a captured setting, unique per (os, domain, key). */
+export const settingId = (os: string, domain: string, key: string): string => {
+  const slug = (s: string): string =>
+    s
+      .replace(/[^a-zA-Z0-9._-]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+  return `${os}__${slug(domain)}__${slug(key)}`;
+};

--- a/src/lib/osSettings/defaults.ts
+++ b/src/lib/osSettings/defaults.ts
@@ -14,6 +14,36 @@ import type { SettingEntry, SettingType } from '../../schemas/osSettings.schema.
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * `defaults export` on a real Mac routinely emits multi-megabyte plists for
+ * domains such as com.apple.finder or the global domain. execFile's default
+ * 1 MB stdout cap would reject those with ERR_CHILD_PROCESS_STDIO_MAXBUFFER,
+ * which previously masqueraded as an empty export — silently skipping the
+ * pre-apply backup and producing bogus "no changes"/delete-everything diffs.
+ * A generous 64 MB ceiling comfortably covers observed domains while still
+ * bounding memory.
+ */
+const MAX_BUFFER = 64 * 1024 * 1024;
+const EXEC_OPTS = { maxBuffer: MAX_BUFFER } as const;
+
+/**
+ * A missing domain is a legitimate "empty" result, not a failure: `defaults`
+ * reports "Domain <x> does not exist" for one that was never written. Every
+ * OTHER export error (maxBuffer exceeded, `defaults` missing, permissions) is a
+ * real failure that must be surfaced, never swallowed into an empty snapshot.
+ */
+const isDomainMissingError = (error: unknown): boolean => {
+  const e = error as { stderr?: string; message?: string };
+  const text = `${e?.stderr ?? ''} ${e?.message ?? ''}`.toLowerCase();
+  return text.includes('does not exist');
+};
+
+const errorText = (error: unknown): string => {
+  const e = error as { stderr?: string; message?: string };
+  const stderr = (e?.stderr ?? '').trim();
+  return stderr || e?.message || String(error);
+};
+
 /** Map a supported scalar type to its `defaults write` flag. */
 const TYPE_FLAG: Record<SettingType, string> = {
   boolean: '-bool',
@@ -50,7 +80,7 @@ export class MacOsDefaultsBackend implements OsSettingsBackend {
 
   async currentOsVersion(): Promise<string> {
     try {
-      const { stdout } = await execFileAsync('sw_vers', ['-productVersion']);
+      const { stdout } = await execFileAsync('sw_vers', ['-productVersion'], EXEC_OPTS);
       return stdout.trim();
     } catch {
       return '';
@@ -60,7 +90,7 @@ export class MacOsDefaultsBackend implements OsSettingsBackend {
   async listDomains(): Promise<string[]> {
     let domains: string[] = [];
     try {
-      const { stdout } = await execFileAsync('defaults', ['domains']);
+      const { stdout } = await execFileAsync('defaults', ['domains'], EXEC_OPTS);
       domains = stdout
         .split(',')
         .map((d) => d.trim())
@@ -76,18 +106,25 @@ export class MacOsDefaultsBackend implements OsSettingsBackend {
 
   async exportRaw(domain: string): Promise<string> {
     try {
-      const { stdout } = await execFileAsync('defaults', ['export', domain, '-']);
+      const { stdout } = await execFileAsync('defaults', ['export', domain, '-'], EXEC_OPTS);
       return stdout;
-    } catch {
-      return '';
+    } catch (error) {
+      // A never-written domain is legitimately empty; anything else (maxBuffer
+      // exceeded, missing binary, permissions) is a real failure that must NOT
+      // be silently reported as an empty export — that would skip the pre-apply
+      // backup and produce delete-everything capture diffs.
+      if (isDomainMissingError(error)) return '';
+      throw new Error(`Failed to export defaults domain "${domain}": ${errorText(error)}`);
     }
   }
 
   async snapshotDomain(domain: string): Promise<DomainSnapshot> {
+    // exportRaw throws on a real export failure; let it propagate so capture
+    // surfaces the error instead of masquerading it as "no changes".
     const raw = await this.exportRaw(domain);
     if (!raw.trim()) {
-      // A domain with no preferences (or one that cannot be exported) is treated
-      // as empty rather than fatal — capture diffs against an empty snapshot.
+      // A domain with no preferences is treated as empty — capture diffs against
+      // an empty snapshot.
       return { domain, entries: new Map() };
     }
     try {
@@ -104,14 +141,14 @@ export class MacOsDefaultsBackend implements OsSettingsBackend {
 
   async apply(entry: SettingEntry): Promise<void> {
     const argv = buildDefaultsArgv(entry);
-    await execFileAsync('defaults', argv);
+    await execFileAsync('defaults', argv, EXEC_OPTS);
   }
 
   async restartApp(app: string): Promise<void> {
     // Best-effort: `killall` exits non-zero if the app is not running. That is
     // not an error for our purposes (nothing to restart), so swallow it.
     try {
-      await execFileAsync('killall', [app]);
+      await execFileAsync('killall', [app], EXEC_OPTS);
     } catch {
       /* app was not running */
     }

--- a/src/lib/osSettings/defaults.ts
+++ b/src/lib/osSettings/defaults.ts
@@ -1,0 +1,119 @@
+/**
+ * macOS backend for `tuck settings`, built on the `defaults` CLI.
+ *
+ * All process invocations go through `execFileAsync` (never a shell) so
+ * user/domain/key/value strings are passed as discrete argv entries and cannot
+ * be interpreted as shell syntax. Tests mock `child_process` to drive this
+ * backend without a real `defaults`/`sw_vers`/`killall`.
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { topLevelEntries } from './plist.js';
+import type { DomainSnapshot, ApplyOutcome, OsSettingsBackend } from './types.js';
+import type { SettingEntry, SettingType } from '../../schemas/osSettings.schema.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Map a supported scalar type to its `defaults write` flag. */
+const TYPE_FLAG: Record<SettingType, string> = {
+  boolean: '-bool',
+  integer: '-int',
+  float: '-float',
+  string: '-string',
+  date: '-date',
+};
+
+/**
+ * The "global" domain has a canonical name plus the `-g`/`-globalDomain`
+ * aliases; we always store and query it under NSGlobalDomain for stability.
+ */
+export const GLOBAL_DOMAIN = 'NSGlobalDomain';
+
+/** Build the argv (after `defaults`) that replays a stored setting entry. */
+export const buildDefaultsArgv = (entry: SettingEntry): string[] => {
+  if (entry.action === 'delete') {
+    return ['delete', entry.domain, entry.key];
+  }
+  if (!entry.type) {
+    throw new Error(`Setting "${entry.id}" is a write with no type`);
+  }
+  const flag = TYPE_FLAG[entry.type];
+  return ['write', entry.domain, entry.key, flag, entry.value ?? ''];
+};
+
+export class MacOsDefaultsBackend implements OsSettingsBackend {
+  readonly os = 'macos' as const;
+
+  async isAvailable(): Promise<boolean> {
+    return process.platform === 'darwin';
+  }
+
+  async currentOsVersion(): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync('sw_vers', ['-productVersion']);
+      return stdout.trim();
+    } catch {
+      return '';
+    }
+  }
+
+  async listDomains(): Promise<string[]> {
+    let domains: string[] = [];
+    try {
+      const { stdout } = await execFileAsync('defaults', ['domains']);
+      domains = stdout
+        .split(',')
+        .map((d) => d.trim())
+        .filter((d) => d.length > 0);
+    } catch {
+      domains = [];
+    }
+    // `defaults domains` omits the global domain; always include it so a
+    // full-system capture watches NSGlobalDomain too.
+    if (!domains.includes(GLOBAL_DOMAIN)) domains.unshift(GLOBAL_DOMAIN);
+    return domains;
+  }
+
+  async exportRaw(domain: string): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync('defaults', ['export', domain, '-']);
+      return stdout;
+    } catch {
+      return '';
+    }
+  }
+
+  async snapshotDomain(domain: string): Promise<DomainSnapshot> {
+    const raw = await this.exportRaw(domain);
+    if (!raw.trim()) {
+      // A domain with no preferences (or one that cannot be exported) is treated
+      // as empty rather than fatal — capture diffs against an empty snapshot.
+      return { domain, entries: new Map() };
+    }
+    try {
+      return { domain, entries: topLevelEntries(raw) };
+    } catch {
+      return { domain, entries: new Map() };
+    }
+  }
+
+  plan(entry: SettingEntry): ApplyOutcome {
+    const argv = buildDefaultsArgv(entry);
+    return { argv, display: `defaults ${argv.join(' ')}` };
+  }
+
+  async apply(entry: SettingEntry): Promise<void> {
+    const argv = buildDefaultsArgv(entry);
+    await execFileAsync('defaults', argv);
+  }
+
+  async restartApp(app: string): Promise<void> {
+    // Best-effort: `killall` exits non-zero if the app is not running. That is
+    // not an error for our purposes (nothing to restart), so swallow it.
+    try {
+      await execFileAsync('killall', [app]);
+    } catch {
+      /* app was not running */
+    }
+  }
+}

--- a/src/lib/osSettings/index.ts
+++ b/src/lib/osSettings/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Barrel + backend selection for `tuck settings`.
+ *
+ * `selectBackend()` returns the settings backend for the current platform. Only
+ * macOS is implemented in v1; other platforms return null so the command can
+ * emit a clear "not supported yet" message. Adding Linux/dconf later means
+ * adding a branch here and a new backend module — the command layer is
+ * unchanged.
+ */
+import { MacOsDefaultsBackend } from './defaults.js';
+import type { OsSettingsBackend } from './types.js';
+
+export * from './types.js';
+export * from './version.js';
+export * from './plist.js';
+export * from './capture.js';
+export * from './manifest.js';
+export * from './operations.js';
+export { MacOsDefaultsBackend, GLOBAL_DOMAIN, buildDefaultsArgv } from './defaults.js';
+
+/** Pick the settings backend for the current OS, or null if unsupported. */
+export const selectBackend = (
+  platform: NodeJS.Platform = process.platform
+): OsSettingsBackend | null => {
+  if (platform === 'darwin') return new MacOsDefaultsBackend();
+  return null;
+};

--- a/src/lib/osSettings/manifest.ts
+++ b/src/lib/osSettings/manifest.ts
@@ -1,0 +1,146 @@
+/**
+ * Read/write helpers for the two on-disk artifacts of `tuck settings`:
+ *   - the SHARED manifest (`os-settings.json`) committed to the tuck repo, and
+ *   - the MACHINE-LOCAL state (`os-settings-state.json`) in the platform state
+ *     dir, recording which manual steps are done on this machine only.
+ *
+ * Both are validated with zod on read: the manifest can be pulled from an
+ * untrusted remote, and the state file can be hand-edited, so neither is ever
+ * `as`-cast.
+ */
+import { join } from 'path';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { pathExists } from '../paths.js';
+import { getStateDir } from '../state.js';
+import { TuckError } from '../../errors.js';
+import {
+  osSettingsManifestSchema,
+  osSettingsStateSchema,
+  type OsSettingsManifest,
+  type OsSettingsState,
+} from '../../schemas/osSettings.schema.js';
+
+export const OS_SETTINGS_MANIFEST = 'os-settings.json';
+const OS_SETTINGS_STATE_FILE = 'os-settings-state.json';
+
+const emptyManifest = (): OsSettingsManifest => ({
+  version: '1',
+  settings: {},
+  manualSteps: {},
+});
+
+const emptyState = (): OsSettingsState => ({
+  version: '1',
+  manualDone: {},
+});
+
+export const osSettingsManifestPath = (tuckDir: string): string =>
+  join(tuckDir, OS_SETTINGS_MANIFEST);
+
+/**
+ * Load and validate the shared settings manifest. A MISSING file yields an
+ * empty manifest (first use). A file that exists but cannot be parsed or fails
+ * schema validation throws instead: every mutator does load→mutate→save, so
+ * degrading a corrupt or newer-version manifest to empty would make the next
+ * capture/remove silently WIPE all tracked settings.
+ */
+export const loadOsSettingsManifest = async (tuckDir: string): Promise<OsSettingsManifest> => {
+  const p = osSettingsManifestPath(tuckDir);
+  if (!(await pathExists(p))) return emptyManifest();
+  let raw: string;
+  try {
+    raw = await readFile(p, 'utf-8');
+  } catch {
+    throw new TuckError(
+      'Could not read the OS-settings manifest',
+      'OS_SETTINGS_MANIFEST_ERROR',
+      [`Check permissions on ${p}`]
+    );
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    throw new TuckError(
+      'The OS-settings manifest is not valid JSON',
+      'OS_SETTINGS_MANIFEST_ERROR',
+      [
+        `Inspect ${p} and fix or remove it`,
+        'Restore it from git history: git -C ~/.tuck checkout -- os-settings.json',
+      ]
+    );
+  }
+  const parsed = osSettingsManifestSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new TuckError(
+      'The OS-settings manifest failed validation (corrupt, or written by a newer tuck)',
+      'OS_SETTINGS_MANIFEST_ERROR',
+      [
+        'Upgrade tuck if this repo was written by a newer version (tuck upgrade)',
+        `Inspect ${p}: ${parsed.error.issues[0]?.message ?? 'schema mismatch'}`,
+      ]
+    );
+  }
+  return parsed.data;
+};
+
+export const saveOsSettingsManifest = async (
+  tuckDir: string,
+  manifest: OsSettingsManifest
+): Promise<void> => {
+  // Validate before writing so we never persist a malformed manifest.
+  const data = osSettingsManifestSchema.parse(manifest);
+  await writeFile(osSettingsManifestPath(tuckDir), JSON.stringify(data, null, 2) + '\n', 'utf-8');
+};
+
+export const osSettingsStatePath = (): string => join(getStateDir(), OS_SETTINGS_STATE_FILE);
+
+export const osSettingsBackupsDir = (): string => join(getStateDir(), 'os-settings-backups');
+
+const slugForFile = (s: string): string =>
+  s
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'domain';
+
+/**
+ * Persist a raw domain export into a timestamped backup batch directory so the
+ * user can restore the pre-apply state. Returns the written file path (or null
+ * when there was nothing to back up).
+ */
+export const writeDomainBackup = async (
+  batchDir: string,
+  domain: string,
+  raw: string
+): Promise<string | null> => {
+  if (!raw.trim()) return null;
+  await mkdir(batchDir, { recursive: true });
+  const file = join(batchDir, `${slugForFile(domain)}.plist`);
+  await writeFile(file, raw, 'utf-8');
+  return file;
+};
+
+/** A fresh backup batch directory path for one apply run. */
+export const newBackupBatchDir = (): string => {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  return join(osSettingsBackupsDir(), ts);
+};
+
+/** Load this machine's manual-step completion state (empty if absent/invalid). */
+export const loadOsSettingsState = async (): Promise<OsSettingsState> => {
+  const p = osSettingsStatePath();
+  if (!(await pathExists(p))) return emptyState();
+  try {
+    const parsed = osSettingsStateSchema.safeParse(JSON.parse(await readFile(p, 'utf-8')));
+    return parsed.success ? parsed.data : emptyState();
+  } catch {
+    return emptyState();
+  }
+};
+
+export const saveOsSettingsState = async (state: OsSettingsState): Promise<void> => {
+  const data = osSettingsStateSchema.parse(state);
+  const p = osSettingsStatePath();
+  await mkdir(getStateDir(), { recursive: true });
+  await writeFile(p, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+};

--- a/src/lib/osSettings/operations.ts
+++ b/src/lib/osSettings/operations.ts
@@ -4,7 +4,8 @@
  * unit-tested directly with a backend whose `defaults` calls are mocked.
  */
 import { settingId } from './capture.js';
-import { isVersionInRange } from './version.js';
+import { isVersionInRange, parseVersion } from './version.js';
+import { SettingsError } from '../../errors.js';
 import {
   loadOsSettingsManifest,
   saveOsSettingsManifest,
@@ -88,10 +89,28 @@ export interface SkippedSetting {
   id: string;
   reason: string;
 }
+export interface FailedSetting {
+  id: string;
+  display: string;
+  /** The underlying backend error message. */
+  error: string;
+}
+/** A setting whose captured OS major version differs from the current machine's. */
+export interface OsVersionMismatch {
+  id: string;
+  capturedOsVersion: string;
+}
 export interface ApplyResult {
   applied: AppliedSetting[];
   skipped: SkippedSetting[];
+  /** Entries whose `defaults` command failed mid-replay (real apply only). */
+  failed: FailedSetting[];
+  /** Apps actually restarted (empty in dry-run or when restart is disabled). */
   restarted: string[];
+  /** Apps the applied settings declare needing a restart to take effect. */
+  restartRequired: string[];
+  /** Applied entries captured on a different OS major version than the current. */
+  osVersionMismatch: OsVersionMismatch[];
   backupDir: string | null;
   pendingManual: { id: string; title: string }[];
 }
@@ -102,6 +121,11 @@ export interface ApplyOptions {
   restart?: boolean;
   /** If set, only apply settings whose id is in this list. */
   only?: string[];
+  /**
+   * Proceed even if a pre-apply domain backup cannot be taken. Off by default:
+   * a failed backup fails closed so we never write settings we cannot roll back.
+   */
+  force?: boolean;
 }
 
 /**
@@ -124,6 +148,7 @@ export const applySettings = async (
 
   const applied: AppliedSetting[] = [];
   const skipped: SkippedSetting[] = [];
+  const failed: FailedSetting[] = [];
   const restartApps = new Set<string>();
 
   // Decide which entries pass their version guard up front so we only back up
@@ -138,13 +163,35 @@ export const applySettings = async (
     toApply.push(entry);
   }
 
-  // Backup affected domains (real apply only).
+  // Warn (do not block) when a setting was captured on a different OS MAJOR
+  // version than the one we are applying on: minor `defaults` semantics shift
+  // between major macOS releases, so the replay may not do what was intended.
+  const osVersionMismatch = computeOsVersionMismatch(opts.currentVersion, toApply);
+
+  // Backup affected domains before writing anything (real apply only). A backup
+  // that fails to export is fatal by default: we refuse to mutate settings we
+  // cannot roll back. `force` downgrades this to a skipped backup.
   let backupDir: string | null = null;
   if (!opts.dryRun && toApply.length > 0) {
     backupDir = newBackupBatchDir();
     const domains = new Set(toApply.map((e) => e.domain));
     for (const domain of domains) {
-      const raw = await backend.exportRaw(domain);
+      let raw: string;
+      try {
+        raw = await backend.exportRaw(domain);
+      } catch (error) {
+        if (!opts.force) {
+          throw new SettingsError(
+            `Could not back up domain "${domain}" before applying: ${errMessage(error)}`,
+            [
+              'No settings were changed — the domain could not be safely backed up first',
+              'Re-run with --force to apply anyway (WITHOUT a pre-apply backup of this domain)',
+            ]
+          );
+        }
+        // force: proceed without a backup for this domain.
+        continue;
+      }
       await writeDomainBackup(backupDir, domain, raw);
     }
   }
@@ -152,12 +199,23 @@ export const applySettings = async (
   for (const entry of toApply) {
     const plan = backend.plan(entry);
     if (!opts.dryRun) {
-      await backend.apply(entry);
+      try {
+        await backend.apply(entry);
+      } catch (error) {
+        // Record the failure and keep going so the caller gets a complete
+        // applied/failed report (backups already exist on disk) instead of an
+        // exception that discards everything done so far.
+        failed.push({ id: entry.id, display: plan.display, error: errMessage(error) });
+        continue;
+      }
     }
     applied.push({ id: entry.id, display: plan.display });
     for (const app of entry.restartApps) restartApps.add(app);
   }
 
+  // Apps declared by settings that actually applied — what needs a restart to
+  // take effect, whether or not we perform the restart ourselves.
+  const restartRequired = [...restartApps];
   const restarted: string[] = [];
   if (opts.restart && !opts.dryRun) {
     for (const app of restartApps) {
@@ -174,10 +232,42 @@ export const applySettings = async (
   return {
     applied,
     skipped,
-    restarted: opts.restart ? restarted : [...restartApps],
+    failed,
+    // Report only the apps we truly restarted; `restartRequired` carries the
+    // list to restart manually when restart is disabled or in dry-run.
+    restarted,
+    restartRequired,
+    osVersionMismatch,
     backupDir,
     pendingManual,
   };
+};
+
+/** Best-effort message extraction from an unknown thrown value. */
+const errMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * Flag applied entries whose captured OS major version differs from the current
+ * machine's. Blank versions on either side are skipped (nothing to compare).
+ */
+const computeOsVersionMismatch = (
+  currentVersion: string,
+  entries: SettingEntry[]
+): OsVersionMismatch[] => {
+  const cur = currentVersion.trim();
+  if (!cur) return [];
+  const currentMajor = parseVersion(cur)[0] ?? 0;
+  const out: OsVersionMismatch[] = [];
+  for (const entry of entries) {
+    const captured = entry.capturedOsVersion?.trim();
+    if (!captured) continue;
+    const capturedMajor = parseVersion(captured)[0] ?? 0;
+    if (capturedMajor !== currentMajor) {
+      out.push({ id: entry.id, capturedOsVersion: captured });
+    }
+  }
+  return out;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/osSettings/operations.ts
+++ b/src/lib/osSettings/operations.ts
@@ -1,0 +1,234 @@
+/**
+ * Stateful operations for `tuck settings` that combine a backend with the
+ * on-disk manifest/state. Kept separate from the Commander layer so they can be
+ * unit-tested directly with a backend whose `defaults` calls are mocked.
+ */
+import { settingId } from './capture.js';
+import { isVersionInRange } from './version.js';
+import {
+  loadOsSettingsManifest,
+  saveOsSettingsManifest,
+  loadOsSettingsState,
+  saveOsSettingsState,
+  newBackupBatchDir,
+  writeDomainBackup,
+} from './manifest.js';
+import type { OsSettingsBackend } from './types.js';
+import type {
+  SettingEntry,
+  SettingType,
+  SettingAction,
+  ManualStep,
+  SettingsOs,
+} from '../../schemas/osSettings.schema.js';
+
+export interface RecordSettingInput {
+  os: SettingsOs;
+  domain: string;
+  key: string;
+  action: SettingAction;
+  type?: SettingType;
+  value?: string;
+  description?: string;
+  capturedOsVersion?: string;
+  minVersion?: string | null;
+  maxVersion?: string | null;
+  restartApps?: string[];
+}
+
+/**
+ * Upsert a captured setting into the shared manifest. Re-capturing the same
+ * (os, domain, key) updates the value/type in place and preserves the original
+ * `added` timestamp.
+ */
+export const recordSetting = async (
+  tuckDir: string,
+  input: RecordSettingInput
+): Promise<{ id: string; entry: SettingEntry; created: boolean }> => {
+  const id = settingId(input.os, input.domain, input.key);
+  const now = new Date().toISOString();
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  const existing = manifest.settings[id];
+
+  const entry: SettingEntry = {
+    id,
+    os: input.os,
+    description: input.description ?? existing?.description ?? '',
+    domain: input.domain,
+    key: input.key,
+    action: input.action,
+    type: input.action === 'write' ? input.type : undefined,
+    value: input.action === 'write' ? input.value : undefined,
+    capturedOsVersion: input.capturedOsVersion ?? existing?.capturedOsVersion ?? '',
+    minVersion: input.minVersion ?? existing?.minVersion ?? null,
+    maxVersion: input.maxVersion ?? existing?.maxVersion ?? null,
+    restartApps: input.restartApps ?? existing?.restartApps ?? [],
+    added: existing?.added ?? now,
+    modified: now,
+  };
+
+  manifest.settings[id] = entry;
+  await saveOsSettingsManifest(tuckDir, manifest);
+  return { id, entry, created: !existing };
+};
+
+export const removeSetting = async (tuckDir: string, id: string): Promise<boolean> => {
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  if (!manifest.settings[id]) return false;
+  delete manifest.settings[id];
+  await saveOsSettingsManifest(tuckDir, manifest);
+  return true;
+};
+
+export interface AppliedSetting {
+  id: string;
+  display: string;
+}
+export interface SkippedSetting {
+  id: string;
+  reason: string;
+}
+export interface ApplyResult {
+  applied: AppliedSetting[];
+  skipped: SkippedSetting[];
+  restarted: string[];
+  backupDir: string | null;
+  pendingManual: { id: string; title: string }[];
+}
+
+export interface ApplyOptions {
+  currentVersion: string;
+  dryRun?: boolean;
+  restart?: boolean;
+  /** If set, only apply settings whose id is in this list. */
+  only?: string[];
+}
+
+/**
+ * Apply tracked settings for the backend's OS, honoring per-entry version
+ * guards. Backs up each affected domain before writing (unless dry-run) and,
+ * when `restart` is set, restarts each app the applied settings declare.
+ */
+export const applySettings = async (
+  backend: OsSettingsBackend,
+  tuckDir: string,
+  opts: ApplyOptions
+): Promise<ApplyResult> => {
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  const onlySet = opts.only ? new Set(opts.only) : null;
+
+  const entries = Object.values(manifest.settings)
+    .filter((e) => e.os === backend.os)
+    .filter((e) => (onlySet ? onlySet.has(e.id) : true))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  const applied: AppliedSetting[] = [];
+  const skipped: SkippedSetting[] = [];
+  const restartApps = new Set<string>();
+
+  // Decide which entries pass their version guard up front so we only back up
+  // the domains we are actually going to touch.
+  const toApply: SettingEntry[] = [];
+  for (const entry of entries) {
+    const guard = isVersionInRange(opts.currentVersion, entry.minVersion, entry.maxVersion);
+    if (!guard.ok) {
+      skipped.push({ id: entry.id, reason: guard.reason ?? 'version guard failed' });
+      continue;
+    }
+    toApply.push(entry);
+  }
+
+  // Backup affected domains (real apply only).
+  let backupDir: string | null = null;
+  if (!opts.dryRun && toApply.length > 0) {
+    backupDir = newBackupBatchDir();
+    const domains = new Set(toApply.map((e) => e.domain));
+    for (const domain of domains) {
+      const raw = await backend.exportRaw(domain);
+      await writeDomainBackup(backupDir, domain, raw);
+    }
+  }
+
+  for (const entry of toApply) {
+    const plan = backend.plan(entry);
+    if (!opts.dryRun) {
+      await backend.apply(entry);
+    }
+    applied.push({ id: entry.id, display: plan.display });
+    for (const app of entry.restartApps) restartApps.add(app);
+  }
+
+  const restarted: string[] = [];
+  if (opts.restart && !opts.dryRun) {
+    for (const app of restartApps) {
+      await backend.restartApp(app);
+      restarted.push(app);
+    }
+  }
+
+  const state = await loadOsSettingsState();
+  const pendingManual = Object.values(manifest.manualSteps)
+    .filter((m) => m.os === backend.os && !state.manualDone[m.id])
+    .map((m) => ({ id: m.id, title: m.title }));
+
+  return {
+    applied,
+    skipped,
+    restarted: opts.restart ? restarted : [...restartApps],
+    backupDir,
+    pendingManual,
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Manual steps
+// ─────────────────────────────────────────────────────────────────────────────
+
+const manualId = (os: string, title: string): string => {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return `${os}__manual__${slug || 'step'}`;
+};
+
+export const addManualStep = async (
+  tuckDir: string,
+  input: { os: SettingsOs; title: string; instructions?: string }
+): Promise<{ id: string; step: ManualStep; created: boolean }> => {
+  const id = manualId(input.os, input.title);
+  const now = new Date().toISOString();
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  const existing = manifest.manualSteps[id];
+  const step: ManualStep = {
+    id,
+    os: input.os,
+    title: input.title,
+    instructions: input.instructions ?? existing?.instructions ?? '',
+    added: existing?.added ?? now,
+    modified: now,
+  };
+  manifest.manualSteps[id] = step;
+  await saveOsSettingsManifest(tuckDir, manifest);
+  return { id, step, created: !existing };
+};
+
+export const removeManualStep = async (tuckDir: string, id: string): Promise<boolean> => {
+  const manifest = await loadOsSettingsManifest(tuckDir);
+  if (!manifest.manualSteps[id]) return false;
+  delete manifest.manualSteps[id];
+  await saveOsSettingsManifest(tuckDir, manifest);
+  return true;
+};
+
+/** Mark or unmark a manual step as done on THIS machine (state dir, not repo). */
+export const setManualDone = async (id: string, done: boolean): Promise<void> => {
+  const state = await loadOsSettingsState();
+  if (done) {
+    state.manualDone[id] = new Date().toISOString();
+  } else {
+    delete state.manualDone[id];
+  }
+  await saveOsSettingsState(state);
+};

--- a/src/lib/osSettings/plist.ts
+++ b/src/lib/osSettings/plist.ts
@@ -1,0 +1,206 @@
+/**
+ * A focused parser for the XML property lists that `defaults export <domain> -`
+ * emits. We only need enough of the format to answer two questions during
+ * capture: which top-level preference keys exist, and did a given key's value
+ * change between two snapshots. We therefore parse the standard Apple plist XML
+ * into a plain JS value tree and expose a canonical, stable string per top-level
+ * key for diffing.
+ *
+ * This is deliberately NOT a general-purpose plist library — it handles the tag
+ * vocabulary Apple's exporter uses (dict/array/key/string/integer/real/true/
+ * false/date/data) and decodes the five predefined XML entities. Anything it
+ * cannot classify becomes a string, which is safe for diffing (a change is still
+ * detected) even if the type inference then declines to auto-apply it.
+ */
+
+export type PlistScalar =
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'integer'; value: number }
+  | { kind: 'real'; value: number }
+  | { kind: 'string'; value: string }
+  | { kind: 'date'; value: string }
+  | { kind: 'data'; value: string };
+
+export type PlistValue =
+  | PlistScalar
+  | { kind: 'dict'; value: Map<string, PlistValue> }
+  | { kind: 'array'; value: PlistValue[] };
+
+type Token =
+  | { t: 'open'; name: string; selfClose: boolean }
+  | { t: 'close'; name: string }
+  | { t: 'text'; value: string };
+
+const decodeEntities = (s: string): string =>
+  s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    // Ampersand last so we don't double-decode e.g. "&amp;lt;".
+    .replace(/&amp;/g, '&');
+
+/** Tokenize plist XML into a flat tag/text stream, skipping the XML prolog. */
+const tokenize = (xml: string): Token[] => {
+  const tokens: Token[] = [];
+  const re = /<([^>]*)>/g;
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) {
+    // Capture any text between the previous tag and this one.
+    const text = xml.slice(lastIndex, m.index);
+    if (text.trim().length > 0) {
+      tokens.push({ t: 'text', value: decodeEntities(text) });
+    }
+    lastIndex = re.lastIndex;
+
+    const inner = m[1].trim();
+    // Skip declarations, doctypes, comments, and processing instructions.
+    if (inner.startsWith('?') || inner.startsWith('!')) continue;
+
+    if (inner.startsWith('/')) {
+      tokens.push({ t: 'close', name: inner.slice(1).trim() });
+      continue;
+    }
+    const selfClose = inner.endsWith('/');
+    const body = selfClose ? inner.slice(0, -1).trim() : inner;
+    const name = body.split(/\s/)[0];
+    tokens.push({ t: 'open', name, selfClose });
+  }
+  return tokens;
+};
+
+class Cursor {
+  private i = 0;
+  constructor(private readonly tokens: Token[]) {}
+  peek(): Token | undefined {
+    return this.tokens[this.i];
+  }
+  next(): Token | undefined {
+    return this.tokens[this.i++];
+  }
+}
+
+const parseValue = (cur: Cursor): PlistValue => {
+  const open = cur.next();
+  if (!open || open.t !== 'open') {
+    throw new Error('Malformed plist: expected a value element');
+  }
+
+  const readText = (closeName: string): string => {
+    let text = '';
+    for (;;) {
+      const tok = cur.next();
+      if (!tok) throw new Error(`Malformed plist: unterminated <${closeName}>`);
+      if (tok.t === 'text') text += tok.value;
+      else if (tok.t === 'close' && tok.name === closeName) break;
+      else throw new Error(`Malformed plist: unexpected token in <${closeName}>`);
+    }
+    return text;
+  };
+
+  switch (open.name) {
+    case 'true':
+      return { kind: 'boolean', value: true };
+    case 'false':
+      return { kind: 'boolean', value: false };
+    case 'string':
+      return { kind: 'string', value: open.selfClose ? '' : readText('string') };
+    case 'integer': {
+      const raw = open.selfClose ? '0' : readText('integer');
+      return { kind: 'integer', value: Number.parseInt(raw.trim(), 10) };
+    }
+    case 'real': {
+      const raw = open.selfClose ? '0' : readText('real');
+      return { kind: 'real', value: Number.parseFloat(raw.trim()) };
+    }
+    case 'date':
+      return { kind: 'date', value: open.selfClose ? '' : readText('date').trim() };
+    case 'data':
+      return { kind: 'data', value: open.selfClose ? '' : readText('data').replace(/\s+/g, '') };
+    case 'dict': {
+      const map = new Map<string, PlistValue>();
+      if (open.selfClose) return { kind: 'dict', value: map };
+      for (;;) {
+        const tok = cur.peek();
+        if (!tok) throw new Error('Malformed plist: unterminated <dict>');
+        if (tok.t === 'close' && tok.name === 'dict') {
+          cur.next();
+          break;
+        }
+        // Expect <key>...</key>
+        const keyOpen = cur.next();
+        if (!keyOpen || keyOpen.t !== 'open' || keyOpen.name !== 'key') {
+          throw new Error('Malformed plist: expected <key> in <dict>');
+        }
+        const keyName = keyOpen.selfClose ? '' : readText('key');
+        const value = parseValue(cur);
+        map.set(keyName, value);
+      }
+      return { kind: 'dict', value: map };
+    }
+    case 'array': {
+      const items: PlistValue[] = [];
+      if (open.selfClose) return { kind: 'array', value: items };
+      for (;;) {
+        const tok = cur.peek();
+        if (!tok) throw new Error('Malformed plist: unterminated <array>');
+        if (tok.t === 'close' && tok.name === 'array') {
+          cur.next();
+          break;
+        }
+        items.push(parseValue(cur));
+      }
+      return { kind: 'array', value: items };
+    }
+    default:
+      // Unknown scalar-ish element: consume any text up to its close and treat
+      // as a string so diffing still works.
+      if (open.selfClose) return { kind: 'string', value: '' };
+      return { kind: 'string', value: readText(open.name) };
+  }
+};
+
+/** Parse a full plist document and return its root value. */
+export const parsePlist = (xml: string): PlistValue => {
+  const tokens = tokenize(xml);
+  const cur = new Cursor(tokens);
+  // Advance to the <plist> wrapper, then parse its single child value.
+  for (;;) {
+    const tok = cur.peek();
+    if (!tok) throw new Error('Malformed plist: no <plist> root');
+    if (tok.t === 'open' && tok.name === 'plist') {
+      cur.next();
+      break;
+    }
+    cur.next();
+  }
+  return parseValue(cur);
+};
+
+/** A canonical, order-stable serialization used purely to diff two snapshots. */
+export const stableStringify = (value: PlistValue): string => {
+  switch (value.kind) {
+    case 'dict': {
+      const parts = [...value.value.entries()]
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+      return `{${parts.join(',')}}`;
+    }
+    case 'array':
+      return `[${value.value.map(stableStringify).join(',')}]`;
+    default:
+      return `${value.kind}(${JSON.stringify(value.value)})`;
+  }
+};
+
+/**
+ * Extract the top-level preference entries from an exported domain plist.
+ * Returns a map of key -> parsed value for the root `<dict>`. A domain whose
+ * root is not a dict (empty domain, or an array root) yields an empty map.
+ */
+export const topLevelEntries = (xml: string): Map<string, PlistValue> => {
+  const root = parsePlist(xml);
+  if (root.kind !== 'dict') return new Map();
+  return root.value;
+};

--- a/src/lib/osSettings/types.ts
+++ b/src/lib/osSettings/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Backend abstraction for `tuck settings`.
+ *
+ * v1 ships one backend (macOS `defaults`). The interface is the seam that lets a
+ * Linux/dconf backend be added later without touching the command layer: the
+ * command talks only to `OsSettingsBackend`, and `selectBackend()` picks the
+ * implementation for the current platform.
+ */
+import type { PlistValue } from './plist.js';
+import type { SettingEntry, SettingType, SettingsOs } from '../../schemas/osSettings.schema.js';
+
+/** A point-in-time snapshot of one settings domain's top-level entries. */
+export interface DomainSnapshot {
+  domain: string;
+  /** Top-level key -> parsed value. Backend-specific value shape. */
+  entries: Map<string, PlistValue>;
+}
+
+/** A single detected change between two snapshots of a domain. */
+export interface CapturedChange {
+  domain: string;
+  key: string;
+  action: 'write' | 'delete';
+  /** Present for action=write. Undefined means the value type is unsupported. */
+  type?: SettingType;
+  /** String form for the write command; present for supported write changes. */
+  value?: string;
+  /**
+   * True when the value changed but its type (dict/array/data) is not something
+   * v1 can safely replay. The change is surfaced to the user as a candidate
+   * manual step rather than an auto-applied write.
+   */
+  unsupported?: boolean;
+}
+
+export interface ApplyOutcome {
+  /** The argv (after the base command) that was or would be run. */
+  argv: string[];
+  /** Human-readable command string for display/audit. */
+  display: string;
+}
+
+/**
+ * A settings backend for one OS family. All methods that shell out are async so
+ * they can be mocked in tests without a real `defaults`/`sw_vers`/`killall`.
+ */
+export interface OsSettingsBackend {
+  readonly os: SettingsOs;
+  /** True when this backend can run on the current machine. */
+  isAvailable(): Promise<boolean>;
+  /** Current OS product version, e.g. "15.1"; empty string if undetectable. */
+  currentOsVersion(): Promise<string>;
+  /** All settings domains present on the machine (for a full-system capture). */
+  listDomains(): Promise<string[]>;
+  /** Snapshot one domain's top-level entries. */
+  snapshotDomain(domain: string): Promise<DomainSnapshot>;
+  /** Raw serialized form of a domain (for pre-apply backups); '' if empty. */
+  exportRaw(domain: string): Promise<string>;
+  /** Compute the applyable command for a stored setting entry. */
+  plan(entry: SettingEntry): ApplyOutcome;
+  /** Execute a stored setting entry (write or delete). */
+  apply(entry: SettingEntry): Promise<void>;
+  /** Restart an application so a setting takes effect (best-effort). */
+  restartApp(app: string): Promise<void>;
+}

--- a/src/lib/osSettings/version.ts
+++ b/src/lib/osSettings/version.ts
@@ -1,0 +1,68 @@
+/**
+ * OS-version comparison for apply-mode guards.
+ *
+ * macOS product versions are dotted numeric strings ("15", "15.1", "13.6.1").
+ * We compare them component-wise as integers so a setting captured on 15.1 can
+ * declare a `minVersion`/`maxVersion` window and apply mode can decide whether
+ * the current machine falls inside it. Non-numeric noise is ignored rather than
+ * throwing — a malformed version must never crash apply, only fail the guard.
+ */
+
+/** Parse a dotted version into an integer tuple, ignoring non-numeric parts. */
+export const parseVersion = (version: string): number[] => {
+  return version
+    .trim()
+    .split('.')
+    .map((part) => {
+      const n = Number.parseInt(part, 10);
+      return Number.isFinite(n) ? n : 0;
+    });
+};
+
+/**
+ * Compare two dotted versions.
+ * @returns negative if a < b, 0 if equal, positive if a > b.
+ */
+export const compareVersions = (a: string, b: string): number => {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+};
+
+export interface VersionGuardResult {
+  ok: boolean;
+  /** Human-readable reason when `ok` is false. */
+  reason?: string;
+}
+
+/**
+ * Check whether `current` satisfies the inclusive [min, max] window. A missing
+ * or empty bound means "unbounded on that side". An empty/blank `current`
+ * version passes (we cannot prove it fails a guard, and blocking on an
+ * undetectable OS version would be more surprising than allowing it).
+ */
+export const isVersionInRange = (
+  current: string,
+  minVersion?: string | null,
+  maxVersion?: string | null
+): VersionGuardResult => {
+  const cur = current.trim();
+  if (!cur) return { ok: true };
+
+  const min = minVersion?.trim();
+  if (min && compareVersions(cur, min) < 0) {
+    return { ok: false, reason: `requires OS >= ${min} (current ${cur})` };
+  }
+
+  const max = maxVersion?.trim();
+  if (max && compareVersions(cur, max) > 0) {
+    return { ok: false, reason: `requires OS <= ${max} (current ${cur})` };
+  }
+
+  return { ok: true };
+};

--- a/src/lib/readOnlyMode.ts
+++ b/src/lib/readOnlyMode.ts
@@ -1,0 +1,70 @@
+/**
+ * Read-only guarantee for inspection commands.
+ *
+ * `tuck status`, `tuck diff`, and `tuck list` promise NEVER to touch a secret
+ * backend (1Password/Bitwarden/pass/local external) and NEVER to trigger a
+ * keystore unlock prompt. They only READ what is already on disk. This module
+ * is the single, process-global switch that enforces that promise:
+ *
+ *   - Inspection commands call {@link enterReadOnlyMode} at the top of their run.
+ *   - The keystore accessor ({@link keystorePassphrase}) and the secret resolver
+ *     consult {@link isReadOnlyMode}. When it is on, they refuse to reach out to
+ *     the OS keystore or an external backend — returning a cached value or
+ *     nothing at all, so no interactive prompt can ever appear.
+ *   - {@link assertNotReadOnly} is a defensive guard: any code path that would
+ *     touch a backend from within a read-only command throws instead of silently
+ *     prompting, so a future regression fails loudly in tests rather than nagging
+ *     the user in production.
+ *
+ * The flag is deliberately a plain module-level boolean (one CLI invocation runs
+ * exactly one command), mirroring how `jsonOutput` tracks JSON mode.
+ */
+
+import { ReadOnlyViolationError } from '../errors.js';
+
+let readOnly = false;
+
+/**
+ * Enter read-only mode for the remainder of this process. Idempotent. Called by
+ * inspection commands (status/diff/list) before they read any tracked state.
+ */
+export const enterReadOnlyMode = (): void => {
+  readOnly = true;
+};
+
+/** Whether the current command has declared itself read-only. */
+export const isReadOnlyMode = (): boolean => readOnly;
+
+/**
+ * Reset read-only mode. Intended for tests and long-lived hosts (e.g. the MCP
+ * server) that run many logical commands in one process.
+ */
+export const resetReadOnlyMode = (): void => {
+  readOnly = false;
+};
+
+/**
+ * Throw {@link ReadOnlyViolationError} if a secret-backend / keystore-unlocking
+ * operation is attempted while read-only mode is active. `operation` names the
+ * thing that was blocked so the error message is actionable.
+ */
+export const assertNotReadOnly = (operation: string): void => {
+  if (readOnly) {
+    throw new ReadOnlyViolationError(operation);
+  }
+};
+
+/**
+ * Run `fn` with read-only mode forced on, restoring the previous state
+ * afterwards. Useful for tests and for embedding an inspection routine inside a
+ * larger command without leaking the flag.
+ */
+export const withReadOnlyMode = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const previous = readOnly;
+  readOnly = true;
+  try {
+    return await fn();
+  } finally {
+    readOnly = previous;
+  }
+};

--- a/src/lib/rulesFanout.ts
+++ b/src/lib/rulesFanout.ts
@@ -207,18 +207,36 @@ export interface TrackOptions {
   template?: boolean;
   /** Extra template variables. */
   variables?: Record<string, string>;
+  /**
+   * Consent gate for removing a variant orphaned by dropping its tool on
+   * re-track. Return true to delete. Omitted → non-interactive: orphans are left
+   * in place unless {@link TrackOptions.force} is set.
+   */
+  confirmRemove?: (liveTarget: string) => Promise<boolean>;
+  /** Remove orphaned variants without confirming (non-interactive `--yes`). */
+  force?: boolean;
+}
+
+export interface TrackResult {
+  id: string;
+  set: RuleSet;
+  /** Live targets removed because their tool was dropped on re-track. */
+  orphansRemoved: string[];
+  /** Live targets left in place (foreign/hand-edited or consent declined). */
+  orphansSkipped: string[];
 }
 
 /**
  * Track (or update) a canonical rules file. Records the set in rules.json but
  * writes NO tool variants — that is `tuck rules apply`, which has its own
- * consent + snapshot flow.
+ * consent + snapshot flow. Re-tracking that DROPS a tool cleans up that tool's
+ * previously fanned-out variant (consent-gated) so it does not silently orphan.
  */
 export const trackRuleSet = async (
   tuckDir: string,
   inputPath: string,
   opts: TrackOptions = {}
-): Promise<{ id: string; set: RuleSet }> => {
+): Promise<TrackResult> => {
   // expandPath handles ~, absolute, and relative inputs WITHOUT stamping the
   // host drive letter onto drive-less absolute paths the way win32 resolve()
   // does (D:\test-home\... breaking home confinement checks on Windows).
@@ -251,6 +269,26 @@ export const trackRuleSet = async (
   }
   const tools: RuleTool[] = toolNames.map((tool) => ({ tool, strategy }));
 
+  // Reject any tool whose resolved write destination IS the canonical source —
+  // regardless of how the tool was selected (explicit --tool bypassed the
+  // default self-target guard). Fanning `agents` onto AGENTS.md would, on apply,
+  // either symlink the source to itself (ELOOP, content destroyed) or overwrite
+  // it with rendered output (template markers stripped).
+  const srcResolved = resolve(absPath);
+  for (const tool of tools) {
+    const targetAbs = resolve(join(root, toolRelativePath(tool)));
+    if (targetAbs === srcResolved) {
+      throw new TuckError(
+        `Tool "${tool.tool}" would fan out onto the canonical source itself (${collapsePath(absPath)})`,
+        'RULES_SELF_TARGET',
+        [
+          `Drop "${tool.tool}" from --tool — its destination is the source file.`,
+          'Fanning a tool onto its own source would destroy the canonical content.',
+        ]
+      );
+    }
+  }
+
   const now = new Date().toISOString();
   const set: RuleSet = {
     source,
@@ -266,9 +304,93 @@ export const trackRuleSet = async (
 
   const manifest = await loadRulesManifest(tuckDir);
   const existing = manifest.sets[id];
+
+  // Re-tracking replaces the tool list wholesale; a tool present before but
+  // absent now would otherwise leave its generated variant orphaned on disk
+  // (invisible to `list` and `untrack --clean`). Clean those up, consent-gated.
+  let orphansRemoved: string[] = [];
+  let orphansSkipped: string[] = [];
+  if (existing) {
+    const stillTracked = (t: RuleTool): boolean =>
+      tools.some((n) => n.tool === t.tool && (n.path ?? '') === (t.path ?? ''));
+    const dropped = existing.tools.filter((t) => !stillTracked(t));
+    const cleanup = await cleanupOrphanedVariants(tuckDir, existing, dropped, opts);
+    orphansRemoved = cleanup.removed;
+    orphansSkipped = cleanup.skipped;
+  }
+
   manifest.sets[id] = existing ? { ...set, added: existing.added } : set;
   await saveRulesManifest(tuckDir, manifest);
-  return { id, set: manifest.sets[id] };
+  return { id, set: manifest.sets[id], orphansRemoved, orphansSkipped };
+};
+
+/**
+ * Remove the on-disk variants for tools dropped from a set on re-track. A variant
+ * that is foreign/hand-edited (per {@link toolStatus}) is never deleted; others
+ * require consent (`confirmRemove` or `force`). Everything removed is snapshotted
+ * first so `tuck undo` can bring it back.
+ */
+const cleanupOrphanedVariants = async (
+  tuckDir: string,
+  oldSet: RuleSet,
+  dropped: RuleTool[],
+  opts: TrackOptions
+): Promise<{ removed: string[]; skipped: string[] }> => {
+  const removed: string[] = [];
+  const skipped: string[] = [];
+  if (dropped.length === 0) return { removed, skipped };
+
+  const base = await buildRulesContext(tuckDir);
+  const srcAbs = sourceAbsolute(oldSet);
+  const sourceExists = await pathExists(srcAbs);
+  const sourceText = sourceExists ? await readFile(srcAbs, 'utf-8').catch(() => '') : '';
+
+  const toRemove: { writeTarget: string; liveTarget: string }[] = [];
+  for (const tool of dropped) {
+    const writeTarget = toolWriteTarget(oldSet, tool);
+    const liveTarget = toolLiveTarget(oldSet, tool);
+    if (!(await lstatExists(writeTarget))) continue;
+    const status = await toolStatus(
+      oldSet,
+      tool,
+      writeTarget,
+      srcAbs,
+      sourceText,
+      sourceExists,
+      base
+    );
+    if (status === 'foreign') {
+      // Not a file we generated — never delete a hand-edited/foreign file.
+      skipped.push(liveTarget);
+      continue;
+    }
+    const allowed = opts.force
+      ? true
+      : opts.confirmRemove
+        ? await opts.confirmRemove(liveTarget)
+        : false;
+    if (!allowed) {
+      skipped.push(liveTarget);
+      continue;
+    }
+    toRemove.push({ writeTarget, liveTarget });
+  }
+
+  if (toRemove.length > 0) {
+    await createSnapshot(
+      toRemove.map((t) => t.writeTarget),
+      `Pre rules-retrack cleanup: ${oldSet.source}`
+    ).catch(() => undefined);
+    for (const t of toRemove) {
+      try {
+        await removeVariantPath(t.writeTarget);
+        removed.push(t.liveTarget);
+      } catch {
+        skipped.push(t.liveTarget);
+      }
+    }
+  }
+  return { removed, skipped };
 };
 
 /** Remove a tracked set. Returns the removed set (or null if absent). */
@@ -379,7 +501,10 @@ const toolStatus = async (
   if (link !== null) return 'foreign'; // a symlink where a real file is expected
   if (!sourceExists) return 'drift';
   const expected = renderToolContent(sourceText, set, tool.tool, base);
-  const actual = await readFile(target, 'utf-8');
+  // A directory or an unreadable file (EISDIR/EACCES) at the variant path is not
+  // something we generated — report it as foreign rather than crashing `list`.
+  const actual = await readFile(target, 'utf-8').catch(() => null);
+  if (actual === null) return 'foreign';
   return actual === expected ? 'in-sync' : 'drift';
 };
 
@@ -397,6 +522,12 @@ export interface ApplyToolResult {
 export interface ApplySetResult {
   id: string;
   applied: ApplyToolResult[];
+  /**
+   * Set-level failure (missing source, unusable repoRoot, unexpected error).
+   * Present iff the set could NOT be applied; `applied` is then empty. One failed
+   * set never blocks the others — the caller reports errors and exits non-zero.
+   */
+  error?: string;
 }
 
 export interface ApplyRulesOptions {
@@ -436,17 +567,76 @@ export const applyRuleSets = async (
     }
   }
 
-  // Register repo roots so repo-scoped writes pass destination validation.
-  const repoRoots = entries
-    .map(([, s]) => s.repoRoot)
+  // Validate each set's repoRoot BEFORE trusting it into the write sandbox. A
+  // hostile rules.json could name repoRoot "/" (plus a relative override) to
+  // create files anywhere writable; and a repo-scoped set whose absolute root
+  // simply doesn't exist on THIS machine must be skipped, not crash the run.
+  interface Decision {
+    id: string;
+    set: RuleSet;
+    error?: string;
+  }
+  const decisions: Decision[] = [];
+  for (const [id, set] of entries) {
+    if (set.scope === 'repo') {
+      const why = await repoRootRejection(set.repoRoot);
+      if (why) {
+        decisions.push({ id, set, error: why });
+        continue;
+      }
+    }
+    decisions.push({ id, set });
+  }
+
+  // Register ONLY the validated repo roots so repo-scoped writes pass
+  // destination validation — never an unvalidated manifest-supplied root.
+  const repoRoots = decisions
+    .filter((d) => !d.error && d.set.scope === 'repo')
+    .map((d) => d.set.repoRoot)
     .filter((r): r is string => typeof r === 'string');
   if (repoRoots.length > 0) addKnownRepoRoots(repoRoots);
 
+  // Per-set isolation: a failed set (missing source, bad repoRoot, thrown error)
+  // is recorded and reported, but never blocks the remaining sets.
   const results: ApplySetResult[] = [];
-  for (const [id, set] of entries) {
-    results.push(await applyOneSet(id, set, opts));
+  for (const d of decisions) {
+    if (d.error) {
+      results.push({ id: d.id, applied: [], error: d.error });
+      continue;
+    }
+    try {
+      results.push(await applyOneSet(d.id, d.set, opts));
+    } catch (err) {
+      results.push({
+        id: d.id,
+        applied: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
   return results;
+};
+
+/**
+ * Reason a manifest-supplied repoRoot must NOT be trusted, or null if it is a
+ * genuine, present git repository on this machine. Rejects the filesystem root
+ * and the user's home directory outright (a `.git` there would still be far too
+ * broad a write scope), anything that is not an existing directory, and anything
+ * without a `.git` entry.
+ */
+const repoRootRejection = async (repoRoot: string | undefined): Promise<string | null> => {
+  if (!repoRoot) return 'repo-scoped set has no repoRoot';
+  const abs = resolve(expandPath(repoRoot));
+  if (abs === resolve('/') || abs === resolve(expandPath('~'))) {
+    return `refusing repoRoot "${repoRoot}": filesystem root / home is too broad a write scope`;
+  }
+  if (!(await isDirectory(abs))) {
+    return `repoRoot "${repoRoot}" is not a directory on this machine (skipped)`;
+  }
+  if (!(await pathExists(join(abs, '.git')))) {
+    return `repoRoot "${repoRoot}" is not a git repository (no .git) — skipped`;
+  }
+  return null;
 };
 
 const applyOneSet = async (
@@ -523,43 +713,60 @@ const applyOneTool = async (
     }
   }
 
+  const mk = (
+    action: ApplyToolResult['action'],
+    reason?: string
+  ): ApplyToolResult => ({ tool: tool.tool, target: liveTarget, action, reason });
+
   if (tool.strategy === 'symlink') {
     const desired = resolve(srcAbs);
     if (exists && isLink && linkDest !== null && resolve(dirname(writeTarget), linkDest) === desired) {
-      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'already linked' };
+      return mk('skipped', 'already linked');
     }
-    if (exists && !(await allowOverwrite(liveTarget, opts))) {
-      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'exists (declined)' };
+    if (exists) {
+      // Replacing an existing entry is a change. Dry-run must NEVER prompt:
+      // report what WOULD happen instead of calling the consent gate.
+      if (opts.dryRun) {
+        return opts.force
+          ? mk('symlinked', 'dry-run')
+          : mk('skipped', opts.confirmOverwrite ? 'would prompt to overwrite' : 'exists (declined)');
+      }
+      if (!(await allowOverwrite(liveTarget, opts))) {
+        return mk('skipped', 'exists (declined)');
+      }
+    } else if (opts.dryRun) {
+      return mk('symlinked', 'dry-run');
     }
-    if (opts.dryRun) return { tool: tool.tool, target: liveTarget, action: 'symlinked', reason: 'dry-run' };
     await createSymlink(collapsePath(srcAbs), writeTarget, { overwrite: true });
-    return { tool: tool.tool, target: liveTarget, action: 'symlinked' };
+    return mk('symlinked');
   }
 
   // materialize
   const content = expected ?? '';
   if (exists && !isLink) {
     const actual = await readFile(writeTarget, 'utf-8').catch(() => null);
-    if (actual === content) {
-      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'up to date' };
-    }
-    if (!(await allowOverwrite(liveTarget, opts))) {
-      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'differs (declined)' };
-    }
-  } else if (exists && isLink) {
-    // A symlink where we want a real file — replacing it is a change; gate it.
-    if (!(await allowOverwrite(liveTarget, opts))) {
-      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'symlink (declined)' };
-    }
-    if (!opts.dryRun) await deleteFileOrDir(writeTarget);
+    if (actual === content) return mk('skipped', 'up to date');
   }
 
-  if (opts.dryRun) {
-    return { tool: tool.tool, target: liveTarget, action: exists ? 'updated' : 'created', reason: 'dry-run' };
+  if (exists) {
+    // Existing entry differs (real file) or is a symlink to replace — a change.
+    const declineReason = isLink ? 'symlink (declined)' : 'differs (declined)';
+    if (opts.dryRun) {
+      return opts.force
+        ? mk('updated', 'dry-run')
+        : mk('skipped', opts.confirmOverwrite ? 'would prompt to overwrite' : declineReason);
+    }
+    if (!(await allowOverwrite(liveTarget, opts))) {
+      return mk('skipped', declineReason);
+    }
+    if (isLink) await deleteFileOrDir(writeTarget);
+  } else if (opts.dryRun) {
+    return mk('created', 'dry-run');
   }
+
   await ensureDirectory(dirname(writeTarget));
   await atomicWriteFile(writeTarget, content);
-  return { tool: tool.tool, target: liveTarget, action: exists ? 'updated' : 'created' };
+  return mk(exists ? 'updated' : 'created');
 };
 
 /** Consent gate for overwriting an existing variant. */
@@ -598,18 +805,47 @@ export const listExistingToolVariants = async (set: RuleSet): Promise<string[]> 
   return out;
 };
 
+/**
+ * Delete a single variant path. `recursive` handles a directory that landed at
+ * the variant location; `force` swallows a not-found race but NOT real errors
+ * (EACCES), which propagate so the caller can report the failure. On a symlink,
+ * `rm` removes the link itself (never follows it).
+ */
+const removeVariantPath = async (writeTarget: string): Promise<void> => {
+  await rm(writeTarget, { force: true, recursive: true });
+};
+
+export interface RemoveVariantsResult {
+  /** Live targets that were actually removed (or would be, on dry-run). */
+  removed: string[];
+  /** Live targets whose deletion failed (surfaced to the user). */
+  failed: string[];
+}
+
 export const removeToolVariants = async (
   set: RuleSet,
   opts: { dryRun?: boolean } = {}
-): Promise<string[]> => {
+): Promise<RemoveVariantsResult> => {
   const removed: string[] = [];
+  const failed: string[] = [];
   for (const tool of set.tools) {
     const writeTarget = toolWriteTarget(set, tool);
+    const liveTarget = toolLiveTarget(set, tool);
     if (!(await lstatExists(writeTarget))) continue;
-    removed.push(toolLiveTarget(set, tool));
-    if (!opts.dryRun) await rm(writeTarget, { force: true }).catch(() => undefined);
+    if (opts.dryRun) {
+      removed.push(liveTarget);
+      continue;
+    }
+    // Only report a path as removed once the delete actually succeeds; a swallowed
+    // rm error must not masquerade as a successful cleanup.
+    try {
+      await removeVariantPath(writeTarget);
+      removed.push(liveTarget);
+    } catch {
+      failed.push(liveTarget);
+    }
   }
-  return removed;
+  return { removed, failed };
 };
 
 /** Build the render context once per command (machine vars + config vars). */

--- a/src/lib/rulesFanout.ts
+++ b/src/lib/rulesFanout.ts
@@ -1,0 +1,624 @@
+/**
+ * Rules fan-out — one canonical rules/instructions file, many tool variants.
+ *
+ * A single tracked source (e.g. `AGENTS.md`) is fanned out on demand into every
+ * tool-specific file the user's agents look for — CLAUDE.md, .cursorrules,
+ * .windsurfrules, copilot-instructions.md, GEMINI.md — either globally ($HOME)
+ * or per-repo, with per-tool overrides expressed through tuck's existing
+ * template engine (`{{#if tool == "cursor"}}…{{/if}}`).
+ *
+ * This module owns the data model (`rules.json`), the tool → destination
+ * registry, and the pure planning/materialization logic. The `tuck rules`
+ * command is a thin wrapper over these functions; the MCP server and tests call
+ * them directly.
+ *
+ * Writes are safe: every destination routes through {@link resolveWriteTarget}
+ * so `--root` sandboxing and home/repo confinement are enforced, and existing
+ * files that would change are snapshotted (Time Machine) before being touched.
+ */
+
+import { join, dirname, basename, relative, resolve, posix } from 'path';
+import { readFile, writeFile, lstat, readlink, rm } from 'fs/promises';
+import {
+  expandPath,
+  collapsePath,
+  pathExists,
+  isDirectory,
+  validateSafeSourcePath,
+} from './paths.js';
+import {
+  atomicWriteFile,
+  createSymlink,
+  ensureDirectory,
+  deleteFileOrDir,
+} from './files.js';
+import { resolveWriteTarget, addKnownRepoRoots, type RepoWriteTarget } from './writeContext.js';
+import { renderTemplate, defaultTemplateContext, type TemplateContext } from './template.js';
+import { createSnapshot } from './timemachine.js';
+import { TuckError, FileNotFoundError } from '../errors.js';
+import {
+  rulesManifestSchema,
+  type RulesManifest,
+  type RuleSet,
+  type RuleTool,
+  type RuleToolName,
+} from '../schemas/rules.schema.js';
+
+const RULES_MANIFEST = 'rules.json';
+
+/**
+ * Canonical relative destination for each supported tool. Home-scoped sets
+ * resolve these against `$HOME`; repo-scoped sets against the repo root. All are
+ * POSIX so the stored manifest stays portable across machines.
+ */
+export const TOOL_TARGETS: Record<RuleToolName, string> = {
+  claude: 'CLAUDE.md',
+  cursor: '.cursorrules',
+  'cursor-dir': '.cursor/rules/tuck.mdc',
+  windsurf: '.windsurfrules',
+  copilot: '.github/copilot-instructions.md',
+  gemini: 'GEMINI.md',
+  agents: 'AGENTS.md',
+};
+
+/** Human-friendly label per tool, for list/status output. */
+export const TOOL_LABELS: Record<RuleToolName, string> = {
+  claude: 'Claude Code / Claude Desktop',
+  cursor: 'Cursor (.cursorrules)',
+  'cursor-dir': 'Cursor (.cursor/rules)',
+  windsurf: 'Windsurf',
+  copilot: 'GitHub Copilot',
+  gemini: 'Gemini CLI',
+  agents: 'AGENTS.md',
+};
+
+export const ALL_TOOLS = Object.keys(TOOL_TARGETS) as RuleToolName[];
+
+export const isKnownTool = (name: string): name is RuleToolName =>
+  Object.prototype.hasOwnProperty.call(TOOL_TARGETS, name);
+
+const rulesManifestPath = (tuckDir: string): string => join(tuckDir, RULES_MANIFEST);
+
+/** Empty (but valid) manifest used when rules.json is absent or unreadable. */
+const emptyManifest = (): RulesManifest => ({ version: '1', sets: {} });
+
+/**
+ * Load and validate rules.json. A missing file yields an empty manifest; a
+ * present-but-invalid file throws so the user is told rather than silently
+ * losing their configured sets.
+ */
+export const loadRulesManifest = async (tuckDir: string): Promise<RulesManifest> => {
+  const p = rulesManifestPath(tuckDir);
+  if (!(await pathExists(p))) return emptyManifest();
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await readFile(p, 'utf-8'));
+  } catch {
+    throw new TuckError(`Corrupt ${RULES_MANIFEST}: not valid JSON`, 'RULES_MANIFEST_CORRUPT', [
+      `Fix or delete ${p} and re-run \`tuck rules track\`.`,
+    ]);
+  }
+  const parsed = rulesManifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new TuckError(`Invalid ${RULES_MANIFEST}`, 'RULES_MANIFEST_INVALID', [
+      parsed.error.issues[0]?.message ?? 'schema validation failed',
+    ]);
+  }
+  return parsed.data;
+};
+
+export const saveRulesManifest = async (
+  tuckDir: string,
+  manifest: RulesManifest
+): Promise<void> => {
+  await writeFile(rulesManifestPath(tuckDir), JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+};
+
+const slugifyPath = (p: string): string =>
+  p
+    .replace(/^~?\/+/, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+
+const repoScopeKey = (repoRoot: string): string =>
+  slugifyPath(basename(repoRoot)) + '__' + slugifyPath(repoRoot);
+
+/** Walk up from `start` looking for a `.git` entry; return the repo root or null. */
+const findGitRoot = async (start: string): Promise<string | null> => {
+  // expandPath, not resolve(): win32 resolve() stamps the host drive letter
+  // onto drive-less absolute paths, corrupting the returned repo root.
+  let dir = expandPath(start);
+  for (let i = 0; i < 64; i++) {
+    if (await pathExists(join(dir, '.git'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+};
+
+/** Stable id for a rule set (home vs repo, collision-safe across repos). */
+export const ruleSetId = (set: Pick<RuleSet, 'scope' | 'source' | 'repoRoot'>): string => {
+  if (set.scope === 'home') return `home__${slugifyPath(set.source)}`;
+  const rel = relative(set.repoRoot!, expandPath(set.source));
+  return `repo__${repoScopeKey(set.repoRoot!)}__${slugifyPath(rel)}`;
+};
+
+/** The POSIX relative destination a tool writes to (override or default). */
+export const toolRelativePath = (tool: RuleTool): string => {
+  const rel = tool.path ?? TOOL_TARGETS[tool.tool];
+  return rel.replace(/\\/g, '/');
+};
+
+/**
+ * The LIVE absolute destination for a tool variant (before sandbox rebasing).
+ * Home scope → under `$HOME`; repo scope → under the repo root. Used for status
+ * comparisons and display, NOT for writing (writes go through
+ * {@link resolveWriteTarget} to honor `--root`).
+ */
+export const toolLiveTarget = (set: RuleSet, tool: RuleTool): string => {
+  const rel = toolRelativePath(tool);
+  const root = set.scope === 'home' ? expandPath('~') : set.repoRoot!;
+  return join(root, rel);
+};
+
+/** Resolve the sandbox-safe write destination for a tool variant. */
+const toolWriteTarget = (set: RuleSet, tool: RuleTool): string => {
+  const rel = toolRelativePath(tool);
+  if (set.scope === 'home') {
+    return resolveWriteTarget(posix.join('~', rel));
+  }
+  const repo: RepoWriteTarget = {
+    repoKey: repoScopeKey(set.repoRoot!),
+    repoRelative: rel,
+    repoRoot: set.repoRoot!,
+  };
+  return resolveWriteTarget('', repo);
+};
+
+/** Absolute path of a set's canonical source (reads always use the real path). */
+export const sourceAbsolute = (set: Pick<RuleSet, 'scope' | 'source'>): string =>
+  set.scope === 'home' ? expandPath(set.source) : set.source;
+
+/**
+ * Choose the default tool set for a newly tracked source: every known tool,
+ * except one whose default destination IS the canonical source itself (tracking
+ * AGENTS.md should not fan out `agents` → AGENTS.md onto itself).
+ */
+export const defaultToolsForSource = (
+  sourceAbs: string,
+  root: string
+): RuleToolName[] => {
+  const srcResolved = resolve(sourceAbs);
+  return ALL_TOOLS.filter((tool) => {
+    const targetAbs = resolve(join(root, TOOL_TARGETS[tool]));
+    return targetAbs !== srcResolved;
+  });
+};
+
+export interface TrackOptions {
+  /** Tools to fan out to; defaults to every applicable tool. */
+  tools?: RuleToolName[];
+  /** `symlink` to link instead of render; defaults to `materialize`. */
+  strategy?: 'materialize' | 'symlink';
+  /** Render the source as a template on materialize (default true). */
+  template?: boolean;
+  /** Extra template variables. */
+  variables?: Record<string, string>;
+}
+
+/**
+ * Track (or update) a canonical rules file. Records the set in rules.json but
+ * writes NO tool variants — that is `tuck rules apply`, which has its own
+ * consent + snapshot flow.
+ */
+export const trackRuleSet = async (
+  tuckDir: string,
+  inputPath: string,
+  opts: TrackOptions = {}
+): Promise<{ id: string; set: RuleSet }> => {
+  // expandPath handles ~, absolute, and relative inputs WITHOUT stamping the
+  // host drive letter onto drive-less absolute paths the way win32 resolve()
+  // does (D:\test-home\... breaking home confinement checks on Windows).
+  const absPath = expandPath(inputPath);
+  if (!(await pathExists(absPath))) throw new FileNotFoundError(inputPath);
+  validateSafeSourcePath(absPath);
+  if (await isDirectory(absPath)) {
+    throw new TuckError(
+      'A rules source must be a single file, not a directory',
+      'RULES_SOURCE_NOT_FILE',
+      ['Point `tuck rules track` at a file like AGENTS.md.']
+    );
+  }
+
+  const gitRoot = await findGitRoot(dirname(absPath));
+  const scope: 'home' | 'repo' = gitRoot ? 'repo' : 'home';
+  const repoRoot = gitRoot ?? undefined;
+  const root = scope === 'home' ? expandPath('~') : repoRoot!;
+  const source = scope === 'home' ? collapsePath(absPath) : absPath;
+
+  const strategy = opts.strategy ?? 'materialize';
+  const toolNames =
+    opts.tools && opts.tools.length > 0
+      ? opts.tools
+      : defaultToolsForSource(absPath, root);
+  if (toolNames.length === 0) {
+    throw new TuckError('No fan-out tools selected', 'RULES_NO_TOOLS', [
+      'Pass --tool <name> with at least one target.',
+    ]);
+  }
+  const tools: RuleTool[] = toolNames.map((tool) => ({ tool, strategy }));
+
+  const now = new Date().toISOString();
+  const set: RuleSet = {
+    source,
+    scope,
+    repoRoot,
+    template: opts.template ?? true,
+    tools,
+    variables: opts.variables ?? {},
+    added: now,
+    modified: now,
+  };
+  const id = ruleSetId(set);
+
+  const manifest = await loadRulesManifest(tuckDir);
+  const existing = manifest.sets[id];
+  manifest.sets[id] = existing ? { ...set, added: existing.added } : set;
+  await saveRulesManifest(tuckDir, manifest);
+  return { id, set: manifest.sets[id] };
+};
+
+/** Remove a tracked set. Returns the removed set (or null if absent). */
+export const untrackRuleSet = async (
+  tuckDir: string,
+  id: string
+): Promise<RuleSet | null> => {
+  const manifest = await loadRulesManifest(tuckDir);
+  const set = manifest.sets[id];
+  if (!set) return null;
+  delete manifest.sets[id];
+  await saveRulesManifest(tuckDir, manifest);
+  return set;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rendering / planning
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Build the per-tool render context: machine vars + set vars + `tool`. */
+const renderContextFor = (
+  base: TemplateContext,
+  set: RuleSet,
+  tool: RuleToolName
+): TemplateContext => ({ ...base, ...set.variables, tool });
+
+/**
+ * The exact content a `materialize` tool variant should hold: the canonical
+ * source, rendered through the template engine (when `set.template`) with
+ * `tool` bound so per-tool `{{#if tool == …}}` blocks resolve.
+ */
+export const renderToolContent = (
+  sourceText: string,
+  set: RuleSet,
+  tool: RuleToolName,
+  base: TemplateContext
+): string => {
+  if (!set.template) return sourceText;
+  return renderTemplate(sourceText, renderContextFor(base, set, tool));
+};
+
+export type ToolStatus = 'missing' | 'in-sync' | 'drift' | 'foreign';
+
+export interface ToolPlan {
+  tool: RuleToolName;
+  strategy: 'materialize' | 'symlink';
+  /** Live (non-sandboxed) destination, for display. */
+  target: string;
+  status: ToolStatus;
+}
+
+export interface SetStatus {
+  id: string;
+  set: RuleSet;
+  /** Whether the canonical source exists on disk. */
+  sourceExists: boolean;
+  tools: ToolPlan[];
+}
+
+/**
+ * Compute, without writing anything, the current state of every tool variant in
+ * a set: missing / in-sync / drift (materialize) or foreign (a symlink target
+ * that is a real file, or vice-versa).
+ */
+export const computeSetStatus = async (
+  set: RuleSet,
+  base: TemplateContext
+): Promise<Omit<SetStatus, 'id'>> => {
+  const srcAbs = sourceAbsolute(set);
+  const sourceExists = await pathExists(srcAbs);
+  const sourceText = sourceExists ? await readFile(srcAbs, 'utf-8') : '';
+
+  const tools: ToolPlan[] = [];
+  for (const tool of set.tools) {
+    const target = toolLiveTarget(set, tool);
+    const status = await toolStatus(set, tool, target, srcAbs, sourceText, sourceExists, base);
+    tools.push({ tool: tool.tool, strategy: tool.strategy, target, status });
+  }
+  return { set, sourceExists, tools };
+};
+
+const toolStatus = async (
+  set: RuleSet,
+  tool: RuleTool,
+  target: string,
+  srcAbs: string,
+  sourceText: string,
+  sourceExists: boolean,
+  base: TemplateContext
+): Promise<ToolStatus> => {
+  const exists = await lstatExists(target);
+  if (!exists) return 'missing';
+
+  let link: string | null = null;
+  try {
+    const st = await lstat(target);
+    if (st.isSymbolicLink()) link = await readlink(target);
+  } catch {
+    link = null;
+  }
+
+  if (tool.strategy === 'symlink') {
+    if (link === null) return 'foreign'; // a real file where a symlink is expected
+    return resolve(dirname(target), link) === resolve(srcAbs) ? 'in-sync' : 'drift';
+  }
+
+  // materialize
+  if (link !== null) return 'foreign'; // a symlink where a real file is expected
+  if (!sourceExists) return 'drift';
+  const expected = renderToolContent(sourceText, set, tool.tool, base);
+  const actual = await readFile(target, 'utf-8');
+  return actual === expected ? 'in-sync' : 'drift';
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Apply
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ApplyToolResult {
+  tool: RuleToolName;
+  target: string;
+  action: 'created' | 'updated' | 'skipped' | 'symlinked';
+  reason?: string;
+}
+
+export interface ApplySetResult {
+  id: string;
+  applied: ApplyToolResult[];
+}
+
+export interface ApplyRulesOptions {
+  /** Restrict to a single set id. */
+  id?: string;
+  /** Plan only; write nothing. */
+  dryRun?: boolean;
+  /** Base template context (built once by the caller). */
+  context: TemplateContext;
+  /**
+   * Confirm overwriting an existing, differing variant. Return true to proceed.
+   * Omit for non-interactive: differing files are skipped unless `force`.
+   */
+  confirmOverwrite?: (target: string) => Promise<boolean>;
+  /** Overwrite differing variants without confirming (`--force`). */
+  force?: boolean;
+}
+
+/**
+ * Fan a set (or all sets) out to disk. Existing files that would change are
+ * first captured in a Time Machine snapshot; a variant that already matches is
+ * left untouched. Foreign/differing files are only overwritten with consent
+ * (interactive confirm) or `--force`; otherwise they are skipped and reported.
+ */
+export const applyRuleSets = async (
+  tuckDir: string,
+  opts: ApplyRulesOptions
+): Promise<ApplySetResult[]> => {
+  const manifest = await loadRulesManifest(tuckDir);
+  let entries = Object.entries(manifest.sets);
+  if (opts.id) {
+    entries = entries.filter(([id]) => id === opts.id);
+    if (entries.length === 0) {
+      throw new TuckError(`No tracked rule set with id "${opts.id}"`, 'RULES_SET_NOT_FOUND', [
+        'Run `tuck rules list` to see tracked sets.',
+      ]);
+    }
+  }
+
+  // Register repo roots so repo-scoped writes pass destination validation.
+  const repoRoots = entries
+    .map(([, s]) => s.repoRoot)
+    .filter((r): r is string => typeof r === 'string');
+  if (repoRoots.length > 0) addKnownRepoRoots(repoRoots);
+
+  const results: ApplySetResult[] = [];
+  for (const [id, set] of entries) {
+    results.push(await applyOneSet(id, set, opts));
+  }
+  return results;
+};
+
+const applyOneSet = async (
+  id: string,
+  set: RuleSet,
+  opts: ApplyRulesOptions
+): Promise<ApplySetResult> => {
+  const srcAbs = sourceAbsolute(set);
+  if (!(await pathExists(srcAbs))) {
+    throw new FileNotFoundError(set.source);
+  }
+  const sourceText = await readFile(srcAbs, 'utf-8');
+
+  // Pre-plan so we can snapshot everything that will change in one shot.
+  interface Planned {
+    tool: RuleTool;
+    writeTarget: string;
+    liveTarget: string;
+    expected: string | null; // materialize only
+  }
+  const planned: Planned[] = [];
+  const toSnapshot: string[] = [];
+
+  for (const tool of set.tools) {
+    const writeTarget = toolWriteTarget(set, tool);
+    const liveTarget = toolLiveTarget(set, tool);
+    const expected =
+      tool.strategy === 'materialize'
+        ? renderToolContent(sourceText, set, tool.tool, opts.context)
+        : null;
+    planned.push({ tool, writeTarget, liveTarget, expected });
+    // Snapshot EVERY planned destination — createSnapshot records missing
+    // paths as existed:false, which is what lets `tuck undo` REMOVE variants
+    // a create-only apply produced (a pre-existing-only snapshot made the
+    // printed undo breadcrumb a lie).
+    toSnapshot.push(writeTarget);
+  }
+
+  if (!opts.dryRun && toSnapshot.length > 0) {
+    // A failed snapshot aborts the apply (same policy as sync/apply): never
+    // mutate files without a recovery point.
+    await createSnapshot(toSnapshot, `Pre rules-apply backup for ${id}`);
+  }
+
+  const applied: ApplyToolResult[] = [];
+  for (const p of planned) {
+    applied.push(await applyOneTool(p.tool, p.writeTarget, p.liveTarget, p.expected, srcAbs, opts));
+  }
+  return { id, applied };
+};
+
+const applyOneTool = async (
+  tool: RuleTool,
+  writeTarget: string,
+  liveTarget: string,
+  expected: string | null,
+  srcAbs: string,
+  opts: ApplyRulesOptions
+): Promise<ApplyToolResult> => {
+  const exists = await lstatExists(writeTarget);
+
+  // Inspect the existing entry's link-ness once.
+  let isLink = false;
+  let linkDest: string | null = null;
+  if (exists) {
+    try {
+      const st = await lstat(writeTarget);
+      if (st.isSymbolicLink()) {
+        isLink = true;
+        linkDest = await readlink(writeTarget);
+      }
+    } catch {
+      isLink = false;
+    }
+  }
+
+  if (tool.strategy === 'symlink') {
+    const desired = resolve(srcAbs);
+    if (exists && isLink && linkDest !== null && resolve(dirname(writeTarget), linkDest) === desired) {
+      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'already linked' };
+    }
+    if (exists && !(await allowOverwrite(liveTarget, opts))) {
+      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'exists (declined)' };
+    }
+    if (opts.dryRun) return { tool: tool.tool, target: liveTarget, action: 'symlinked', reason: 'dry-run' };
+    await createSymlink(collapsePath(srcAbs), writeTarget, { overwrite: true });
+    return { tool: tool.tool, target: liveTarget, action: 'symlinked' };
+  }
+
+  // materialize
+  const content = expected ?? '';
+  if (exists && !isLink) {
+    const actual = await readFile(writeTarget, 'utf-8').catch(() => null);
+    if (actual === content) {
+      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'up to date' };
+    }
+    if (!(await allowOverwrite(liveTarget, opts))) {
+      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'differs (declined)' };
+    }
+  } else if (exists && isLink) {
+    // A symlink where we want a real file — replacing it is a change; gate it.
+    if (!(await allowOverwrite(liveTarget, opts))) {
+      return { tool: tool.tool, target: liveTarget, action: 'skipped', reason: 'symlink (declined)' };
+    }
+    if (!opts.dryRun) await deleteFileOrDir(writeTarget);
+  }
+
+  if (opts.dryRun) {
+    return { tool: tool.tool, target: liveTarget, action: exists ? 'updated' : 'created', reason: 'dry-run' };
+  }
+  await ensureDirectory(dirname(writeTarget));
+  await atomicWriteFile(writeTarget, content);
+  return { tool: tool.tool, target: liveTarget, action: exists ? 'updated' : 'created' };
+};
+
+/** Consent gate for overwriting an existing variant. */
+const allowOverwrite = async (
+  target: string,
+  opts: ApplyRulesOptions
+): Promise<boolean> => {
+  if (opts.force) return true;
+  if (opts.confirmOverwrite) return opts.confirmOverwrite(target);
+  return false;
+};
+
+/** Delete every generated variant for a set (used by `untrack --clean`). */
+/**
+ * Link-aware existence: a DANGLING symlink still counts as existing (exactly
+ * the state a symlink-strategy apply leaves behind if the canonical source is
+ * later moved) — pathExists follows links and would report it missing, making
+ * overwrite/cleanup logic crash or skip.
+ */
+const lstatExists = async (p: string): Promise<boolean> => {
+  try {
+    await lstat(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Write targets of a set's variants that currently exist on disk (link-aware). */
+export const listExistingToolVariants = async (set: RuleSet): Promise<string[]> => {
+  const out: string[] = [];
+  for (const tool of set.tools) {
+    const writeTarget = toolWriteTarget(set, tool);
+    if (await lstatExists(writeTarget)) out.push(writeTarget);
+  }
+  return out;
+};
+
+export const removeToolVariants = async (
+  set: RuleSet,
+  opts: { dryRun?: boolean } = {}
+): Promise<string[]> => {
+  const removed: string[] = [];
+  for (const tool of set.tools) {
+    const writeTarget = toolWriteTarget(set, tool);
+    if (!(await lstatExists(writeTarget))) continue;
+    removed.push(toolLiveTarget(set, tool));
+    if (!opts.dryRun) await rm(writeTarget, { force: true }).catch(() => undefined);
+  }
+  return removed;
+};
+
+/** Build the render context once per command (machine vars + config vars). */
+export const buildRulesContext = async (tuckDir: string): Promise<TemplateContext> => {
+  try {
+    const { loadConfig } = await import('./config.js');
+    const config = await loadConfig(tuckDir);
+    return defaultTemplateContext(config?.templates?.variables ?? {});
+  } catch {
+    return defaultTemplateContext({});
+  }
+};

--- a/src/lib/secretBackends/resolver.ts
+++ b/src/lib/secretBackends/resolver.ts
@@ -21,6 +21,7 @@ import { BitwardenBackend } from './bitwarden.js';
 import { PassBackend } from './pass.js';
 import { SecretCache, getGlobalCache } from './cache.js';
 import { getBackendPath, listMappings } from './mappings.js';
+import { assertNotReadOnly } from '../readOnlyMode.js';
 import { BackendNotAvailableError, BackendAuthenticationError, UnresolvedSecretsError } from '../../errors.js';
 
 /**
@@ -202,6 +203,12 @@ export class SecretResolver {
         };
       }
     }
+
+    // Read-only guarantee: a cache HIT above is fine (no backend access), but
+    // actually reaching out to a secret backend from a read-only command
+    // (status/diff/list) would break the "never prompt" promise. Fail loudly so a
+    // regression is caught in tests instead of nagging the user in production.
+    assertNotReadOnly(`resolve secret "${name}"`);
 
     // Determine which backend to use
     const backendName = options?.backend || (await this.getEffectiveBackendName());

--- a/src/lib/secrets/allowlist.ts
+++ b/src/lib/secrets/allowlist.ts
@@ -1,0 +1,257 @@
+/**
+ * Centralized, auditable secret allowlist for tuck.
+ *
+ * When the scanner flags a value that is actually safe (a false positive, or an
+ * intentionally-tracked non-secret), the user can allowlist it once. Every
+ * subsequent scan (`tuck add`, `tuck sync`, `tuck secrets scan`, the MCP server)
+ * then skips that finding.
+ *
+ * The allowlist lives in a committed `secrets.allow.json` file so it is
+ * centralized and reviewable in code review — the opposite of scattered inline
+ * `# tuck:allow` comments. It records only a SHA-256 fingerprint of the value,
+ * never the value itself, so it is safe to commit and share.
+ */
+
+import { createHash } from 'crypto';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { ensureDir } from 'fs-extra';
+import { pathExists } from '../paths.js';
+import { atomicWriteFile } from '../files.js';
+import {
+  secretsAllowlistSchema,
+  type AllowlistEntry,
+  type SecretsAllowlist,
+} from '../../schemas/secretsAllowlist.schema.js';
+import type { SecretMatch, FileScanResult, ScanSummary } from './scanner.js';
+
+const ALLOWLIST_FILENAME = 'secrets.allow.json';
+
+// ============================================================================
+// Path + fingerprint helpers
+// ============================================================================
+
+/** Path to the committed allowlist file inside the tuck repo. */
+export const getAllowlistPath = (tuckDir: string): string => {
+  return join(tuckDir, ALLOWLIST_FILENAME);
+};
+
+/**
+ * Deterministic, non-reversible fingerprint of a secret value.
+ *
+ * SECURITY: we hash the raw value with SHA-256 so the committed allowlist never
+ * contains the plaintext. Matching later re-hashes the scanned value and
+ * compares digests.
+ */
+export const computeFingerprint = (value: string): string => {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+};
+
+// ============================================================================
+// Store operations
+// ============================================================================
+
+/** Load the allowlist, returning an empty store when the file is absent. */
+export const loadAllowlist = async (tuckDir: string): Promise<SecretsAllowlist> => {
+  const allowlistPath = getAllowlistPath(tuckDir);
+
+  if (!(await pathExists(allowlistPath))) {
+    return { version: '1.0.0', entries: [] };
+  }
+
+  try {
+    const content = await readFile(allowlistPath, 'utf-8');
+    const parsed = JSON.parse(content);
+    return secretsAllowlistSchema.parse(parsed);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    // A corrupt allowlist must NOT silently disable the scanner (that would let
+    // real secrets through). Surface a clear, actionable failure instead.
+    throw new Error(
+      `[tuck] Failed to load secret allowlist from '${allowlistPath}': ${errorMsg}`
+    );
+  }
+};
+
+/** Persist the allowlist atomically (committed file — default permissions). */
+export const saveAllowlist = async (
+  tuckDir: string,
+  store: SecretsAllowlist
+): Promise<void> => {
+  const allowlistPath = getAllowlistPath(tuckDir);
+  await ensureDir(tuckDir);
+  const content = JSON.stringify(store, null, 2) + '\n';
+  await atomicWriteFile(allowlistPath, content);
+};
+
+// ============================================================================
+// CRUD
+// ============================================================================
+
+export interface AddAllowlistOptions {
+  /** Justification for why this value is safe (required, keeps it auditable). */
+  reason: string;
+  /** Optional pattern id scope. */
+  pattern?: string;
+  /** Optional collapsed path scope. */
+  path?: string;
+  /** Override the recorded actor (defaults to $USER/$USERNAME). */
+  addedBy?: string;
+}
+
+/**
+ * Add (or update) an allowlist entry keyed by fingerprint + optional scope.
+ *
+ * If an entry with the same fingerprint, pattern, and path already exists its
+ * reason/actor/timestamp are refreshed rather than duplicated. Returns the
+ * stored entry.
+ */
+export const addAllowlistEntryByFingerprint = async (
+  tuckDir: string,
+  fingerprint: string,
+  options: AddAllowlistOptions
+): Promise<AllowlistEntry> => {
+  const store = await loadAllowlist(tuckDir);
+
+  const entry: AllowlistEntry = {
+    fingerprint,
+    reason: options.reason,
+    ...(options.pattern ? { pattern: options.pattern } : {}),
+    ...(options.path ? { path: options.path } : {}),
+    addedBy: options.addedBy ?? process.env.USER ?? process.env.USERNAME,
+    addedAt: new Date().toISOString(),
+  };
+
+  const idx = store.entries.findIndex(
+    (existing) =>
+      existing.fingerprint === entry.fingerprint &&
+      existing.pattern === entry.pattern &&
+      existing.path === entry.path
+  );
+
+  if (idx >= 0) {
+    store.entries[idx] = entry;
+  } else {
+    store.entries.push(entry);
+  }
+
+  await saveAllowlist(tuckDir, store);
+  return entry;
+};
+
+/**
+ * Add an allowlist entry for a raw value. The value is fingerprinted before
+ * storage and is never written to disk in cleartext.
+ */
+export const addAllowlistEntryForValue = async (
+  tuckDir: string,
+  value: string,
+  options: AddAllowlistOptions
+): Promise<AllowlistEntry> => {
+  return addAllowlistEntryByFingerprint(tuckDir, computeFingerprint(value), options);
+};
+
+/**
+ * Remove all entries whose fingerprint starts with the given prefix (allowing
+ * short prefixes on the CLI). Returns the entries that were removed.
+ */
+export const removeAllowlistEntries = async (
+  tuckDir: string,
+  fingerprintPrefix: string
+): Promise<AllowlistEntry[]> => {
+  const store = await loadAllowlist(tuckDir);
+  const prefix = fingerprintPrefix.toLowerCase();
+  const removed = store.entries.filter((entry) => entry.fingerprint.startsWith(prefix));
+
+  if (removed.length === 0) {
+    return [];
+  }
+
+  store.entries = store.entries.filter((entry) => !entry.fingerprint.startsWith(prefix));
+  await saveAllowlist(tuckDir, store);
+  return removed;
+};
+
+/** List all allowlist entries. */
+export const listAllowlistEntries = async (tuckDir: string): Promise<AllowlistEntry[]> => {
+  const store = await loadAllowlist(tuckDir);
+  return store.entries;
+};
+
+// ============================================================================
+// Matching + filtering
+// ============================================================================
+
+/**
+ * True when a scanner match is suppressed by any allowlist entry.
+ *
+ * An entry matches when its fingerprint equals SHA-256(match.value) AND every
+ * scope it declares also matches: `pattern` (against match.patternId) and
+ * `path` (against the file's collapsed path).
+ */
+export const isMatchAllowed = (
+  match: Pick<SecretMatch, 'value' | 'patternId'>,
+  collapsedPath: string,
+  entries: AllowlistEntry[]
+): boolean => {
+  if (entries.length === 0) return false;
+  const fingerprint = computeFingerprint(match.value);
+
+  return entries.some((entry) => {
+    if (entry.fingerprint !== fingerprint) return false;
+    if (entry.pattern !== undefined && entry.pattern !== match.patternId) return false;
+    if (entry.path !== undefined && entry.path !== collapsedPath) return false;
+    return true;
+  });
+};
+
+/**
+ * Return a new ScanSummary with allowlisted matches removed and all aggregate
+ * counts recomputed. Files whose matches are all allowlisted drop out entirely.
+ */
+export const filterSummaryWithAllowlist = (
+  summary: ScanSummary,
+  entries: AllowlistEntry[]
+): ScanSummary => {
+  if (entries.length === 0) return summary;
+
+  const filteredResults: FileScanResult[] = [];
+
+  for (const result of summary.results) {
+    const keptMatches = result.matches.filter(
+      (match) => !isMatchAllowed(match, result.collapsedPath, entries)
+    );
+
+    if (keptMatches.length === 0) continue;
+
+    filteredResults.push({
+      ...result,
+      matches: keptMatches,
+      hasSecrets: true,
+      criticalCount: keptMatches.filter((m) => m.severity === 'critical').length,
+      highCount: keptMatches.filter((m) => m.severity === 'high').length,
+      mediumCount: keptMatches.filter((m) => m.severity === 'medium').length,
+      lowCount: keptMatches.filter((m) => m.severity === 'low').length,
+    });
+  }
+
+  const bySeverity = { critical: 0, high: 0, medium: 0, low: 0 };
+  let totalSecrets = 0;
+  for (const result of filteredResults) {
+    totalSecrets += result.matches.length;
+    bySeverity.critical += result.criticalCount;
+    bySeverity.high += result.highCount;
+    bySeverity.medium += result.mediumCount;
+    bySeverity.low += result.lowCount;
+  }
+
+  // `scannedFiles`/`skippedFiles`/`totalFiles` describe the scan itself and are
+  // unchanged by allowlisting; only the secret-bearing view narrows.
+  return {
+    ...summary,
+    filesWithSecrets: filteredResults.length,
+    totalSecrets,
+    bySeverity,
+    results: filteredResults,
+  };
+};

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -122,16 +122,52 @@ import { setSecret, ensureSecretsGitignored, getAllSecrets } from './store.js';
 import { createCustomPattern, type SecretPattern } from './patterns.js';
 import type { CustomPattern } from '../../schemas/secrets.schema.js';
 import { scanWithScanner, isGitleaksInstalled, isTrufflehogInstalled, type ExternalScanner } from './external.js';
+import { loadAllowlist, filterSummaryWithAllowlist } from './allowlist.js';
+
+// Re-export allowlist API from the barrel so callers use `secrets/index.js`.
+export {
+  getAllowlistPath,
+  computeFingerprint,
+  loadAllowlist,
+  saveAllowlist,
+  addAllowlistEntryByFingerprint,
+  addAllowlistEntryForValue,
+  removeAllowlistEntries,
+  listAllowlistEntries,
+  isMatchAllowed,
+  filterSummaryWithAllowlist,
+  type AddAllowlistOptions,
+} from './allowlist.js';
+export type { AllowlistEntry, SecretsAllowlist } from '../../schemas/secretsAllowlist.schema.js';
 
 /**
  * Scan files for secrets using config-aware settings
  *
  * Supports external scanners (gitleaks, trufflehog) via config.
  * Falls back to built-in scanner if external tool not available.
+ *
+ * Findings that appear in the committed allowlist (`secrets.allow.json`) are
+ * filtered out here so every caller — `tuck add`, `tuck sync`, the scan command
+ * and the MCP server — honors the same centralized, auditable allowlist rather
+ * than scattered inline ignore comments.
  */
-export const scanForSecrets = async (filepaths: string[], tuckDir: string): Promise<ScanSummary> => {
+export const scanForSecrets = async (
+  filepaths: string[],
+  tuckDir: string,
+  options: {
+    /**
+     * Return findings even when they are allowlisted. Used by
+     * `tuck secrets allow add`, which must see the same findings the gate
+     * sees (same scanner, custom patterns, and pattern ids) BEFORE the
+     * allowlist filter — otherwise recorded scopes never match the gate.
+     */
+    includeAllowlisted?: boolean;
+  } = {}
+): Promise<ScanSummary> => {
   const config = await loadConfig(tuckDir);
   const security = config.security || {};
+
+  const allowlist = await loadAllowlist(tuckDir);
 
   // Check if an external scanner is configured
   const configuredScanner = (security.scanner || 'builtin') as ExternalScanner;
@@ -147,7 +183,10 @@ export const scanForSecrets = async (filepaths: string[], tuckDir: string): Prom
     }
 
     if (useExternal) {
-      return scanWithScanner(filepaths, configuredScanner);
+      const externalSummary = await scanWithScanner(filepaths, configuredScanner);
+      return options.includeAllowlisted
+        ? externalSummary
+        : filterSummaryWithAllowlist(externalSummary, allowlist.entries);
     }
     // Fall through to built-in if external not available
   }
@@ -162,12 +201,16 @@ export const scanForSecrets = async (filepaths: string[], tuckDir: string): Prom
     })
   );
 
-  return scanFiles(filepaths, {
+  const summary = await scanFiles(filepaths, {
     customPatterns: customPatterns.length > 0 ? customPatterns : undefined,
     excludePatternIds: security.excludePatterns,
     minSeverity: security.minSeverity,
     maxFileSize: security.maxFileSize,
   });
+
+  return options.includeAllowlisted
+    ? summary
+    : filterSummaryWithAllowlist(summary, allowlist.entries);
 };
 
 /**

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -81,6 +81,28 @@ export {
   previewRestorationWithResolver,
 } from './redactor.js';
 
+// Re-export value-level (SOPS-style) encryption
+export {
+  type EncryptValuesResult,
+  type DecryptValuesResult,
+  type EncryptFileResult,
+  type DecryptFileResult,
+  VALUE_TOKEN_REGEX,
+  formatValueToken,
+  parseValueToken,
+  isValueToken,
+  hasEncryptedValues,
+  countEncryptedValues,
+  findValueTokens,
+  encryptValue,
+  decryptValue,
+  encryptContentValues,
+  decryptContentValues,
+  encryptFileValues,
+  decryptFileValues,
+  fileHasEncryptedValues,
+} from './valueEncryption.js';
+
 // Re-export schema types
 export type { SecurityConfig, CustomPattern, SecretEntry, SecretsStore } from '../../schemas/secrets.schema.js';
 

--- a/src/lib/secrets/valueEncryption.ts
+++ b/src/lib/secrets/valueEncryption.ts
@@ -23,6 +23,16 @@
  * AES-256-GCM with a unique 96-bit nonce per value. This mirrors
  * {@link ../crypto/fileEncryption.ts} but packs the parameters into a compact,
  * text-embeddable token instead of a binary file header.
+ *
+ * Security limitation — no context binding (accepted for v1): a token's GCM auth
+ * tag authenticates ONLY the value, not the key it sits next to or the file it
+ * lives in. Unlike SOPS's file-level MAC, tuck's tokens carry no AAD, so an
+ * attacker with write access to the repo can transplant a valid `ENC[…]` token to
+ * a different key or file and it will still decrypt cleanly under the same
+ * passphrase — the substitution is undetectable at decrypt time. Changing the
+ * token format to bind context would break compatibility, so the mitigation is
+ * out-of-band: git history and code review make such a swap visible in a diff.
+ * See docs/VALUE-ENCRYPTION.md → "Security notes".
  */
 
 import {
@@ -122,8 +132,21 @@ interface DerivedKey {
   iterations: number;
 }
 
+/**
+ * Key-derivation seam. Production code always runs PBKDF2 here; exposing it as a
+ * mutable binding lets tests assert the per-salt cache in
+ * {@link decryptContentValues} collapses N same-salt tokens down to a single
+ * (expensive) derivation. Do not depend on this shape outside of tests.
+ * @internal
+ */
+export const keyDerivation = {
+  derive(passphrase: string, salt: Buffer, iterations: number): Promise<Buffer> {
+    return pbkdf2(passphrase, salt, iterations, KEY_LENGTH, PBKDF2_DIGEST);
+  },
+};
+
 const deriveValueKey = async (passphrase: string, salt: Buffer): Promise<Buffer> => {
-  return pbkdf2(passphrase, salt, PBKDF2_ITERATIONS, KEY_LENGTH, PBKDF2_DIGEST);
+  return keyDerivation.derive(passphrase, salt, PBKDF2_ITERATIONS);
 };
 
 /**
@@ -161,16 +184,23 @@ export const encryptValue = async (plaintext: string, passphrase: string): Promi
   return encryptWithKey(plaintext, { key, salt, iterations: PBKDF2_ITERATIONS });
 };
 
+/** The parsed, still-encrypted components of a value token. */
+interface TokenParts {
+  iterations: number;
+  salt: Buffer;
+  iv: Buffer;
+  authTag: Buffer;
+  ciphertext: Buffer;
+}
+
 /**
- * Decrypt a single value token back to its plaintext.
- *
- * Throws {@link DecryptionError} on a malformed token, an out-of-range iteration
- * count, or an authentication failure (wrong passphrase / tampered ciphertext).
+ * Parse a value token's base64 payload into its crypto components. Throws
+ * {@link DecryptionError} on a non-token, invalid base64, a truncated header, or
+ * an out-of-range iteration count. Does NOT derive a key or decrypt — so callers
+ * can share one key derivation across many tokens (see the cache in
+ * {@link decryptContentValues}).
  */
-export const decryptValue = async (token: string, passphrase: string): Promise<string> => {
-  if (typeof passphrase !== 'string' || passphrase.length === 0) {
-    throw new DecryptionError('Passphrase must be a non-empty string');
-  }
+const parseTokenPayload = (token: string): TokenParts => {
   const base64 = parseValueToken(token);
   if (base64 === null) {
     throw new DecryptionError('Not a tuck value-encryption token');
@@ -197,11 +227,15 @@ export const decryptValue = async (token: string, passphrase: string): Promise<s
   const authTag = payload.subarray(offset, (offset += AUTH_TAG_LENGTH));
   const ciphertext = payload.subarray(offset);
 
+  return { iterations, salt, iv, authTag, ciphertext };
+};
+
+/** Decrypt already-parsed token parts with a pre-derived key. */
+const decryptTokenParts = (parts: TokenParts, key: Buffer): string => {
   try {
-    const key = await pbkdf2(passphrase, salt, iterations, KEY_LENGTH, PBKDF2_DIGEST);
-    const decipher = createDecipheriv(ALGORITHM, key, iv);
-    decipher.setAuthTag(authTag);
-    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    const decipher = createDecipheriv(ALGORITHM, key, parts.iv);
+    decipher.setAuthTag(parts.authTag);
+    const plaintext = Buffer.concat([decipher.update(parts.ciphertext), decipher.final()]);
     return plaintext.toString('utf8');
   } catch {
     throw new DecryptionError('Failed to decrypt value: wrong passphrase or corrupted token', [
@@ -209,6 +243,21 @@ export const decryptValue = async (token: string, passphrase: string): Promise<s
       'Ensure the token was not modified',
     ]);
   }
+};
+
+/**
+ * Decrypt a single value token back to its plaintext.
+ *
+ * Throws {@link DecryptionError} on a malformed token, an out-of-range iteration
+ * count, or an authentication failure (wrong passphrase / tampered ciphertext).
+ */
+export const decryptValue = async (token: string, passphrase: string): Promise<string> => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new DecryptionError('Passphrase must be a non-empty string');
+  }
+  const parts = parseTokenPayload(token);
+  const key = await keyDerivation.derive(passphrase, parts.salt, parts.iterations);
+  return decryptTokenParts(parts, key);
 };
 
 // ============================================================================
@@ -230,6 +279,43 @@ export interface DecryptValuesResult {
   /** Tokens that could not be decrypted (wrong passphrase / corruption). */
   failed: number;
 }
+
+/**
+ * Pick a delimiter character present in NEITHER the content nor any secret value.
+ * A marker built around it can never be a substring of a real secret value (and
+ * no value can be a substring of the marker's fixed delimiters), which keeps the
+ * two-pass replacement below collision-free. Control chars are absent from
+ * virtually every real config; we fall back to the Unicode Private Use Area.
+ */
+const pickReplacementSentinel = (content: string, values: string[]): string => {
+  const inUse = (ch: string): boolean =>
+    content.includes(ch) || values.some((v) => v.includes(ch));
+  for (let code = 0x00; code <= 0x1f; code++) {
+    if (code === 0x09 || code === 0x0a || code === 0x0d) continue; // keep tab / CR / LF
+    const ch = String.fromCharCode(code);
+    if (!inUse(ch)) return ch;
+  }
+  for (let code = 0xe000; code <= 0xf8ff; code++) {
+    const ch = String.fromCharCode(code);
+    if (!inUse(ch)) return ch;
+  }
+  throw new EncryptionError('Unable to allocate a collision-free replacement marker');
+};
+
+/**
+ * Build a unique placeholder `<sentinel><32 random hex><sentinel>` that contains
+ * no secret value as a substring. The sentinel is absent from every value, so a
+ * value can only ever match inside the random hex core — regenerated away in the
+ * astronomically rare case it does.
+ */
+const makeMarker = (sentinel: string, values: string[]): string => {
+  for (;;) {
+    const marker = `${sentinel}${randomBytes(16).toString('hex')}${sentinel}`;
+    if (!values.some((v) => v.length > 0 && marker.includes(v))) {
+      return marker;
+    }
+  }
+};
 
 /**
  * Replace each detected secret span with an inline ciphertext token, encrypting
@@ -268,10 +354,21 @@ export const encryptContentValues = async (
   const key = await deriveValueKey(passphrase, salt);
   const derived: DerivedKey = { key, salt, iterations: PBKDF2_ITERATIONS };
 
+  // Two FULL passes, not a per-iteration two-step. Pass 1 swaps every live secret
+  // value for a unique placeholder marker; only once ALL values are gone does pass
+  // 2 splice in the ciphertext tokens. This is what makes the operation correct:
+  // a single-pass value→token swap can corrupt an earlier token, because a later,
+  // shorter value that coincidentally occurs inside that token's base64 gets
+  // spliced into the ciphertext (occursOutsideTokens only masks tokens that
+  // existed BEFORE the loop, never the ones freshly inserted this call). Because
+  // no token exists in `result` until pass 2, no value can ever land inside one.
+  const sentinel = pickReplacementSentinel(content, uniqueValues);
+  const pending: Array<{ marker: string; token: string }> = [];
   let result = content;
   let encrypted = 0;
   let skipped = 0;
 
+  // Pass 1: live values → markers.
   for (const value of uniqueValues) {
     if (!result.includes(value)) {
       continue;
@@ -284,14 +381,16 @@ export const encryptContentValues = async (
       continue;
     }
 
-    const token = encryptWithKey(value, derived);
-    // Two-step replace via a random marker so the freshly inserted token (which
-    // contains base64 that could, in theory, contain a later `value`) is never
-    // itself rewritten by a subsequent iteration.
-    const marker = ` TUCK_ENC_${randomBytes(12).toString('hex')} `;
+    const marker = makeMarker(sentinel, uniqueValues);
     result = result.split(value).join(marker);
-    result = result.split(marker).join(token);
+    pending.push({ marker, token: encryptWithKey(value, derived) });
     encrypted++;
+  }
+
+  // Pass 2: markers → tokens. Tokens only enter `result` now, so none can be
+  // corrupted by a value replacement.
+  for (const { marker, token } of pending) {
+    result = result.split(marker).join(token);
   }
 
   return { content: result, encrypted, skipped };
@@ -341,13 +440,33 @@ export const decryptContentValues = async (
     return { content, decrypted: 0, failed: 0 };
   }
 
+  // Per-call key cache. Every token written by one encryptContentValues call
+  // shares a single salt, so without a cache a 50-token file would run the
+  // 600k-iteration PBKDF2 fifty times (seconds of CPU). Keying on salt+iterations
+  // (the passphrase is fixed for the whole call) collapses that to one derivation
+  // per distinct salt. Promises are cached so a same-salt token reuses the very
+  // first derivation even before it resolves. The cache is scoped to this call —
+  // derived keys never outlive the operation.
+  const keyCache = new Map<string, Promise<Buffer>>();
+  const deriveCached = (salt: Buffer, iterations: number): Promise<Buffer> => {
+    const cacheKey = `${iterations}:${salt.toString('base64')}`;
+    let derived = keyCache.get(cacheKey);
+    if (!derived) {
+      derived = keyDerivation.derive(passphrase, salt, iterations);
+      keyCache.set(cacheKey, derived);
+    }
+    return derived;
+  };
+
   let result = content;
   let decrypted = 0;
   let failed = 0;
 
   for (const token of tokens) {
     try {
-      const plaintext = await decryptValue(token, passphrase);
+      const parts = parseTokenPayload(token);
+      const key = await deriveCached(parts.salt, parts.iterations);
+      const plaintext = decryptTokenParts(parts, key);
       // Two-step replace via a random marker: a decrypted plaintext could, in a
       // pathological case, contain another not-yet-processed token's text, so we
       // never insert plaintext where a later iteration might rescan it. split/join

--- a/src/lib/secrets/valueEncryption.ts
+++ b/src/lib/secrets/valueEncryption.ts
@@ -1,0 +1,449 @@
+/**
+ * Value-level (SOPS-style) encryption for tuck.
+ *
+ * Where {@link ./redactor.ts | the redactor} replaces a detected secret span with
+ * a `{{PLACEHOLDER}}` and stores the plaintext elsewhere, value-encryption
+ * replaces the *same* span with an inline, self-contained ciphertext token:
+ *
+ *   AWS_SECRET_ACCESS_KEY=ENC[tuck:v1:<base64>]
+ *
+ * Only the secret VALUE changes. Keys, structure, comments, and whitespace stay
+ * plaintext, so `git diff`, `git merge`, and code review keep working on the
+ * encrypted file — the property git-crypt and whole-file encryption throw away.
+ *
+ * Each token is independently decryptable (it carries its own KDF params, salt,
+ * IV, and auth tag), so a three-way merge that moves or reorders lines never
+ * corrupts a value. Within a single {@link encryptContentValues} call every new
+ * token shares one salt so the key derivation (PBKDF2) runs once regardless of
+ * how many values are encrypted; re-encrypting a file only touches values that
+ * are still plaintext, leaving existing tokens byte-for-byte unchanged for clean
+ * diffs.
+ *
+ * Crypto: PBKDF2-HMAC-SHA256 (OWASP-recommended 600k iterations) → 32-byte key,
+ * AES-256-GCM with a unique 96-bit nonce per value. This mirrors
+ * {@link ../crypto/fileEncryption.ts} but packs the parameters into a compact,
+ * text-embeddable token instead of a binary file header.
+ */
+
+import {
+  randomBytes,
+  createCipheriv,
+  createDecipheriv,
+  pbkdf2 as pbkdf2Cb,
+} from 'node:crypto';
+import { promisify } from 'node:util';
+import { readFile, stat } from 'node:fs/promises';
+import { expandPath, pathExists } from '../paths.js';
+import { atomicWriteFile } from '../files.js';
+import { EncryptionError, DecryptionError } from '../../errors.js';
+import type { SecretMatch } from './scanner.js';
+
+const pbkdf2 = promisify(pbkdf2Cb);
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const TOKEN_PREFIX = 'ENC[tuck:v1:';
+const TOKEN_SUFFIX = ']';
+
+const ITER_LENGTH = 4; // uint32 BE iteration count
+const SALT_LENGTH = 16;
+const IV_LENGTH = 12; // GCM nonce
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32; // 256 bits
+const PBKDF2_DIGEST = 'sha256';
+const ALGORITHM = 'aes-256-gcm';
+
+// Current KDF cost. OWASP recommends >= 600,000 for PBKDF2-HMAC-SHA256.
+const PBKDF2_ITERATIONS = 600_000;
+// Guard a malicious/corrupt token from forcing an absurd (DoS) or zero-cost KDF.
+const MIN_PBKDF2_ITERATIONS = 1;
+const MAX_PBKDF2_ITERATIONS = 10_000_000;
+
+const MIN_PAYLOAD_LENGTH = ITER_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH;
+
+/**
+ * Matches a value-encryption token and captures its base64 payload. The base64
+ * alphabet (`A-Za-z0-9+/=`) never contains the `]` terminator, so the match is
+ * unambiguous even when several tokens sit on one line.
+ */
+export const VALUE_TOKEN_REGEX = /ENC\[tuck:v1:([A-Za-z0-9+/=]+)\]/g;
+
+// ============================================================================
+// Token helpers
+// ============================================================================
+
+/** Wrap a base64 payload in the value-token envelope. */
+export const formatValueToken = (payloadBase64: string): string =>
+  `${TOKEN_PREFIX}${payloadBase64}${TOKEN_SUFFIX}`;
+
+/** Extract the base64 payload from a token, or null when it is not a token. */
+export const parseValueToken = (token: string): string | null => {
+  const match = token.match(/^ENC\[tuck:v1:([A-Za-z0-9+/=]+)\]$/);
+  return match ? match[1] : null;
+};
+
+/** True when the whole string is exactly one value-encryption token. */
+export const isValueToken = (value: string): boolean => parseValueToken(value) !== null;
+
+/** True when the content contains at least one value-encryption token. */
+export const hasEncryptedValues = (content: string): boolean => {
+  // Fresh instance so the shared regex's lastIndex is never carried across calls.
+  const regex = new RegExp(VALUE_TOKEN_REGEX.source, VALUE_TOKEN_REGEX.flags);
+  return regex.test(content);
+};
+
+/** Count the value-encryption tokens in the content. */
+export const countEncryptedValues = (content: string): number => {
+  const matches = content.match(VALUE_TOKEN_REGEX);
+  return matches ? matches.length : 0;
+};
+
+/** Return each token string (e.g. `ENC[tuck:v1:...]`) present in the content. */
+export const findValueTokens = (content: string): string[] => {
+  const regex = new RegExp(VALUE_TOKEN_REGEX.source, VALUE_TOKEN_REGEX.flags);
+  const tokens: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) {
+    tokens.push(match[0]);
+  }
+  return tokens;
+};
+
+// ============================================================================
+// Single-value crypto
+// ============================================================================
+
+/** Derived key + the salt it came from, so callers can reuse one derivation. */
+interface DerivedKey {
+  key: Buffer;
+  salt: Buffer;
+  iterations: number;
+}
+
+const deriveValueKey = async (passphrase: string, salt: Buffer): Promise<Buffer> => {
+  return pbkdf2(passphrase, salt, PBKDF2_ITERATIONS, KEY_LENGTH, PBKDF2_DIGEST);
+};
+
+/**
+ * Encrypt a single plaintext value into a token payload using a pre-derived key.
+ * A fresh IV is generated per value so reusing one key across many values within
+ * a file stays GCM-safe.
+ */
+const encryptWithKey = (plaintext: string, derived: DerivedKey): string => {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, derived.key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(plaintext, 'utf8')),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  const iters = Buffer.alloc(ITER_LENGTH);
+  iters.writeUInt32BE(derived.iterations);
+
+  const payload = Buffer.concat([iters, derived.salt, iv, authTag, ciphertext]);
+  return formatValueToken(payload.toString('base64'));
+};
+
+/**
+ * Encrypt one value into a self-contained token (its own salt + key derivation).
+ * Prefer {@link encryptContentValues} for files — it derives the key once for all
+ * values. Exposed for tests and single-value callers.
+ */
+export const encryptValue = async (plaintext: string, passphrase: string): Promise<string> => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new EncryptionError('Passphrase must be a non-empty string');
+  }
+  const salt = randomBytes(SALT_LENGTH);
+  const key = await deriveValueKey(passphrase, salt);
+  return encryptWithKey(plaintext, { key, salt, iterations: PBKDF2_ITERATIONS });
+};
+
+/**
+ * Decrypt a single value token back to its plaintext.
+ *
+ * Throws {@link DecryptionError} on a malformed token, an out-of-range iteration
+ * count, or an authentication failure (wrong passphrase / tampered ciphertext).
+ */
+export const decryptValue = async (token: string, passphrase: string): Promise<string> => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new DecryptionError('Passphrase must be a non-empty string');
+  }
+  const base64 = parseValueToken(token);
+  if (base64 === null) {
+    throw new DecryptionError('Not a tuck value-encryption token');
+  }
+
+  let payload: Buffer;
+  try {
+    payload = Buffer.from(base64, 'base64');
+  } catch {
+    throw new DecryptionError('Value token payload is not valid base64');
+  }
+  if (payload.length < MIN_PAYLOAD_LENGTH) {
+    throw new DecryptionError('Value token is too short to contain a valid header');
+  }
+
+  let offset = 0;
+  const iterations = payload.readUInt32BE(offset);
+  offset += ITER_LENGTH;
+  if (iterations < MIN_PBKDF2_ITERATIONS || iterations > MAX_PBKDF2_ITERATIONS) {
+    throw new DecryptionError('Value token declares an out-of-range iteration count');
+  }
+  const salt = payload.subarray(offset, (offset += SALT_LENGTH));
+  const iv = payload.subarray(offset, (offset += IV_LENGTH));
+  const authTag = payload.subarray(offset, (offset += AUTH_TAG_LENGTH));
+  const ciphertext = payload.subarray(offset);
+
+  try {
+    const key = await pbkdf2(passphrase, salt, iterations, KEY_LENGTH, PBKDF2_DIGEST);
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return plaintext.toString('utf8');
+  } catch {
+    throw new DecryptionError('Failed to decrypt value: wrong passphrase or corrupted token', [
+      'Verify the encryption passphrase is correct',
+      'Ensure the token was not modified',
+    ]);
+  }
+};
+
+// ============================================================================
+// Content-level operations
+// ============================================================================
+
+export interface EncryptValuesResult {
+  content: string;
+  /** Number of distinct secret values that were encrypted into new tokens. */
+  encrypted: number;
+  /** Distinct values skipped because they already sat inside an existing token. */
+  skipped: number;
+}
+
+export interface DecryptValuesResult {
+  content: string;
+  /** Number of tokens successfully decrypted. */
+  decrypted: number;
+  /** Tokens that could not be decrypted (wrong passphrase / corruption). */
+  failed: number;
+}
+
+/**
+ * Replace each detected secret span with an inline ciphertext token, encrypting
+ * every new value under a single key derivation.
+ *
+ * Longest values are replaced first: when a shorter secret is a literal
+ * substring of a longer one, replacing the shorter first would rewrite the
+ * longer secret's prefix and leak its tail — the same ordering rule the redactor
+ * uses. Values that already appear only inside an existing token are skipped so
+ * re-encrypting a file never double-encrypts its own ciphertext.
+ */
+export const encryptContentValues = async (
+  content: string,
+  matches: SecretMatch[],
+  passphrase: string
+): Promise<EncryptValuesResult> => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new EncryptionError('Passphrase must be a non-empty string');
+  }
+
+  // Unique secret values, longest first.
+  const uniqueValues = [...new Set(matches.map((m) => m.value))].sort(
+    (a, b) => b.length - a.length
+  );
+
+  if (uniqueValues.length === 0) {
+    return { content, encrypted: 0, skipped: 0 };
+  }
+
+  // Regions already occupied by tokens — a value found only inside one of these
+  // is ciphertext we must not re-encrypt.
+  const existingTokens = findValueTokens(content);
+
+  // Derive the key ONCE for every value encrypted in this call.
+  const salt = randomBytes(SALT_LENGTH);
+  const key = await deriveValueKey(passphrase, salt);
+  const derived: DerivedKey = { key, salt, iterations: PBKDF2_ITERATIONS };
+
+  let result = content;
+  let encrypted = 0;
+  let skipped = 0;
+
+  for (const value of uniqueValues) {
+    if (!result.includes(value)) {
+      continue;
+    }
+    // Skip a value that only ever appears as part of an existing token's base64
+    // payload (i.e. it is already-encrypted content, not a live secret).
+    const appearsOutsideTokens = occursOutsideTokens(result, value, existingTokens);
+    if (!appearsOutsideTokens) {
+      skipped++;
+      continue;
+    }
+
+    const token = encryptWithKey(value, derived);
+    // Two-step replace via a random marker so the freshly inserted token (which
+    // contains base64 that could, in theory, contain a later `value`) is never
+    // itself rewritten by a subsequent iteration.
+    const marker = ` TUCK_ENC_${randomBytes(12).toString('hex')} `;
+    result = result.split(value).join(marker);
+    result = result.split(marker).join(token);
+    encrypted++;
+  }
+
+  return { content: result, encrypted, skipped };
+};
+
+/**
+ * True when `value` occurs somewhere in `content` outside of the given token
+ * strings. Used to avoid re-encrypting a value that only exists as part of an
+ * already-present ciphertext token.
+ */
+const occursOutsideTokens = (
+  content: string,
+  value: string,
+  tokens: string[]
+): boolean => {
+  if (tokens.length === 0) {
+    return content.includes(value);
+  }
+  // Blank out every token region, then check if the value still appears.
+  let masked = content;
+  for (const token of tokens) {
+    masked = masked.split(token).join(' '.repeat(token.length));
+  }
+  return masked.includes(value);
+};
+
+/**
+ * Replace every value token in `content` with its decrypted plaintext.
+ *
+ * Tokens are decrypted independently; a per-salt key cache means files written
+ * by a single {@link encryptContentValues} call derive the key just once. When
+ * `throwOnFailure` is true (the default) the first undecryptable token throws;
+ * otherwise failures are counted and their tokens left in place.
+ */
+export const decryptContentValues = async (
+  content: string,
+  passphrase: string,
+  options: { throwOnFailure?: boolean } = {}
+): Promise<DecryptValuesResult> => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new DecryptionError('Passphrase must be a non-empty string');
+  }
+  const throwOnFailure = options.throwOnFailure ?? true;
+
+  const tokens = [...new Set(findValueTokens(content))];
+  if (tokens.length === 0) {
+    return { content, decrypted: 0, failed: 0 };
+  }
+
+  let result = content;
+  let decrypted = 0;
+  let failed = 0;
+
+  for (const token of tokens) {
+    try {
+      const plaintext = await decryptValue(token, passphrase);
+      // Two-step replace via a random marker: a decrypted plaintext could, in a
+      // pathological case, contain another not-yet-processed token's text, so we
+      // never insert plaintext where a later iteration might rescan it. split/join
+      // is a LITERAL replace (unlike String.replace it never interprets
+      // `$`-sequences in the secret), preserving the credential byte-for-byte.
+      const marker = ` TUCK_DEC_${randomBytes(12).toString('hex')} `;
+      result = result.split(token).join(marker);
+      result = result.split(marker).join(plaintext);
+      decrypted++;
+    } catch (error) {
+      if (throwOnFailure) {
+        throw error;
+      }
+      failed++;
+    }
+  }
+
+  return { content: result, decrypted, failed };
+};
+
+// ============================================================================
+// File-level operations
+// ============================================================================
+
+export interface EncryptFileResult extends EncryptValuesResult {
+  /** True when the file content changed and was rewritten. */
+  changed: boolean;
+}
+
+export interface DecryptFileResult extends DecryptValuesResult {
+  /** True when the file content changed and was rewritten. */
+  changed: boolean;
+}
+
+/**
+ * Encrypt detected secret values in a file in place, preserving its structure.
+ *
+ * Uses an atomic write so a crash mid-write never truncates the file. Returns
+ * `changed: false` (without touching the file) when nothing was encrypted.
+ */
+export const encryptFileValues = async (
+  filepath: string,
+  matches: SecretMatch[],
+  passphrase: string
+): Promise<EncryptFileResult> => {
+  const expandedPath = expandPath(filepath);
+  const content = await readFile(expandedPath, 'utf-8');
+  const result = await encryptContentValues(content, matches, passphrase);
+
+  if (result.content === content) {
+    return { ...result, changed: false };
+  }
+
+  await atomicWriteFile(expandedPath, result.content);
+  return { ...result, changed: true };
+};
+
+/**
+ * Decrypt all value tokens in a file in place.
+ *
+ * Uses an atomic write and only rewrites when at least one token decrypted.
+ * Returns `changed: false` when the file has no tokens.
+ */
+export const decryptFileValues = async (
+  filepath: string,
+  passphrase: string,
+  options: { throwOnFailure?: boolean } = {}
+): Promise<DecryptFileResult> => {
+  const expandedPath = expandPath(filepath);
+  const content = await readFile(expandedPath, 'utf-8');
+  const result = await decryptContentValues(content, passphrase, options);
+
+  if (result.decrypted === 0 || result.content === content) {
+    return { ...result, changed: false };
+  }
+
+  await atomicWriteFile(expandedPath, result.content);
+  return { ...result, changed: true };
+};
+
+/**
+ * True when the path is an existing regular file that contains value tokens.
+ * Directories, missing paths, and binary/unreadable files return false.
+ */
+export const fileHasEncryptedValues = async (filepath: string): Promise<boolean> => {
+  const expandedPath = expandPath(filepath);
+  if (!(await pathExists(expandedPath))) {
+    return false;
+  }
+  try {
+    if ((await stat(expandedPath)).isDirectory()) {
+      return false;
+    }
+    const content = await readFile(expandedPath, 'utf-8');
+    return hasEncryptedValues(content);
+  } catch {
+    return false;
+  }
+};

--- a/src/lib/stateModel.ts
+++ b/src/lib/stateModel.ts
@@ -21,6 +21,7 @@ import { getFileChecksum } from './files.js';
 import { getAllTrackedFiles } from './manifest.js';
 import { resolveLiveTarget } from './repoScope.js';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from './materialize.js';
+import { extractSubtree, hasSubtree } from './jsonKey.js';
 import { isReadOnlyMode } from './readOnlyMode.js';
 import { compareLiveToCache, recordDriftEntry } from './crypto/driftCache.js';
 import { getStoredValueMap, getRedactedChecksum } from './secrets/redactor.js';
@@ -137,6 +138,36 @@ export const computeFileState = async (
   if (sourceAbs === null) {
     // Repo-scoped file whose repo is not bound on this machine — cannot compare.
     return entry('unknown-repo', null, repoChecksum);
+  }
+
+  // JSON-key files: the tracked unit is the SUBTREE at `jsonKey`, not the whole
+  // live file. Compare the checksum of the subtree extracted from the LIVE file
+  // against the repo copy (which stores exactly that canonical subtree) — so
+  // machine-managed keys elsewhere in the live file never register as drift.
+  if (file.jsonKey) {
+    const liveExists = await pathExists(sourceAbs);
+    if (!liveExists && repoChecksum === null) return entry('missing-both', null, repoChecksum);
+    if (!liveExists) return entry('missing-live', null, repoChecksum);
+    if (repoChecksum === null) return entry('missing-repo', null, repoChecksum);
+    try {
+      const liveContent = await readFile(sourceAbs, 'utf8');
+      // The tracked key is absent from the live file: the subtree is effectively
+      // missing on this machine (apply would re-add it).
+      if (!hasSubtree(liveContent, file.jsonKey)) return entry('missing-live', null, repoChecksum);
+      const liveSub = extractSubtree(liveContent, file.jsonKey);
+      const liveChecksum = createHash('sha256').update(Buffer.from(liveSub, 'utf8')).digest('hex');
+      const state: FileState =
+        liveChecksum !== repoChecksum
+          ? 'drift-local'
+          : repoChecksum !== file.checksum
+            ? 'drift-repo'
+            : 'ok';
+      return entry(state, liveChecksum, repoChecksum);
+    } catch {
+      // Live file is unreadable / not valid JSON: surface as local drift so the
+      // user investigates, rather than crashing status/verify.
+      return entry('drift-local', null, repoChecksum);
+    }
   }
 
   // Materialized files (template/encrypted): the LIVE form is materialize(repo),

--- a/src/lib/stateModel.ts
+++ b/src/lib/stateModel.ts
@@ -21,6 +21,8 @@ import { getFileChecksum } from './files.js';
 import { getAllTrackedFiles } from './manifest.js';
 import { resolveLiveTarget } from './repoScope.js';
 import { materializeForLive, keystorePassphrase, buildMaterializeCtx } from './materialize.js';
+import { isReadOnlyMode } from './readOnlyMode.js';
+import { compareLiveToCache, recordDriftEntry } from './crypto/driftCache.js';
 import { getStoredValueMap, getRedactedChecksum } from './secrets/redactor.js';
 import type { TemplateContext } from './template.js';
 import type { TrackedFileOutput } from '../schemas/manifest.schema.js';
@@ -150,11 +152,40 @@ export const computeFileState = async (
     if (liveChecksum === null && repoChecksum === null) return entry('missing-both', liveChecksum, repoChecksum);
     if (liveChecksum === null) return entry('missing-live', liveChecksum, repoChecksum);
     if (repoChecksum === null) return entry('missing-repo', liveChecksum, repoChecksum);
+
+    // Read-only + ENCRYPTED: never decrypt (that would unlock the keystore and
+    // could prompt). Detect drift from the keyed-HMAC cache instead — comparing
+    // the live bytes against the last-known-good plaintext fingerprint recorded
+    // by a previous full command (verify/apply). Pure (non-encrypted) templates
+    // touch no secret and are cheap to render, so they fall through to the
+    // materialize path below even in read-only mode.
+    if (isReadOnlyMode() && file.encrypted) {
+      try {
+        const liveBytes = await readFile(sourceAbs);
+        const cmp = await compareLiveToCache(id, liveBytes, repoChecksum);
+        if (cmp === 'mismatch') return entry('drift-local', liveChecksum, repoChecksum);
+        // The repo-vs-manifest comparison is free (no decryption) — apply it on
+        // BOTH the 'match' and 'unknown' branches so a pulled repo change is
+        // still reported when the live fingerprint pin has been invalidated.
+        return entry(repoChecksum !== file.checksum ? 'drift-repo' : 'ok', liveChecksum, repoChecksum);
+      } catch {
+        // Unreadable live path (EISDIR, permissions): degrade to the same
+        // ok-by-presence fallback as the materialize path, never crash status.
+        return entry(repoChecksum !== file.checksum ? 'drift-repo' : 'ok', liveChecksum, repoChecksum);
+      }
+    }
+
     try {
       const useCtx = ctx ?? (await buildMaterializeCtx(tuckDir));
       const raw = await readFile(repoAbs);
       const expected = await materializeForLive(raw, file, useCtx, { getPassphrase: keystorePassphrase });
       const expectedChecksum = createHash('sha256').update(Buffer.from(expected, 'utf8')).digest('hex');
+      // We just materialized the plaintext in a non-read-only run — record its
+      // keyed-HMAC fingerprint so future read-only status/diff can detect drift
+      // in this encrypted file WITHOUT decrypting. Best-effort; never throws.
+      if (file.encrypted) {
+        await recordDriftEntry(id, expected, repoChecksum);
+      }
       // live ≠ materialize(repo) → stale/edited (remedy: `tuck apply`, since sync
       // skips these files). Otherwise raw repo vs manifest distinguishes drift-repo.
       const state: FileState =

--- a/src/lib/trackPipeline.ts
+++ b/src/lib/trackPipeline.ts
@@ -31,6 +31,7 @@ import { readFile } from 'fs/promises';
 import { scanContent } from './secrets/index.js';
 import { logForceSecretBypass, logSecretAllowlisted } from './audit.js';
 import { isJsonMode } from './jsonOutput.js';
+import { loadConfig } from './config.js';
 import {
   getSecretsPath,
   getAllowlistPath,
@@ -40,8 +41,12 @@ import {
   shouldBlockOnSecrets,
   addAllowlistEntryByFingerprint,
   computeFingerprint,
+  createCustomPattern,
+  loadAllowlist,
+  isMatchAllowed,
   type ScanSummary,
   type SecretMatch,
+  type SecretPattern,
 } from './secrets/index.js';
 
 const PRIVATE_KEY_PATTERNS = [
@@ -463,6 +468,45 @@ const applySecretPolicy = async (
 };
 
 /**
+ * Scan an in-memory JSON subtree for secrets the SAME way the whole-file gate
+ * scans a file: honoring config-configured custom patterns, excludes, and
+ * min-severity, then dropping any finding recorded in the committed allowlist.
+ *
+ * The subtree lives only in memory (it is the extracted bytes, never the whole
+ * live file), so we cannot hand it to the file-based {@link scanForSecrets};
+ * instead we replicate its built-in-scanner branch over `content`. Without the
+ * allowlist filter, an allowlisted false positive would permanently block
+ * `tuck add --key` in strict mode and re-prompt forever in interactive mode.
+ */
+const scanSubtreeForSecrets = async (
+  content: string,
+  collapsedLivePath: string,
+  tuckDir: string
+): Promise<SecretMatch[]> => {
+  const config = await loadConfig(tuckDir);
+  const security = config.security || {};
+
+  const customPatterns: SecretPattern[] = (security.customPatterns || []).map((p, i) =>
+    createCustomPattern(`config-${i}`, p.name || `Custom Pattern ${i + 1}`, p.pattern, {
+      severity: p.severity,
+      description: p.description,
+      placeholder: p.placeholder,
+      flags: p.flags,
+    })
+  );
+
+  const matches = scanContent(content, {
+    customPatterns: customPatterns.length > 0 ? customPatterns : undefined,
+    excludePatternIds: security.excludePatterns,
+    minSeverity: security.minSeverity,
+  });
+
+  const allowlist = await loadAllowlist(tuckDir);
+  if (allowlist.entries.length === 0) return matches;
+  return matches.filter((match) => !isMatchAllowed(match, collapsedLivePath, allowlist.entries));
+};
+
+/**
  * Secret gate for JSON-key files: scans ONLY the extracted subtree (the bytes
  * that will actually land in the repo), not the whole live file. This is what
  * makes the feature usable — a `~/.claude.json` mixes `mcpServers` with OAuth
@@ -504,7 +548,10 @@ const applyJsonKeySecretPolicy = async (
     const live = file.liveSource ?? expandPath(file.source);
     const content = await readFile(live, 'utf8');
     const subtree = extractSubtree(content, file.jsonKey as string);
-    const matches = scanContent(subtree);
+    // Allowlist- and custom-pattern-aware (mirrors the whole-file gate): an
+    // allowlisted finding must NOT block the add, or strict mode re-prompts
+    // forever. The path used for path-scoped allowlist entries is the live file.
+    const matches = await scanSubtreeForSecrets(subtree, collapsePath(live), tuckDir);
     if (matches.length > 0) {
       withSecrets.push({ file, count: matches.length });
     }

--- a/src/lib/trackPipeline.ts
+++ b/src/lib/trackPipeline.ts
@@ -25,14 +25,17 @@ import {
   PrivateKeyError,
   SecretsDetectedError,
 } from '../errors.js';
-import { logForceSecretBypass } from './audit.js';
+import { logForceSecretBypass, logSecretAllowlisted } from './audit.js';
 import { isJsonMode } from './jsonOutput.js';
 import {
   getSecretsPath,
+  getAllowlistPath,
   isSecretScanningEnabled,
   processSecretsForRedaction,
   scanForSecrets,
   shouldBlockOnSecrets,
+  addAllowlistEntryByFingerprint,
+  computeFingerprint,
   type ScanSummary,
   type SecretMatch,
 } from './secrets/index.js';
@@ -312,6 +315,11 @@ const applySecretPolicy = async (
       label: 'Replace with placeholders',
       hint: 'Repo copy gets placeholders; live file untouched. Originals in secrets.local.json (never committed)',
     },
+    {
+      value: 'allow',
+      label: 'Mark as safe (allowlist)',
+      hint: 'False positive? Record in secrets.allow.json and track',
+    },
     { value: 'ignore', label: 'Add files to .tuckignore', hint: 'Skip these files permanently' },
     { value: 'proceed', label: 'Proceed anyway', hint: 'Track files with secrets (dangerous!)' },
   ]);
@@ -319,6 +327,38 @@ const applySecretPolicy = async (
   if (action === 'abort') {
     logger.info('Operation aborted');
     return [];
+  }
+
+  if (action === 'allow') {
+    const reason = await prompts.text(
+      'Why are these findings safe? (recorded in the allowlist)',
+      { placeholder: 'e.g. example values from docs, not real secrets' }
+    );
+    if (!reason || reason.trim().length === 0) {
+      logger.info('Operation aborted (a reason is required to allowlist)');
+      return [];
+    }
+    let allowlisted = 0;
+    for (const result of summary.results) {
+      if (!result.hasSecrets) continue;
+      for (const match of result.matches) {
+        const entry = await addAllowlistEntryByFingerprint(
+          tuckDir,
+          computeFingerprint(match.value),
+          { reason: reason.trim(), pattern: match.patternId, path: result.collapsedPath }
+        );
+        await logSecretAllowlisted(entry.fingerprint, entry.reason, {
+          pattern: entry.pattern,
+          path: entry.path,
+        });
+        allowlisted++;
+      }
+    }
+    console.log();
+    logger.success(`Allowlisted ${allowlisted} finding${allowlisted === 1 ? '' : 's'} as safe`);
+    logger.dim(`Recorded in ${collapsePath(getAllowlistPath(tuckDir))} (commit it to share)`);
+    console.log();
+    return files;
   }
 
   if (action === 'redact') {

--- a/src/lib/trackPipeline.ts
+++ b/src/lib/trackPipeline.ts
@@ -21,10 +21,14 @@ import { addToTuckignore, isIgnored } from './tuckignore.js';
 import {
   FileAlreadyTrackedError,
   FileNotFoundError,
+  JsonKeyError,
   OperationCancelledError,
   PrivateKeyError,
   SecretsDetectedError,
 } from '../errors.js';
+import { extractSubtree } from './jsonKey.js';
+import { readFile } from 'fs/promises';
+import { scanContent } from './secrets/index.js';
 import { logForceSecretBypass, logSecretAllowlisted } from './audit.js';
 import { isJsonMode } from './jsonOutput.js';
 import {
@@ -99,6 +103,11 @@ export interface PreparedTrackFile {
   remoteUrl?: string;
   /** Absolute live path to copy FROM (repo scope only). */
   liveSource?: string;
+  /**
+   * Dot-delimited JSON key path when tracking only a subtree of a JSON file
+   * (e.g. `mcpServers`). The repo copy holds just that subtree.
+   */
+  jsonKey?: string;
   /** Redaction plans for secret-bearing files: applied to the REPO copy after
    *  the copy step; the live file is never modified (issue #100 RC5). For a
    *  tracked DIRECTORY, livePath points at the inner file that holds the secret. */
@@ -131,6 +140,11 @@ export interface PreparePathsForTrackingOptions {
   repo?: string | boolean;
   /** Explicit repoKey override (advanced; default derives from the remote). */
   repoKey?: string;
+  /**
+   * Track only the JSON subtree at this dot-delimited key path (e.g.
+   * `mcpServers`) instead of the whole file.
+   */
+  jsonKey?: string;
 }
 
 const isPrivateKey = (collapsedPath: string): boolean => {
@@ -448,6 +462,89 @@ const applySecretPolicy = async (
   return files;
 };
 
+/**
+ * Secret gate for JSON-key files: scans ONLY the extracted subtree (the bytes
+ * that will actually land in the repo), not the whole live file. This is what
+ * makes the feature usable — a `~/.claude.json` mixes `mcpServers` with OAuth
+ * tokens and history, and scanning the whole file would block tracking the
+ * safe subtree. Mirrors {@link applySecretPolicy}'s force/strict/interactive
+ * decision structure at a subtree granularity (redact/ignore are omitted: a
+ * placeholder rewrite of a temporary in-memory subtree has nothing to persist).
+ */
+const applyJsonKeySecretPolicy = async (
+  files: PreparedTrackFile[],
+  tuckDir: string,
+  options: PreparePathsForTrackingOptions
+): Promise<PreparedTrackFile[]> => {
+  if (files.length === 0) return files;
+  if (!(await isSecretScanningEnabled(tuckDir))) return files;
+
+  const secretHandling = options.secretHandling ?? 'interactive';
+
+  if (options.force) {
+    if (secretHandling === 'interactive') {
+      const confirmed = await prompts.confirmDangerous(
+        'Using --force bypasses secret scanning.\n' +
+          'Any secrets in the tracked JSON subtree may be committed to git and potentially exposed.',
+        'force'
+      );
+      if (!confirmed) {
+        logger.info('Operation cancelled');
+        return [];
+      }
+    }
+    logger.warning('Secret scanning bypassed with --force');
+    await logForceSecretBypass(options.forceBypassCommand ?? 'tuck add --force', files.length);
+    return files;
+  }
+
+  // Scan each subtree independently so a finding maps back to exactly one file.
+  const withSecrets: Array<{ file: PreparedTrackFile; count: number }> = [];
+  for (const file of files) {
+    const live = file.liveSource ?? expandPath(file.source);
+    const content = await readFile(live, 'utf8');
+    const subtree = extractSubtree(content, file.jsonKey as string);
+    const matches = scanContent(subtree);
+    if (matches.length > 0) {
+      withSecrets.push({ file, count: matches.length });
+    }
+  }
+
+  if (withSecrets.length === 0) return files;
+
+  const totalSecrets = withSecrets.reduce((sum, w) => sum + w.count, 0);
+  const affected = withSecrets.map((w) => `${collapsePath(w.file.source)} (--key ${w.file.jsonKey})`);
+
+  if (secretHandling === 'strict') {
+    if (await shouldBlockOnSecrets(tuckDir)) {
+      throw new SecretsDetectedError(totalSecrets, affected);
+    }
+    logger.warning('Secrets detected in a tracked JSON subtree but blockOnSecrets is disabled - proceeding');
+    logger.warning('Make sure your repository is private!');
+    return files;
+  }
+
+  console.log();
+  console.log(
+    c.error(c.bold(`  Security Warning: Found ${totalSecrets} potential secret(s) in the tracked JSON subtree`))
+  );
+  for (const entry of affected) {
+    console.log(`    ${c.brand(entry)}`);
+  }
+  console.log();
+
+  const proceed = await prompts.confirm(
+    c.error('The tracked JSON subtree contains potential secrets. Track it anyway?'),
+    false
+  );
+  if (!proceed) {
+    logger.info('Operation aborted');
+    return [];
+  }
+  logger.warning('Proceeding with secrets - make sure your repository is private!');
+  return files;
+};
+
 export const preparePathsForTracking = async (
   candidates: TrackPathCandidate[],
   tuckDir: string,
@@ -456,6 +553,19 @@ export const preparePathsForTracking = async (
   const secretHandling = options.secretHandling ?? 'interactive';
   const prepared: PreparedTrackFile[] = [];
   const isRepoScoped = options.repo !== undefined && options.repo !== false;
+  const jsonKey = options.jsonKey?.trim() ? options.jsonKey.trim() : undefined;
+
+  // JSON-key tracking is a home-scoped, single-file operation in v1: it extracts
+  // one JSON subtree per file. Repo-scoped or multi-path combos are rejected up
+  // front so the user gets a clear message instead of a confusing partial result.
+  if (jsonKey) {
+    if (isRepoScoped) {
+      throw new JsonKeyError('--key cannot be combined with --repo (v1 tracks JSON subtrees home-scoped only)');
+    }
+    if (candidates.length !== 1) {
+      throw new JsonKeyError('--key tracks a single JSON file; pass exactly one path');
+    }
+  }
 
   for (const candidate of candidates) {
     const expandedPath = expandPath(candidate.path);
@@ -541,6 +651,19 @@ export const preparePathsForTracking = async (
     }
 
     const isDir = await isDirectory(expandedPath);
+
+    // JSON-key tracking: validate the file is a single JSON file that actually
+    // contains the requested key path BEFORE it enters the manifest, so a typo
+    // or non-JSON file fails loudly at `tuck add` time rather than on apply.
+    if (jsonKey) {
+      if (isDir) {
+        throw new JsonKeyError(`--key requires a single JSON file, but ${candidate.path} is a directory`);
+      }
+      const content = await readFile(expandedPath, 'utf8');
+      // Throws JsonKeyError with a precise reason (bad JSON / missing key).
+      extractSubtree(content, jsonKey);
+    }
+
     const fileCount = isDir ? await getDirectoryFileCount(expandedPath) : 1;
     const category = candidate.category || options.category || detectCategory(expandedPath);
     const customName = candidate.name ?? options.name;
@@ -576,8 +699,18 @@ export const preparePathsForTracking = async (
       isDir,
       fileCount,
       sensitive: isSensitiveFile(trackingId),
+      ...(jsonKey ? { jsonKey } : {}),
     });
   }
 
-  return applySecretPolicy(prepared, tuckDir, options);
+  // JSON-key files scan only their extracted SUBTREE for secrets (not the whole
+  // file): the whole point of the feature is to track e.g. `mcpServers` while
+  // leaving OAuth tokens elsewhere in the file behind, so a token OUTSIDE the
+  // tracked subtree must not block the add. Whole-file entries keep the existing
+  // path-based secret policy untouched.
+  const jsonKeyFiles = prepared.filter((f) => f.jsonKey);
+  const wholeFileEntries = prepared.filter((f) => !f.jsonKey);
+  const survivingJsonKey = await applyJsonKeySecretPolicy(jsonKeyFiles, tuckDir, options);
+  const survivingWhole = await applySecretPolicy(wholeFileEntries, tuckDir, options);
+  return [...survivingJsonKey, ...survivingWhole];
 };

--- a/src/lib/undoHint.ts
+++ b/src/lib/undoHint.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical one-line "restore with tuck undo" breadcrumb.
+ *
+ * tuck already captures a time-machine snapshot before every destructive
+ * mutation (apply, sync pull/conflict resolution, remove --delete). Surfacing
+ * that snapshot as a visible, copy-pasteable recovery path — right after the
+ * mutation happens — is the trust story that answers the "first apply is
+ * destructive" fear (IDEAS 6.5). Every destructive flow prints the SAME line so
+ * users learn one recovery command.
+ *
+ * When the caller knows the exact snapshot id it just created, pass it so the
+ * breadcrumb pins the undo to that precise checkpoint; otherwise the generic
+ * `--latest` form is shown.
+ */
+export const undoBreadcrumb = (snapshotId?: string): string =>
+  snapshotId
+    ? `Undo this change: tuck undo ${snapshotId}  (or tuck undo --latest)`
+    : 'Undo this change: tuck undo --latest';
+
+/** Short title used for boxed/labelled breadcrumb notes. */
+export const UNDO_BREADCRUMB_TITLE = 'Undo';

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -9,6 +9,7 @@ import chalk from 'chalk';
 import boxen from 'boxen';
 import { createInterface } from 'readline';
 import { APP_NAME, VERSION } from '../constants.js';
+import { isNonInteractive } from './agentMode.js';
 
 // Package info for update-notifier
 const pkg = {
@@ -114,9 +115,11 @@ const executeUpdate = (packageManager: 'npm' | 'pnpm'): boolean => {
 };
 
 /**
- * Check if running in an environment where we should skip update checks
+ * Check if running in an environment where we should skip update checks.
+ *
+ * Exported for unit testing of the skip conditions.
  */
-const shouldSkipUpdateCheck = (): boolean => {
+export const shouldSkipUpdateCheck = (): boolean => {
   // Skip in CI environments
   if (process.env.CI) {
     return true;
@@ -133,8 +136,12 @@ const shouldSkipUpdateCheck = (): boolean => {
     return true;
   }
 
-  // Skip if not a TTY (non-interactive)
-  if (!process.stdin.isTTY) {
+  // Skip whenever the CLI is running non-interactively: an explicit
+  // `--non-interactive`, `--json`, or a non-TTY stdin. The update prompt uses a
+  // raw readline (waitForEnterOrCancel) that bypasses the clack interactive gate,
+  // so without this an agent driving tuck in a PTY would block forever. This also
+  // subsumes the previous bare `!process.stdin.isTTY` check.
+  if (isNonInteractive()) {
     return true;
   }
 

--- a/src/lib/writeContext.ts
+++ b/src/lib/writeContext.ts
@@ -35,6 +35,20 @@ export const setKnownRepoRoots = (roots: string[]): void => {
   knownRepoRoots = roots.map((r) => resolve(r));
 };
 
+/**
+ * Merge additional repo roots into the allowed-write set WITHOUT dropping the
+ * ones the CLI preAction already registered. Used by operations that write into
+ * a repo the user is currently sitting in but which is not (yet) in the machine
+ * repo registry — e.g. rules fan-out materializing per-tool variants into the
+ * current checkout. A no-op in sandbox mode, where `allowedRoots()` is only the
+ * sandbox root regardless.
+ */
+export const addKnownRepoRoots = (roots: string[]): void => {
+  const merged = new Set(knownRepoRoots);
+  for (const r of roots) merged.add(resolve(r));
+  knownRepoRoots = Array.from(merged);
+};
+
 /** Test-only: clear the context back to the default (real home). */
 export const resetWriteContext = (): void => {
   ctx = null;

--- a/src/schemas/driftCache.schema.ts
+++ b/src/schemas/driftCache.schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+/**
+ * A single tracked file's last-known-good plaintext fingerprint.
+ *
+ * `plaintextHmac` is a keyed HMAC-SHA256 (hex) of the plaintext tuck last knew
+ * belonged on the live system for this file. The HMAC key is machine-local (see
+ * `driftCache.ts`), so this fingerprint reveals nothing about the secret to
+ * anyone who does not already hold that local key — which is exactly why it is
+ * safe to compare against WITHOUT decrypting anything.
+ *
+ * `repoChecksum` pins the fingerprint to the repo copy it was derived from: if
+ * the repo file changes (e.g. a `git pull`), the entry is considered stale and
+ * ignored until a full command re-derives it.
+ */
+export const driftEntrySchema = z.object({
+  plaintextHmac: z.string(),
+  repoChecksum: z.string(),
+  updated: z.string(),
+});
+
+export const driftCacheSchema = z.object({
+  version: z.literal(1),
+  entries: z.record(driftEntrySchema).default({}),
+});
+
+export type DriftEntry = z.output<typeof driftEntrySchema>;
+export type DriftCache = z.output<typeof driftCacheSchema>;

--- a/src/schemas/manifest.schema.ts
+++ b/src/schemas/manifest.schema.ts
@@ -100,6 +100,17 @@ export const trackedFileSchema = z
     /** POSIX path of the file relative to the repo root. */
     repoRelative: z.string().optional(),
     /**
+     * JSON-key-scoped tracking. ABSENT (undefined) means the whole file is
+     * tracked, exactly as before (this field is `.optional()`, never
+     * `.default()`, so legacy manifests parse byte-identical). When present it
+     * is a dot-delimited key path (e.g. `mcpServers`): the repo copy holds ONLY
+     * that JSON subtree, and on apply/restore it is deep-merged back into the
+     * live file, leaving every other key untouched. Mutually exclusive with
+     * template/encrypted (the repo copy is a plain JSON subtree, not a
+     * rendered/ciphertext artifact).
+     */
+    jsonKey: z.string().optional(),
+    /**
      * Optional structured three-way merge policy. When set, `tuck sync`
      * reconciles this file key-by-key instead of overwriting it wholesale.
      * Undefined for the vast majority of files (plain copy semantics).
@@ -122,6 +133,14 @@ export const trackedFileSchema = z
     requires: z.array(z.string()).optional(),
   })
   .superRefine((file, ctx) => {
+    if (file.jsonKey !== undefined) {
+      if (file.jsonKey.trim() === '') {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['jsonKey'], message: 'jsonKey must be a non-empty key path' });
+      }
+      if (file.template || file.encrypted) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['jsonKey'], message: 'jsonKey cannot be combined with template or encrypted' });
+      }
+    }
     if (file.scope === 'repo') {
       if (!file.repoKey) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['repoKey'], message: 'repoKey is required for repo-scoped files' });

--- a/src/schemas/manifest.schema.ts
+++ b/src/schemas/manifest.schema.ts
@@ -104,8 +104,8 @@ export const trackedFileSchema = z
      * tracked, exactly as before (this field is `.optional()`, never
      * `.default()`, so legacy manifests parse byte-identical). When present it
      * is a dot-delimited key path (e.g. `mcpServers`): the repo copy holds ONLY
-     * that JSON subtree, and on apply/restore it is deep-merged back into the
-     * live file, leaving every other key untouched. Mutually exclusive with
+     * that JSON subtree, and on apply/restore it REPLACES the value at that path
+     * in the live file, leaving every other key untouched. Mutually exclusive with
      * template/encrypted (the repo copy is a plain JSON subtree, not a
      * rendered/ciphertext artifact).
      */

--- a/src/schemas/manifest.schema.ts
+++ b/src/schemas/manifest.schema.ts
@@ -3,6 +3,39 @@ import { z } from 'zod';
 export const fileStrategySchema = z.enum(['copy', 'symlink']);
 
 /**
+ * How arrays are reconciled during a structured (JSON) three-way merge.
+ * - `union`   — combine both sides, dropping deep-duplicate entries (default;
+ *               ideal for allowlists like Claude permission `allow`/`deny`).
+ * - `concat`  — append both sides verbatim, keeping duplicates.
+ * - `replace` — treat a diverged array as a scalar conflict (resolved via the
+ *               `conflict` strategy) instead of combining.
+ */
+export const arrayMergeStrategySchema = z.enum(['union', 'concat', 'replace']);
+
+/**
+ * How an irreconcilable scalar/type conflict is resolved during a structured
+ * merge (both sides changed the same leaf to different values).
+ * - `ours`   — always keep the local value.
+ * - `theirs` — always take the incoming value.
+ * - `manual` — surface the conflict and stop instead of guessing (default).
+ */
+export const conflictResolutionSchema = z.enum(['ours', 'theirs', 'manual']);
+
+/**
+ * Per-file structured-merge policy. When present, `tuck sync` performs a
+ * key-level three-way merge of the tracked file instead of a silent
+ * whole-file overwrite when local and remote have both diverged. Absent
+ * (undefined) preserves the legacy behavior, so existing manifests parse
+ * byte-identical (this field is `.optional()`, never `.default()`).
+ */
+export const mergePolicySchema = z.object({
+  /** Structured format to parse. Only JSON is supported in v1. */
+  format: z.literal('json'),
+  arrays: arrayMergeStrategySchema.default('union'),
+  conflict: conflictResolutionSchema.default('manual'),
+});
+
+/**
  * Profile/tag name grammar. A tag names a machine PROFILE (work, personal,
  * server, agent, …). Constrained to a filename-safe, shell-safe subset so a tag
  * can appear on the CLI and in JSON without quoting surprises — the same
@@ -66,6 +99,12 @@ export const trackedFileSchema = z
     repoKey: z.string().optional(),
     /** POSIX path of the file relative to the repo root. */
     repoRelative: z.string().optional(),
+    /**
+     * Optional structured three-way merge policy. When set, `tuck sync`
+     * reconciles this file key-by-key instead of overwriting it wholesale.
+     * Undefined for the vast majority of files (plain copy semantics).
+     */
+    merge: mergePolicySchema.optional(),
     /**
      * Declarative dependencies for this entry (IDEAS 2.3). Each value is a
      * `<manager>:<package>` spec (e.g. `brew:starship`, `apt:zsh`) that must be

--- a/src/schemas/osSettings.schema.ts
+++ b/src/schemas/osSettings.schema.ts
@@ -1,0 +1,89 @@
+/**
+ * Zod schemas for `tuck settings` — versioned OS settings.
+ *
+ * Two on-disk artifacts are validated here:
+ *
+ *   1. The SHARED settings manifest (`os-settings.json`, committed to the tuck
+ *      repo). It records captured OS settings (macOS `defaults` writes) and a
+ *      manual-steps checklist. Because it round-trips across machines and can be
+ *      pulled from an untrusted remote, it is always parsed, never `as`-cast.
+ *
+ *   2. The MACHINE-LOCAL state (`os-settings-state.json`, in the platform state
+ *      dir, never committed). It records which manual steps the user has
+ *      completed ON THIS MACHINE.
+ *
+ * The `os` discriminator ('macos' today) and the optional min/max version
+ * guards are what let apply mode replay a setting safely on a machine whose OS
+ * version may differ from where the setting was captured. Linux/dconf can be
+ * added later by extending the `os` enum and adding a backend.
+ */
+import { z } from 'zod';
+
+/**
+ * Supported scalar `defaults` value types. Complex plist containers
+ * (dictionary/array) and opaque `data` are intentionally excluded from v1
+ * auto-capture — a GUI toggle almost always writes one of these scalars, and
+ * replaying a raw container safely is out of scope. Such changes are surfaced
+ * as a suggestion to record a manual step instead.
+ */
+export const settingTypeSchema = z.enum(['boolean', 'integer', 'float', 'string', 'date']);
+export type SettingType = z.infer<typeof settingTypeSchema>;
+
+/** Whether apply should `defaults write` a value or `defaults delete` the key. */
+export const settingActionSchema = z.enum(['write', 'delete']);
+export type SettingAction = z.infer<typeof settingActionSchema>;
+
+/** OS discriminator. Only macOS is implemented in v1; the enum is the seam. */
+export const settingsOsSchema = z.enum(['macos']);
+export type SettingsOs = z.infer<typeof settingsOsSchema>;
+
+export const settingEntrySchema = z.object({
+  id: z.string().min(1),
+  os: settingsOsSchema,
+  /** Human description of what this setting does. */
+  description: z.string().default(''),
+  /** `defaults` domain, e.g. "NSGlobalDomain" or "com.apple.dock". */
+  domain: z.string().min(1),
+  /** Preference key within the domain. */
+  key: z.string().min(1),
+  action: settingActionSchema.default('write'),
+  /** Present for action=write; absent/ignored for action=delete. */
+  type: settingTypeSchema.optional(),
+  /** String form of the value passed to `defaults write`. */
+  value: z.string().optional(),
+  /** OS version the setting was captured on (e.g. macOS "15.1"). */
+  capturedOsVersion: z.string().default(''),
+  /** Inclusive lower bound: skip apply when current OS version < minVersion. */
+  minVersion: z.string().nullable().default(null),
+  /** Inclusive upper bound: skip apply when current OS version > maxVersion. */
+  maxVersion: z.string().nullable().default(null),
+  /** Apps to `killall` after applying so the change takes effect. */
+  restartApps: z.array(z.string()).default([]),
+  added: z.string(),
+  modified: z.string(),
+});
+export type SettingEntry = z.infer<typeof settingEntrySchema>;
+
+export const manualStepSchema = z.object({
+  id: z.string().min(1),
+  os: settingsOsSchema,
+  title: z.string().min(1),
+  instructions: z.string().default(''),
+  added: z.string(),
+  modified: z.string(),
+});
+export type ManualStep = z.infer<typeof manualStepSchema>;
+
+export const osSettingsManifestSchema = z.object({
+  version: z.literal('1'),
+  settings: z.record(settingEntrySchema).default({}),
+  manualSteps: z.record(manualStepSchema).default({}),
+});
+export type OsSettingsManifest = z.infer<typeof osSettingsManifestSchema>;
+
+export const osSettingsStateSchema = z.object({
+  version: z.literal('1'),
+  /** manualStepId -> ISO timestamp the step was marked done on this machine. */
+  manualDone: z.record(z.string()).default({}),
+});
+export type OsSettingsState = z.infer<typeof osSettingsStateSchema>;

--- a/src/schemas/rules.schema.ts
+++ b/src/schemas/rules.schema.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+
+/**
+ * Rules fan-out schema — one canonical rules/instructions file materialized into
+ * many tool-specific variants (CLAUDE.md, .cursorrules, .windsurfrules,
+ * copilot-instructions.md, GEMINI.md, …). See IDEAS.md §1.4.
+ *
+ * The manifest (rules.json) is machine-local-ish but committed to the tuck repo,
+ * so all stored paths use POSIX separators and repo-scoped sets identify their
+ * repo by its absolute root (never a per-machine relative guess).
+ */
+
+/** Known fan-out targets. Each maps to a canonical relative destination path. */
+export const ruleToolNameSchema = z.enum([
+  'claude',
+  'cursor',
+  'cursor-dir',
+  'windsurf',
+  'copilot',
+  'gemini',
+  'agents',
+]);
+
+/**
+ * How a tool variant is produced on apply:
+ *   - `materialize`: render the canonical file (honoring per-tool templating)
+ *     and write a real file. Supports per-tool overrides.
+ *   - `symlink`: symlink the variant at the canonical source. Always byte-
+ *     identical to the source, so per-tool templating is NOT applied.
+ */
+export const ruleStrategySchema = z.enum(['materialize', 'symlink']);
+
+export const ruleToolSchema = z.object({
+  tool: ruleToolNameSchema,
+  strategy: ruleStrategySchema.default('materialize'),
+  /**
+   * Optional override for the variant's destination, relative to the set's scope
+   * root ($HOME or the repo root). When absent the tool's canonical default path
+   * is used. Must be a safe, non-escaping relative path.
+   */
+  path: z.string().optional(),
+});
+
+export const ruleSetSchema = z
+  .object({
+    /** Canonical rules file: `~/`-prefixed for home scope, absolute for repo. */
+    source: z.string(),
+    scope: z.enum(['home', 'repo']),
+    /** Absolute repo root; present iff `scope === 'repo'`. */
+    repoRoot: z.string().optional(),
+    /**
+     * Whether to render the canonical file through tuck's template engine when
+     * materializing. Defaults true so `{{#if tool == "cursor"}}…{{/if}}`
+     * per-tool overrides work out of the box.
+     */
+    template: z.boolean().default(true),
+    /** Fan-out targets. */
+    tools: z.array(ruleToolSchema),
+    /** Extra template variables merged into the render context. */
+    variables: z.record(z.string()).default({}),
+    added: z.string(),
+    modified: z.string(),
+  })
+  .superRefine((set, ctx) => {
+    if (set.scope === 'repo') {
+      if (!set.repoRoot) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['repoRoot'],
+          message: 'repoRoot is required for repo-scoped rule sets',
+        });
+      }
+    } else if (set.repoRoot !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['repoRoot'],
+        message: 'repoRoot is only valid on repo-scoped rule sets',
+      });
+    }
+    // Reject unsafe override paths (absolute or `..`-escaping) up front so a
+    // malformed manifest never lets a variant land outside its scope root.
+    for (const t of set.tools) {
+      if (t.path === undefined) continue;
+      const norm = t.path.replace(/\\/g, '/');
+      const unsafe =
+        norm.startsWith('/') ||
+        /^[A-Za-z]:[\\/]/.test(t.path) ||
+        norm.split('/').includes('..');
+      if (unsafe) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['tools'],
+          message: `Unsafe tool path override: ${t.path}`,
+        });
+      }
+    }
+  });
+
+export const rulesManifestSchema = z.object({
+  version: z.literal('1'),
+  sets: z.record(ruleSetSchema),
+});
+
+export type RuleToolName = z.infer<typeof ruleToolNameSchema>;
+export type RuleStrategy = z.infer<typeof ruleStrategySchema>;
+export type RuleToolInput = z.input<typeof ruleToolSchema>;
+export type RuleTool = z.output<typeof ruleToolSchema>;
+export type RuleSetInput = z.input<typeof ruleSetSchema>;
+export type RuleSet = z.output<typeof ruleSetSchema>;
+export type RulesManifestInput = z.input<typeof rulesManifestSchema>;
+export type RulesManifest = z.output<typeof rulesManifestSchema>;

--- a/src/schemas/secretsAllowlist.schema.ts
+++ b/src/schemas/secretsAllowlist.schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Zod schema for the centralized secret allowlist (secrets.allow.json)
+ *
+ * The allowlist is a committed, auditable file that records which specific
+ * scanner findings a user has deliberately marked as safe (false positives or
+ * intentionally-tracked non-secrets). It replaces scattered inline ignore
+ * comments and per-file `.tuckignore` entries with one reviewable list.
+ *
+ * SECURITY: the allowlist NEVER stores raw secret values. Each entry keys on a
+ * SHA-256 fingerprint of the value, so the file is safe to commit and share.
+ */
+
+import { z } from 'zod';
+
+/**
+ * A single allowlist entry.
+ *
+ * An entry suppresses a scanner match when its `fingerprint` equals the SHA-256
+ * of the matched value AND (when present) the optional `pattern`/`path` scopes
+ * also match. Omitting `pattern` and `path` makes the entry apply everywhere the
+ * value appears.
+ */
+export const allowlistEntrySchema = z.object({
+  /** SHA-256 hex digest of the allowed secret value (never the value itself). */
+  fingerprint: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/, 'fingerprint must be a 64-char SHA-256 hex digest'),
+  /** Human-readable justification (required — this is what makes it auditable). */
+  reason: z.string().min(1),
+  /** Optional pattern id scope (e.g. 'aws-access-key-id'). */
+  pattern: z.string().optional(),
+  /** Optional collapsed path scope (e.g. '~/.config/app/config'). */
+  path: z.string().optional(),
+  /** Who added the entry (best-effort, from $USER/$USERNAME). */
+  addedBy: z.string().optional(),
+  /** ISO-8601 timestamp of when the entry was added. */
+  addedAt: z.string(),
+});
+
+export const secretsAllowlistSchema = z.object({
+  version: z.string().default('1.0.0'),
+  entries: z.array(allowlistEntrySchema).default([]),
+});
+
+export type AllowlistEntry = z.infer<typeof allowlistEntrySchema>;
+export type SecretsAllowlist = z.infer<typeof secretsAllowlistSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,12 @@ export interface AddOptions extends CommonOptions {
 export interface RemoveOptions extends CommonOptions {
   delete?: boolean;
   keepOriginal?: boolean;
+  /**
+   * Proceed with `--delete` even if the pre-delete backup snapshot fails.
+   * Without it, a snapshot failure aborts the deletion (fail-closed) so a
+   * destructive delete never runs without a recovery point.
+   */
+  force?: boolean;
 }
 
 export interface SyncOptions extends CommonOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,12 @@ export interface TrackedFile {
   /** Logical group above category. Defaults to "default". */
   bundle: string;
   /**
+   * Dot-delimited JSON key path when this entry tracks only a SUBTREE of a JSON
+   * file (e.g. `mcpServers`). The repo copy holds just that subtree; apply/
+   * restore deep-merge it back into the live file. Absent for whole-file entries.
+   */
+  jsonKey?: string;
+  /**
    * Profile tags this file belongs to. Empty = universal (applies under every
    * profile). Defaults to `[]`.
    */
@@ -153,6 +159,12 @@ export interface AddOptions extends CommonOptions {
   repo?: string | boolean;
   /** Explicit repoKey override (advanced; default derives from the remote). */
   repoKey?: string;
+  /**
+   * Track only the JSON subtree at this dot-delimited key path (e.g.
+   * `mcpServers`) instead of the whole file. On apply/restore the subtree is
+   * deep-merged back into the live file, leaving all other keys untouched.
+   */
+  key?: string;
   /**
    * Track a curated AI-agent config preset instead of explicit paths, e.g.
    * `--preset claude-code`. Enumerates the agent's safe-to-track allowlist and

--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -5,6 +5,7 @@
 
 import * as p from '@clack/prompts';
 import { colors as c } from './theme.js';
+import { logger } from './logger.js';
 import { isJsonMode } from '../lib/jsonOutput.js';
 import { isNonInteractive, isNonInteractiveFlagSet } from '../lib/agentMode.js';
 import { OperationCancelledError } from '../errors.js';
@@ -248,8 +249,11 @@ export const prompts = {
       if (process.env.TUCK_FORCE_DANGEROUS === 'true') {
         return true;
       }
-      prompts.log.error(`Cannot confirm dangerous operation in non-interactive mode.`);
-      prompts.log.info(`Set TUCK_FORCE_DANGEROUS=true to bypass (use with extreme caution).`);
+      // Use the JSON-gated logger (writes to stderr in JSON mode, silent for
+      // info) rather than prompts.log.* which always writes to stdout and would
+      // corrupt the single-object JSON envelope.
+      logger.error(`Cannot confirm dangerous operation in non-interactive mode.`);
+      logger.info(`Set TUCK_FORCE_DANGEROUS=true to bypass (use with extreme caution).`);
       return false;
     }
 

--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -6,18 +6,26 @@
 import * as p from '@clack/prompts';
 import { colors as c } from './theme.js';
 import { isJsonMode } from '../lib/jsonOutput.js';
+import { isNonInteractive, isNonInteractiveFlagSet } from '../lib/agentMode.js';
 import { OperationCancelledError } from '../errors.js';
 
 /**
- * Refuse to prompt when stdin is not a TTY (agent/CI/piped). Without this the
+ * Refuse to prompt when the CLI is running non-interactively: an explicit
+ * `--non-interactive`, `--json` (a prompt would corrupt the envelope), or a
+ * non-TTY stdin (agent/CI/piped — no human to answer). Without this the
  * underlying clack prompt would read EOF and silently cancel — historically
  * exiting 0 (a false "success"). Throwing a structured error gives a non-zero
  * exit and a JSON error envelope in JSON mode.
  */
 const ensureInteractive = (): void => {
-  if (!process.stdin.isTTY) {
+  if (isNonInteractive()) {
+    const why = isNonInteractiveFlagSet()
+      ? '--non-interactive was set'
+      : isJsonMode()
+        ? '--json implies non-interactive'
+        : 'stdin is not a TTY';
     throw new OperationCancelledError(
-      'a prompt was required but stdin is not a TTY — pass the needed flags (e.g. --yes) to run non-interactively'
+      `a prompt was required but ${why} — pass the needed flags (e.g. --yes) to run non-interactively`
     );
   }
 };
@@ -236,7 +244,7 @@ export const prompts = {
    */
   confirmDangerous: async (message: string, confirmWord = 'yes'): Promise<boolean> => {
     // In non-interactive mode, don't allow dangerous operations without explicit CI flag
-    if (!process.stdout.isTTY) {
+    if (isNonInteractive() || !process.stdout.isTTY) {
       if (process.env.TUCK_FORCE_DANGEROUS === 'true') {
         return true;
       }

--- a/tests/commands/apply-audit.test.ts
+++ b/tests/commands/apply-audit.test.ts
@@ -215,4 +215,134 @@ describe('tuck apply — audit regressions', () => {
     expect(pathsToRestore).toEqual([resolve(join(SANDBOX, '.config', 'app', 'config'))]);
     expect(pathsToRestore).not.toContain(resolve(join(TEST_HOME, '.config', 'app', 'config')));
   });
+
+  it('snapshots the SANDBOX write targets under --root, not the untouched real home', async () => {
+    const SANDBOX = join(TEST_HOME, 'sandbox');
+    const localSrc = join(TEST_HOME, 'dotfiles-src');
+    const manifest = createMockManifest({
+      files: {
+        zshrc: createMockTrackedFile({
+          source: '~/.zshrc',
+          destination: 'files/shell/zshrc',
+          category: 'shell',
+        }),
+      },
+    });
+    vol.mkdirSync(join(localSrc, 'files', 'shell'), { recursive: true });
+    vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+    vol.writeFileSync(join(localSrc, 'files', 'shell', 'zshrc'), 'export SANDBOX=1\n');
+
+    setWriteContext({ root: SANDBOX, isSandbox: true });
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply(localSrc, { replace: true });
+
+    // The pre-apply snapshot must cover the SANDBOX write target so `tuck undo`
+    // restores the sandbox copy — never the real ~/.zshrc the apply never wrote.
+    expect(createPreApplySnapshotMock).toHaveBeenCalledTimes(1);
+    const [snapshotPaths] = createPreApplySnapshotMock.mock.calls[0] as [string[], string];
+    expect(snapshotPaths).toEqual([resolve(join(SANDBOX, '.zshrc'))]);
+    expect(snapshotPaths).not.toContain(resolve(join(TEST_HOME, '.zshrc')));
+  });
+
+  it('reads the jsonKey merge base from the sandbox, never the real home, under --root', async () => {
+    const SANDBOX = join(TEST_HOME, 'sandbox');
+    const localSrc = join(TEST_HOME, 'dotfiles-src');
+    const manifest = createMockManifest({
+      files: {
+        claude: createMockTrackedFile({
+          source: '~/.claude.json',
+          destination: 'files/misc/claude.json',
+          category: 'misc',
+          jsonKey: 'mcpServers',
+        }),
+      },
+    });
+    vol.mkdirSync(join(localSrc, 'files', 'misc'), { recursive: true });
+    vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+    // Repo stores ONLY the tracked subtree.
+    vol.writeFileSync(
+      join(localSrc, 'files', 'misc', 'claude.json'),
+      JSON.stringify({ server1: { cmd: 'x' } })
+    );
+
+    // The REAL home file carries a secret untracked key that must never be read.
+    vol.writeFileSync(
+      join(TEST_HOME, '.claude.json'),
+      JSON.stringify({ realSecret: 'tokenXYZ', mcpServers: { fromRealHome: true } })
+    );
+    // The SANDBOX already has its own live file with an untracked key to preserve.
+    vol.mkdirSync(SANDBOX, { recursive: true });
+    vol.writeFileSync(
+      join(SANDBOX, '.claude.json'),
+      JSON.stringify({ sandboxKeep: 'ok', mcpServers: { old: true } })
+    );
+
+    setWriteContext({ root: SANDBOX, isSandbox: true });
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply(localSrc, { replace: true });
+
+    const written = JSON.parse(vol.readFileSync(join(SANDBOX, '.claude.json'), 'utf-8'));
+    // The tracked subtree replaced the sandbox's mcpServers...
+    expect(written.mcpServers).toEqual({ server1: { cmd: 'x' } });
+    // ...the sandbox's untracked key is preserved...
+    expect(written.sandboxKeep).toBe('ok');
+    // ...and the real home's untracked secret was NEVER copied into the sandbox.
+    expect(written.realSecret).toBeUndefined();
+    // The real home file is untouched.
+    expect(JSON.parse(vol.readFileSync(join(TEST_HOME, '.claude.json'), 'utf-8')).realSecret).toBe(
+      'tokenXYZ'
+    );
+  });
+
+  it('never substitutes a secret into an untracked jsonKey remainder', async () => {
+    const SANDBOX = join(TEST_HOME, 'sandbox');
+    const localSrc = join(TEST_HOME, 'dotfiles-src');
+    const manifest = createMockManifest({
+      files: {
+        claude: createMockTrackedFile({
+          source: '~/.claude.json',
+          destination: 'files/misc/claude.json',
+          category: 'misc',
+          jsonKey: 'mcpServers',
+        }),
+      },
+    });
+    vol.mkdirSync(join(localSrc, 'files', 'misc'), { recursive: true });
+    vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+    // Tracked subtree contains NO placeholder.
+    vol.writeFileSync(
+      join(localSrc, 'files', 'misc', 'claude.json'),
+      JSON.stringify({ server1: { cmd: 'x' } })
+    );
+
+    // The sandbox live file has an UNTRACKED key containing a placeholder that a
+    // configured secret would otherwise resolve.
+    vol.mkdirSync(SANDBOX, { recursive: true });
+    vol.writeFileSync(
+      join(SANDBOX, '.claude.json'),
+      JSON.stringify({ greeting: 'Hello {{NAME}}', mcpServers: { old: true } })
+    );
+
+    // A stored secret IS available — proving the untracked key is still not touched.
+    getSecretCountMock.mockResolvedValue(1);
+    getAllSecretsMock.mockResolvedValue({ NAME: 'SECRET_VALUE' });
+
+    setWriteContext({ root: SANDBOX, isSandbox: true });
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply(localSrc, { replace: true });
+
+    const written = JSON.parse(vol.readFileSync(join(SANDBOX, '.claude.json'), 'utf-8'));
+    // The untracked key's placeholder text is preserved verbatim — never resolved.
+    expect(written.greeting).toBe('Hello {{NAME}}');
+    expect(written.mcpServers).toEqual({ server1: { cmd: 'x' } });
+
+    // Secret resolution only ever saw the tracked SUBTREE, never the merged whole
+    // file — so it was never given the untracked "greeting" content.
+    for (const call of findPlaceholdersMock.mock.calls) {
+      expect(String(call[0])).not.toContain('greeting');
+    }
+  });
 });

--- a/tests/commands/apply-audit.test.ts
+++ b/tests/commands/apply-audit.test.ts
@@ -165,7 +165,9 @@ describe('tuck apply — audit regressions', () => {
     const [snapshotPaths] = createPreApplySnapshotMock.mock.calls[0] as [string[], string];
     // The not-yet-existing destination is included, so restoreSnapshot (undo) can
     // delete it (createSnapshot records it as existed:false).
-    expect(snapshotPaths).toContain(join(TEST_HOME, '.tmux.conf'));
+    // resolve() so the expectation matches resolveWriteTarget's output on
+    // Windows too, where resolving '/test-home' adds the current drive letter.
+    expect(snapshotPaths).toContain(resolve(TEST_HOME, '.tmux.conf'));
 
     // The printed undo instruction must reference the real `tuck undo` command,
     // pinned to the snapshot just created, not the non-existent

--- a/tests/commands/apply-audit.test.ts
+++ b/tests/commands/apply-audit.test.ts
@@ -168,9 +168,12 @@ describe('tuck apply — audit regressions', () => {
     expect(snapshotPaths).toContain(join(TEST_HOME, '.tmux.conf'));
 
     // The printed undo instruction must reference the real `tuck undo` command,
-    // not the non-existent `tuck restore --latest` flag.
+    // pinned to the snapshot just created, not the non-existent
+    // `tuck restore --latest` flag.
     const ui = await import('../../src/ui/index.js');
-    expect(vi.mocked(ui.logger.info)).toHaveBeenCalledWith('To undo: tuck undo --latest');
+    expect(vi.mocked(ui.logger.info)).toHaveBeenCalledWith(
+      'Undo this change: tuck undo snapshot-test  (or tuck undo --latest)'
+    );
   });
 
   it('should restore local-store secrets into the sandbox write target under --root, not the real home', async () => {

--- a/tests/commands/apply.test.ts
+++ b/tests/commands/apply.test.ts
@@ -225,6 +225,56 @@ describe('apply command behavior', () => {
     }
   });
 
+  it('shows a full diff summary and an undo breadcrumb before/after applying (IDEAS 2.4/6.5)', async () => {
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          existing: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+          fresh: createMockTrackedFile({ source: '~/.vimrc', destination: 'files/editors/vimrc' }),
+        },
+      });
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.mkdirSync(join(dir, 'files', 'editors'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), 'export NEW=1');
+      vol.writeFileSync(join(dir, 'files', 'editors', 'vimrc'), 'set number');
+    };
+
+    // ~/.zshrc already exists (will update); ~/.vimrc does not (new).
+    vol.writeFileSync(join(TEST_HOME, '.zshrc'), 'export OLD=1');
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    createPreApplySnapshotMock.mockResolvedValueOnce({ id: '2026-07-09-090807' });
+    await runApply('user/repo', { replace: true });
+
+    // Full diff summary printed BEFORE the snapshot/writes.
+    expect(loggerHeadingMock).toHaveBeenCalledWith('Changes to apply:');
+    expect(loggerInfoMock).toHaveBeenCalledWith('1 new, 1 to update');
+
+    // Undo breadcrumb pinned to the concrete snapshot id.
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'Undo this change: tuck undo 2026-07-09-090807  (or tuck undo --latest)'
+    );
+  });
+
+  it('does not print the diff summary in JSON mode', async () => {
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          safe: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+        },
+      });
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), 'export NEW=1');
+    };
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { replace: true, json: true });
+
+    expect(loggerHeadingMock).not.toHaveBeenCalledWith('Changes to apply:');
+  });
+
   it('renders a template file on apply (P0-1)', async () => {
     cloneSetup = (dir: string) => {
       const manifest = createMockManifest({

--- a/tests/commands/apply.test.ts
+++ b/tests/commands/apply.test.ts
@@ -4,6 +4,12 @@ import { join } from 'path';
 import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
 import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
 import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
+import { getFileChecksum } from '../../src/lib/files.js';
+import {
+  getDriftEntry,
+  compareLiveToCache,
+  resetDriftKeyCache,
+} from '../../src/lib/crypto/driftCache.js';
 
 const cloneRepoMock = vi.fn();
 const createPreApplySnapshotMock = vi.fn();
@@ -665,5 +671,85 @@ describe('apply command behavior', () => {
     await runApply('gitlab:team/dotfiles', { dryRun: true });
 
     expect(cloneRepoMock).toHaveBeenCalledWith('https://gitlab.com/team/dotfiles.git', expect.any(String));
+  });
+
+  it('includes the pre-apply snapshot id and undo command in the JSON envelope', async () => {
+    cloneSetup = (dir: string) => {
+      const manifest = createMockManifest({
+        files: {
+          safe: createMockTrackedFile({ source: '~/.zshrc', destination: 'files/shell/zshrc' }),
+        },
+      });
+      vol.mkdirSync(join(dir, 'files', 'shell'), { recursive: true });
+      vol.writeFileSync(join(dir, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+      vol.writeFileSync(join(dir, 'files', 'shell', 'zshrc'), 'export NEW=1');
+    };
+
+    createPreApplySnapshotMock.mockResolvedValueOnce({ id: '2026-07-09-113355' });
+
+    const { __resetJsonEmitState } = await import('../../src/lib/jsonOutput.js');
+    __resetJsonEmitState();
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply('user/repo', { json: true, yes: true } as never);
+
+    writeSpy.mockRestore();
+
+    const env = JSON.parse(writes.join('').trim());
+    expect(env.ok).toBe(true);
+    // Agents get a concrete recovery pointer: the snapshot id and the exact undo command.
+    expect(env.data.snapshot).toBe('2026-07-09-113355');
+    expect(env.data.undo).toBe('Undo this change: tuck undo 2026-07-09-113355  (or tuck undo --latest)');
+  });
+
+  it('warms the encrypted-file drift cache after applying an encrypted file', async () => {
+    resetDriftKeyCache();
+    const plaintext = 'SECRET=1';
+    const ciphertext = await encryptFileContent(Buffer.from(plaintext), 'pw');
+
+    // A local directory source so the repo copy content (and thus its checksum)
+    // is deterministic and readable after the apply.
+    const localSrc = join(TEST_HOME, 'dotfiles-src');
+    const manifest = createMockManifest({
+      files: {
+        enc: createMockTrackedFile({
+          source: '~/.netrc',
+          destination: 'files/shell/netrc',
+          encrypted: true,
+        }),
+      },
+    });
+    vol.mkdirSync(join(localSrc, 'files', 'shell'), { recursive: true });
+    vol.writeFileSync(join(localSrc, '.tuckmanifest.json'), JSON.stringify(manifest, null, 2));
+    vol.writeFileSync(join(localSrc, 'files', 'shell', 'netrc'), ciphertext);
+
+    const { setJsonMode } = await import('../../src/lib/jsonOutput.js');
+    setJsonMode(false);
+
+    const { runApply } = await import('../../src/commands/apply.js');
+    await runApply(localSrc, { replace: true });
+
+    // The decrypted plaintext landed on the live system.
+    expect(vol.readFileSync(join(TEST_HOME, '.netrc'), 'utf-8')).toBe(plaintext);
+
+    // A drift entry was recorded, keyed by the manifest id, and the live bytes
+    // now match the recorded last-known-good fingerprint — so a later read-only
+    // status/diff can detect drift WITHOUT decrypting.
+    const entry = await getDriftEntry('enc');
+    expect(entry).not.toBeNull();
+
+    // The repo copy content is identical to the local source (getFileChecksum
+    // hashes content), so recompute the checksum the recorder used.
+    const repoChecksum = await getFileChecksum(join(localSrc, 'files', 'shell', 'netrc'));
+    const liveBytes = vol.readFileSync(join(TEST_HOME, '.netrc')) as Buffer;
+    expect(await compareLiveToCache('enc', liveBytes, repoChecksum)).toBe('match');
   });
 });

--- a/tests/commands/apply.test.ts
+++ b/tests/commands/apply.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { vol } from 'memfs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { createMockManifest, createMockTrackedFile } from '../utils/factories.js';
 import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
 import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
@@ -219,8 +219,10 @@ describe('apply command behavior', () => {
     await runApply('user/repo', { replace: true });
 
     expect(createPreApplySnapshotMock).toHaveBeenCalledTimes(1);
+    // resolve() so the expectation matches resolveWriteTarget's output on
+    // Windows too, where resolving '/test-home' adds the current drive letter.
     expect(createPreApplySnapshotMock).toHaveBeenCalledWith(
-      [join(TEST_HOME, '.zshrc')],
+      [resolve(TEST_HOME, '.zshrc')],
       'user/repo'
     );
     expect(vol.readFileSync(join(TEST_HOME, '.zshrc'), 'utf-8')).toBe('export NEW=1');

--- a/tests/commands/diff-jsonKey.test.ts
+++ b/tests/commands/diff-jsonKey.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `tuck diff` secret-safety for JSON-key-tracked files.
+ *
+ * Covers two findings in the jsonKey diff paths:
+ *   1. When the repo copy is MISSING, the diff must show ONLY the tracked subtree
+ *      — never the whole live file (which holds untracked keys like oauthToken
+ *      that a jsonKey add never wrote to the local secrets store, so redaction
+ *      cannot cover them).
+ *   2. The normal jsonKey diff branch must redact known stored secret values on
+ *      BOTH the live-subtree and repo-copy sides before display.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_TUCK_DIR, initTestTuck, createTestDotfile } from '../utils/testHelpers.js';
+import { getTrackedFileBySource, clearManifestCache } from '../../src/lib/manifest.js';
+import { addFilesFromPaths } from '../../src/commands/add.js';
+import { getFileDiff } from '../../src/commands/diff.js';
+import { setSecret, getStoredValueMap } from '../../src/lib/secrets/index.js';
+
+vi.mock('simple-git', () => {
+  const mockGit = {
+    init: vi.fn().mockResolvedValue(undefined),
+    add: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue({ commit: 'abc123' }),
+    status: vi.fn().mockResolvedValue({
+      current: 'main',
+      tracking: null,
+      ahead: 0,
+      behind: 0,
+      staged: [],
+      modified: [],
+      not_added: [],
+      deleted: [],
+      isClean: () => true,
+    }),
+    getRemotes: vi.fn().mockResolvedValue([]),
+    push: vi.fn().mockResolvedValue(undefined),
+    pull: vi.fn().mockResolvedValue(undefined),
+    fetch: vi.fn().mockResolvedValue(undefined),
+    revparse: vi.fn().mockResolvedValue('main'),
+    raw: vi.fn().mockResolvedValue('main'),
+    branch: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: vi.fn(() => mockGit), simpleGit: vi.fn(() => mockGit) };
+});
+
+const CLAUDE_JSON = '~/.claude.json';
+
+describe('tuck diff — JSON-key secret safety', () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+    clearManifestCache();
+  });
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+  });
+
+  it('shows ONLY the tracked subtree (not the whole live file) when the repo copy is missing', async () => {
+    await initTestTuck();
+    createTestDotfile(
+      '.claude.json',
+      JSON.stringify(
+        {
+          mcpServers: { git: { command: 'git-mcp' } },
+          oauthToken: 'SUPER-SECRET-TOKEN',
+          history: [{ prompt: 'do not leak me' }],
+        },
+        null,
+        2
+      )
+    );
+    await addFilesFromPaths([CLAUDE_JSON], { key: 'mcpServers', force: true });
+
+    // Simulate a missing repo copy (e.g. never pushed / partial clone).
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, CLAUDE_JSON);
+    vol.unlinkSync(join(TEST_TUCK_DIR, tracked!.file.destination));
+
+    const diff = await getFileDiff(TEST_TUCK_DIR, CLAUDE_JSON);
+    expect(diff).not.toBeNull();
+    expect(diff!.hasChanges).toBe(true);
+    expect(diff!.systemContent).toBeDefined();
+    // The untracked OAuth token and history must NOT appear — only the subtree.
+    expect(diff!.systemContent).not.toContain('SUPER-SECRET-TOKEN');
+    expect(diff!.systemContent).not.toContain('oauthToken');
+    expect(diff!.systemContent).not.toContain('history');
+    expect(JSON.parse(diff!.systemContent!)).toEqual({ git: { command: 'git-mcp' } });
+  });
+
+  it('redacts known stored secrets on both sides of the jsonKey diff', async () => {
+    await initTestTuck();
+    const secret = 'sk-live-abcdef0123456789';
+    createTestDotfile(
+      '.claude.json',
+      JSON.stringify(
+        { mcpServers: { git: { command: 'git-mcp' }, apiKey: secret }, oauthToken: 't' },
+        null,
+        2
+      )
+    );
+    // force so the secret-bearing subtree is tracked verbatim into the repo copy.
+    await addFilesFromPaths([CLAUDE_JSON], { key: 'mcpServers', force: true });
+
+    // Register the secret in the local store so diff's redaction can catch it.
+    await setSecret(TEST_TUCK_DIR, 'API_KEY', secret);
+
+    // Make the live subtree diverge from the repo copy (add a server) so the
+    // diff branch emits content for both sides. Rewrite the live file directly.
+    const { expandPath } = await import('../../src/lib/paths.js');
+    vol.writeFileSync(
+      expandPath(CLAUDE_JSON),
+      JSON.stringify(
+        {
+          mcpServers: { git: { command: 'git-mcp' }, apiKey: secret, fs: { command: 'fs-mcp' } },
+          oauthToken: 't',
+        },
+        null,
+        2
+      )
+    );
+
+    const valueMap = await getStoredValueMap(TEST_TUCK_DIR);
+    const diff = await getFileDiff(TEST_TUCK_DIR, CLAUDE_JSON, valueMap);
+
+    expect(diff).not.toBeNull();
+    expect(diff!.hasChanges).toBe(true);
+    // The cleartext secret must never appear on EITHER side of the diff.
+    expect(diff!.systemContent).toBeDefined();
+    expect(diff!.repoContent).toBeDefined();
+    expect(diff!.systemContent).not.toContain(secret);
+    expect(diff!.repoContent).not.toContain(secret);
+    // Redaction substituted the stored placeholder in its place.
+    expect(diff!.systemContent).toContain('API_KEY');
+    expect(diff!.repoContent).toContain('API_KEY');
+  });
+});

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -192,3 +192,14 @@ describe('init command behavior', () => {
     expect(saveConfigMock).not.toHaveBeenCalled();
   });
 });
+
+describe('buildInitStartChoices', () => {
+  it('offers the scan-based adopt-existing path first (IDEAS 2.4)', async () => {
+    const { buildInitStartChoices } = await import('../../src/commands/init.js');
+    const choices = buildInitStartChoices();
+
+    expect(choices[0].value).toBe('adopt');
+    expect(choices[0].hint.toLowerCase()).toContain('recommended');
+    expect(choices.map((choice) => choice.value)).toEqual(['adopt', 'clone', 'fresh']);
+  });
+});

--- a/tests/commands/merge.test.ts
+++ b/tests/commands/merge.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { writeFile, mkdir } from 'fs/promises';
+import { TEST_TUCK_DIR } from '../setup.js';
+import { loadManifest, clearManifestCache } from '../../src/lib/manifest.js';
+import { setAction, unsetAction, listAction } from '../../src/commands/merge.js';
+
+const manifestPath = `${TEST_TUCK_DIR}/.tuckmanifest.json`;
+
+const writeManifest = async (): Promise<void> => {
+  const manifest = {
+    version: '1.0.0',
+    created: '2024-01-01T00:00:00.000Z',
+    updated: '2024-01-01T00:00:00.000Z',
+    bundles: { default: { created: '2024-01-01T00:00:00.000Z' } },
+    files: {
+      zshrc: {
+        source: '~/.zshrc',
+        destination: 'files/shell/zshrc',
+        category: 'shell',
+        strategy: 'copy',
+        encrypted: false,
+        template: false,
+        added: '2024-01-01T00:00:00.000Z',
+        modified: '2024-01-01T00:00:00.000Z',
+        checksum: 'abc123',
+        bundle: 'default',
+      },
+      settings: {
+        source: '~/.claude/settings.json',
+        destination: 'files/misc/settings.json',
+        category: 'misc',
+        strategy: 'copy',
+        encrypted: false,
+        template: false,
+        added: '2024-01-01T00:00:00.000Z',
+        modified: '2024-01-01T00:00:00.000Z',
+        checksum: 'def456',
+        bundle: 'default',
+      },
+    },
+  };
+  await mkdir(TEST_TUCK_DIR, { recursive: true });
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
+};
+
+beforeEach(async () => {
+  vol.reset();
+  vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  clearManifestCache();
+  vi.restoreAllMocks();
+  await writeManifest();
+});
+
+describe('tuck merge set', () => {
+  it('sets an explicit policy on a tracked file, filling defaults', async () => {
+    await setAction('~/.zshrc', {});
+    clearManifestCache();
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    expect(manifest.files.zshrc.merge).toEqual({
+      format: 'json',
+      arrays: 'union',
+      conflict: 'manual',
+    });
+  });
+
+  it('applies --arrays and --conflict overrides', async () => {
+    await setAction('~/.zshrc', { arrays: 'concat', conflict: 'theirs' });
+    clearManifestCache();
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    expect(manifest.files.zshrc.merge).toEqual({
+      format: 'json',
+      arrays: 'concat',
+      conflict: 'theirs',
+    });
+  });
+
+  it('resolves a shell-expanded absolute path (unquoted ~ in the shell)', async () => {
+    // `tuck merge set ~/.zshrc` reaches the CLI as an ABSOLUTE path because
+    // the shell expands unquoted ~ — resolution must collapse it back to the
+    // manifest's ~-relative source (repo rule: always expandPath/collapsePath).
+    const { expandPath } = await import('../../src/lib/paths.js');
+    await setAction(expandPath('~/.zshrc'), { conflict: 'theirs' });
+    clearManifestCache();
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    expect(manifest.files.zshrc.merge?.conflict).toBe('theirs');
+  });
+
+  it('resolves a file by manifest id as well as source path', async () => {
+    await setAction('settings', { conflict: 'ours' });
+    clearManifestCache();
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    expect(manifest.files.settings.merge?.conflict).toBe('ours');
+  });
+
+  it('rejects an invalid --arrays value', async () => {
+    await expect(setAction('~/.zshrc', { arrays: 'bogus' })).rejects.toThrow(/Invalid --arrays/);
+  });
+
+  it('rejects an unknown file', async () => {
+    await expect(setAction('~/.does-not-exist', {})).rejects.toThrow(/No tracked file/);
+  });
+});
+
+describe('tuck merge unset', () => {
+  it('removes an explicit policy', async () => {
+    await setAction('~/.zshrc', {});
+    clearManifestCache();
+    await unsetAction('~/.zshrc', {});
+    clearManifestCache();
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    expect(manifest.files.zshrc.merge).toBeUndefined();
+  });
+});
+
+describe('tuck merge list --json', () => {
+  it('includes auto-detected agent configs even without an explicit policy', async () => {
+    const spy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    await listAction({ json: true });
+    const output = spy.mock.calls.map((c) => String(c[0])).join('');
+    spy.mockRestore();
+
+    const parsed = JSON.parse(output) as {
+      ok: boolean;
+      data: { count: number; files: Array<{ source: string; explicit: boolean }> };
+    };
+    expect(parsed.ok).toBe(true);
+    const settings = parsed.data.files.find((f) => f.source === '~/.claude/settings.json');
+    expect(settings).toBeDefined();
+    expect(settings?.explicit).toBe(false);
+    // ~/.zshrc has no policy and is not an agent config → excluded.
+    expect(parsed.data.files.some((f) => f.source === '~/.zshrc')).toBe(false);
+  });
+});

--- a/tests/commands/push.test.ts
+++ b/tests/commands/push.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const loadManifestMock = vi.fn();
 const checkLocalModeMock = vi.fn();
@@ -98,10 +98,26 @@ vi.mock('../../src/lib/providers/index.js', () => ({
   assertRemoteAvailable: assertRemoteAvailableMock,
 }));
 
+const originalStdinTTY = process.stdin.isTTY;
+const setStdinTTY = (value: boolean): void => {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+};
+
 describe('push command', () => {
+  afterEach(() => {
+    setStdinTTY(originalStdinTTY as boolean);
+  });
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    // Default to a simulated interactive TTY so the prompt paths are reachable;
+    // the non-interactive regression tests below flip this off explicitly.
+    setStdinTTY(true);
 
     loadManifestMock.mockResolvedValue({ files: {} });
     checkLocalModeMock.mockResolvedValue(false);
@@ -170,6 +186,50 @@ describe('push command', () => {
     expect(pushMock).not.toHaveBeenCalled();
     expect(logForcePushMock).not.toHaveBeenCalled();
     expect(loggerInfoMock).toHaveBeenCalledWith('Push cancelled');
+  });
+
+  it('fails non-zero on --force in non-interactive mode instead of a false success', async () => {
+    // `tuck push --force` on a non-TTY (agent/CI) cannot confirm the dangerous
+    // op and was NOT pre-authorized via --yes/--json. It must throw a typed,
+    // non-zero error rather than print "Push cancelled" and exit 0 having pushed
+    // nothing.
+    setStdinTTY(false);
+    const { pushCommand } = await import('../../src/commands/push.js');
+
+    await expect(pushCommand.parseAsync(['--force'], { from: 'user' })).rejects.toMatchObject({
+      code: 'OPERATION_CANCELLED',
+      exitCode: 1,
+    });
+
+    // Never pushed, never audited, never falsely reported success.
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(logForcePushMock).not.toHaveBeenCalled();
+    expect(promptsConfirmDangerousMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an actionable --yes hint in the non-interactive --force error', async () => {
+    setStdinTTY(false);
+    const { pushCommand } = await import('../../src/commands/push.js');
+
+    await expect(pushCommand.parseAsync(['--force'], { from: 'user' })).rejects.toThrow(/--yes/);
+  });
+
+  it('force pushes without prompting when --force --yes is passed non-interactively', async () => {
+    // --yes is the explicit opt-in: it must skip the confirmation AND actually
+    // push (never route through the non-interactive throw above).
+    setStdinTTY(false);
+    getStatusMock.mockResolvedValue({ ahead: 1, behind: 0, tracking: 'origin/main' });
+    const { pushCommand } = await import('../../src/commands/push.js');
+
+    await pushCommand.parseAsync(['--force', '--yes'], { from: 'user' });
+
+    expect(promptsConfirmDangerousMock).not.toHaveBeenCalled();
+    expect(logForcePushMock).toHaveBeenCalledWith('main');
+    expect(pushMock).toHaveBeenCalledWith('/test-home/.tuck', {
+      force: true,
+      setUpstream: false,
+      branch: 'main',
+    });
   });
 
   it('runs the interactive push flow and sets upstream when needed', async () => {

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -227,3 +227,99 @@ describe('remove command repo-scoped entries', () => {
     expect(remaining['repo-env']).toBeUndefined();
   });
 });
+
+describe('remove command pre-delete snapshot (IDEAS 6.5)', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    setJsonMode(false);
+    __resetJsonEmitState();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+    setJsonMode(false);
+    __resetJsonEmitState();
+  });
+
+  it('snapshots the repo copy before deleting it so `tuck undo` can recover it', async () => {
+    const { listSnapshots } = await import('../../src/lib/timemachine.js');
+
+    const manifest = createMockManifest();
+    manifest.files['zshrc'] = createMockTrackedFile({
+      source: '~/.zshrc',
+      destination: 'files/shell/zshrc',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+
+    // The committed repo copy must exist for the delete (and thus the snapshot).
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files/shell'), { recursive: true });
+    vol.writeFileSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'), 'export FROM_REPO=1');
+
+    await runRemove(['~/.zshrc'], { delete: true });
+
+    const snapshots = await listSnapshots();
+    const preRemove = snapshots.find((s) => s.reason.startsWith('Pre-remove delete backup'));
+    expect(preRemove).toBeDefined();
+
+    // The repo copy is gone from the tuck repo but preserved inside the snapshot.
+    expect(vol.existsSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'))).toBe(false);
+    const remaining = await getAllTrackedFiles(TEST_TUCK_DIR);
+    expect(remaining['zshrc']).toBeUndefined();
+  });
+
+  it('takes ONE snapshot covering EVERY deleted repo copy (multi-file --delete)', async () => {
+    const { listSnapshots } = await import('../../src/lib/timemachine.js');
+
+    const manifest = createMockManifest();
+    manifest.files['zshrc'] = createMockTrackedFile({
+      source: '~/.zshrc',
+      destination: 'files/shell/zshrc',
+    });
+    manifest.files['gitconfig'] = createMockTrackedFile({
+      source: '~/.gitconfig',
+      destination: 'files/git/gitconfig',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files/shell'), { recursive: true });
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files/git'), { recursive: true });
+    vol.writeFileSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'), 'export A=1');
+    vol.writeFileSync(join(TEST_TUCK_DIR, 'files/git/gitconfig'), '[user]');
+
+    await runRemove(['~/.zshrc', '~/.gitconfig'], { delete: true });
+
+    // A per-file snapshot would pin the undo breadcrumb to a checkpoint that
+    // restores only the LAST file — there must be exactly one snapshot and it
+    // must contain BOTH repo copies.
+    const snapshots = (await listSnapshots()).filter((s) =>
+      s.reason.startsWith('Pre-remove delete backup')
+    );
+    expect(snapshots).toHaveLength(1);
+    const files = snapshots[0].files.map((f) => f.originalPath ?? f.path ?? String(f));
+    expect(files.join(' ')).toContain('zshrc');
+    expect(files.join(' ')).toContain('gitconfig');
+  });
+
+  it('does not snapshot when untracking without --delete', async () => {
+    const { listSnapshots } = await import('../../src/lib/timemachine.js');
+
+    const manifest = createMockManifest();
+    manifest.files['zshrc'] = createMockTrackedFile({
+      source: '~/.zshrc',
+      destination: 'files/shell/zshrc',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files/shell'), { recursive: true });
+    vol.writeFileSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'), 'export FROM_REPO=1');
+
+    await runRemove(['~/.zshrc'], {});
+
+    const snapshots = await listSnapshots();
+    expect(snapshots.find((s) => s.reason.startsWith('Pre-remove delete backup'))).toBeUndefined();
+    // Untrack-only leaves the repo copy in place (recover via git / re-add).
+    expect(vol.existsSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'))).toBe(true);
+  });
+});

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -322,4 +322,69 @@ describe('remove command pre-delete snapshot (IDEAS 6.5)', () => {
     // Untrack-only leaves the repo copy in place (recover via git / re-add).
     expect(vol.existsSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'))).toBe(true);
   });
+
+  it('aborts a --delete (fail-closed) when the pre-delete snapshot fails and --force is not set', async () => {
+    const timemachine = await import('../../src/lib/timemachine.js');
+    const snapSpy = vi
+      .spyOn(timemachine, 'createSnapshot')
+      .mockRejectedValueOnce(new Error('disk full'));
+
+    const manifest = createMockManifest();
+    manifest.files['zshrc'] = createMockTrackedFile({
+      source: '~/.zshrc',
+      destination: 'files/shell/zshrc',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files/shell'), { recursive: true });
+    vol.writeFileSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'), 'export FROM_REPO=1');
+
+    // Snapshot failed and --force was NOT given → the deletion must abort.
+    await expect(runRemove(['~/.zshrc'], { delete: true })).rejects.toThrow(
+      /Refusing to delete without a recovery point/
+    );
+
+    // Nothing was deleted or untracked — fail-closed.
+    expect(vol.existsSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'))).toBe(true);
+    const remaining = await getAllTrackedFiles(TEST_TUCK_DIR);
+    expect(remaining['zshrc']).toBeDefined();
+
+    snapSpy.mockRestore();
+  });
+
+  it('proceeds under --force when the snapshot fails, surfacing a JSON warning', async () => {
+    const timemachine = await import('../../src/lib/timemachine.js');
+    const snapSpy = vi
+      .spyOn(timemachine, 'createSnapshot')
+      .mockRejectedValueOnce(new Error('disk full'));
+
+    const manifest = createMockManifest();
+    manifest.files['zshrc'] = createMockTrackedFile({
+      source: '~/.zshrc',
+      destination: 'files/shell/zshrc',
+    });
+    vol.writeFileSync(join(TEST_TUCK_DIR, '.tuckmanifest.json'), JSON.stringify(manifest));
+    vol.mkdirSync(join(TEST_TUCK_DIR, 'files/shell'), { recursive: true });
+    vol.writeFileSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'), 'export FROM_REPO=1');
+
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    await runRemove(['~/.zshrc'], { delete: true, force: true, json: true });
+
+    writeSpy.mockRestore();
+
+    // --force proceeded with the delete despite the missing backup...
+    expect(vol.existsSync(join(TEST_TUCK_DIR, 'files/shell/zshrc'))).toBe(false);
+    // ...and the missing backup is surfaced in the JSON envelope's warnings.
+    const env = JSON.parse(writes.join('').trim());
+    expect(env.ok).toBe(true);
+    expect((env.warnings ?? []).join(' ')).toMatch(/proceeding without a backup because --force/);
+
+    snapSpy.mockRestore();
+  });
 });

--- a/tests/commands/restore-jsonkey-secrets.test.ts
+++ b/tests/commands/restore-jsonkey-secrets.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for JSON-key subtree secret handling on `tuck restore`.
+ *
+ * A jsonKey entry tracks only a SUBTREE of a JSON file; the rest of the live
+ * file holds UNTRACKED keys tuck does not manage (tokens, machine state, notes).
+ * Secret placeholder resolution must therefore run on the tracked subtree ONLY —
+ * never over the whole merged file — so a tuck secret is never spliced into an
+ * untracked key that happens to contain `{{NAME}}` text.
+ *
+ * Uses real modules + memfs (like the sandbox-restore integration test) so the
+ * real secret store, jsonKey merge, and restoreContent path are exercised.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { clearManifestCache } from '../../src/lib/manifest.js';
+import { clearConfigCache } from '../../src/lib/config.js';
+import { resetWriteContext } from '../../src/lib/writeContext.js';
+
+const TUCK = '/test-home/.tuck';
+const LIVE = '/test-home/.claude.json';
+
+const seed = async (): Promise<void> => {
+  vol.mkdirSync(`${TUCK}/files/misc`, { recursive: true });
+  // The repo copy stores ONLY the tracked subtree, with a secret placeholder.
+  const repoSubtree = JSON.stringify({ api: '{{NAME}}' });
+  vol.writeFileSync(`${TUCK}/files/misc/claude.json`, repoSubtree);
+
+  const { getFileChecksum } = await import('../../src/lib/files.js');
+  const checksum = await getFileChecksum(`${TUCK}/files/misc/claude.json`);
+
+  vol.writeFileSync(
+    `${TUCK}/.tuckrc.json`,
+    JSON.stringify({ repository: { path: TUCK }, files: { strategy: 'copy', backupOnRestore: false } })
+  );
+
+  vol.writeFileSync(
+    `${TUCK}/.tuckmanifest.json`,
+    JSON.stringify({
+      version: '1',
+      created: '2026-01-01T00:00:00.000Z',
+      updated: '2026-01-01T00:00:00.000Z',
+      files: {
+        claude: {
+          source: '~/.claude.json',
+          destination: 'files/misc/claude.json',
+          category: 'misc',
+          strategy: 'copy',
+          checksum,
+          jsonKey: 'mcpServers',
+          added: '2026-01-01T00:00:00.000Z',
+          modified: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      bundles: {},
+    })
+  );
+
+  // A real local secret store the restore will resolve from.
+  vol.writeFileSync(
+    `${TUCK}/secrets.local.json`,
+    JSON.stringify({
+      version: '1.0.0',
+      secrets: {
+        NAME: { value: 'RESOLVED', placeholder: '{{NAME}}', addedAt: '2026-01-01T00:00:00.000Z' },
+      },
+    })
+  );
+
+  // The live file: the tracked subtree PLUS an untracked "note" key that happens
+  // to contain the SAME placeholder text.
+  vol.writeFileSync(
+    LIVE,
+    JSON.stringify({ mcpServers: { old: 1 }, note: 'Hello {{NAME}}' })
+  );
+};
+
+describe('tuck restore — jsonKey subtree secret scoping', () => {
+  beforeEach(() => {
+    vol.reset();
+    clearManifestCache();
+    clearConfigCache();
+    resetWriteContext();
+    vol.mkdirSync('/test-home', { recursive: true });
+  });
+  afterEach(() => resetWriteContext());
+
+  it('resolves secrets in the tracked subtree but never in the untracked remainder', async () => {
+    await seed();
+
+    const { runRestoreCommand } = await import('../../src/commands/restore.js');
+    await runRestoreCommand(['~/.claude.json'], { yes: true, noHooks: true } as never);
+
+    const written = JSON.parse(vol.readFileSync(LIVE, 'utf-8'));
+
+    // The tracked subtree's placeholder WAS resolved from the secret store...
+    expect(written.mcpServers).toEqual({ api: 'RESOLVED' });
+    // ...but the UNTRACKED "note" key's identical placeholder text is untouched.
+    expect(written.note).toBe('Hello {{NAME}}');
+  });
+});

--- a/tests/commands/rules.test.ts
+++ b/tests/commands/rules.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `tuck rules` command integration tests.
+ *
+ * Drives the command through Commander against memfs (mocked in tests/setup.ts),
+ * asserting the JSON envelope shape and the on-disk fan-out result end to end.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { Command } from 'commander';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+import { resetWriteContext } from '../../src/lib/writeContext.js';
+
+// Silence the UI layer so no clack prompt / colored output leaks into the runner.
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    cancel: vi.fn(),
+  },
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: vi.fn(),
+    dim: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: {
+    yellow: (x: string) => x,
+    dim: (x: string) => x,
+    bold: (x: string) => x,
+    green: (x: string) => x,
+    cyan: (x: string) => x,
+    red: (x: string) => x,
+  },
+}));
+
+const captureStdout = (): { writes: string[]; restore: () => void } => {
+  const writes: string[] = [];
+  const spy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    });
+  return { writes, restore: () => spy.mockRestore() };
+};
+
+const runRules = async (...args: string[]): Promise<void> => {
+  const { createRulesCommand } = await import('../../src/commands/rules.js');
+  const program = new Command('tuck');
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+  // A fresh command tree per run so Commander option state never leaks between
+  // invocations within this file.
+  program.addCommand(createRulesCommand());
+  await program.parseAsync(['node', 'tuck', 'rules', ...args]);
+};
+
+const runJson = async (...args: string[]): Promise<Record<string, unknown>> => {
+  const { writes, restore } = captureStdout();
+  try {
+    await runRules(...args, '--json');
+  } finally {
+    restore();
+  }
+  return JSON.parse(writes.join('').trim());
+};
+
+const writeBaseManifest = (): void => {
+  vol.writeFileSync(
+    join(TEST_TUCK_DIR, '.tuckmanifest.json'),
+    JSON.stringify({
+      version: '1',
+      created: '2026-01-01T00:00:00.000Z',
+      updated: '2026-01-01T00:00:00.000Z',
+      files: {},
+    })
+  );
+};
+
+beforeEach(async () => {
+  vol.reset();
+  resetWriteContext();
+  vol.mkdirSync(TEST_HOME, { recursive: true });
+  vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  writeBaseManifest();
+  const { clearManifestCache } = await import('../../src/lib/manifest.js');
+  clearManifestCache();
+  const { __resetJsonEmitState, setJsonMode } = await import('../../src/lib/jsonOutput.js');
+  setJsonMode(false);
+  __resetJsonEmitState();
+});
+
+afterEach(() => {
+  resetWriteContext();
+});
+
+const AGENTS = `${TEST_HOME}/AGENTS.md`;
+
+describe('tuck rules track --json', () => {
+  it('tracks a home source and reports the set', async () => {
+    vol.writeFileSync(AGENTS, '# Rules\n');
+    const env = await runJson('track', AGENTS, '--tool', 'claude,gemini');
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck rules track');
+    const data = env.data as Record<string, unknown>;
+    expect(data.scope).toBe('home');
+    expect(data.source).toBe('~/AGENTS.md');
+    expect(data.id).toBe('home__agents.md');
+    expect((data.tools as { tool: string }[]).map((t) => t.tool)).toEqual(['claude', 'gemini']);
+  });
+
+  it('rejects an unknown tool name', async () => {
+    vol.writeFileSync(AGENTS, '# Rules\n');
+    await expect(runRules('track', AGENTS, '--tool', 'bogus', '--json')).rejects.toThrow();
+  });
+});
+
+describe('tuck rules apply --json', () => {
+  beforeEach(() => {
+    vol.writeFileSync(
+      AGENTS,
+      '# Rules\n{{#if tool == "cursor"}}CURSOR{{/if}}{{#if tool == "claude"}}CLAUDE{{/if}}\n'
+    );
+  });
+
+  it('fans out variants with per-tool content', async () => {
+    await runJson('track', AGENTS, '--tool', 'claude,cursor');
+    const env = await runJson('apply', '--yes', '--force');
+    expect(env.ok).toBe(true);
+    const applied = (env.data as { applied: { tool: string; action: string }[] }).applied;
+    expect(applied.map((a) => [a.tool, a.action])).toEqual([
+      ['claude', 'created'],
+      ['cursor', 'created'],
+    ]);
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).toContain('CLAUDE');
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).not.toContain('CURSOR');
+    expect(vol.readFileSync(join(TEST_HOME, '.cursorrules'), 'utf-8')).toContain('CURSOR');
+  });
+
+  it('dry-run reports actions but writes nothing', async () => {
+    await runJson('track', AGENTS, '--tool', 'claude');
+    const env = await runJson('apply', '--dry-run', '--yes');
+    expect((env.data as { dryRun: boolean }).dryRun).toBe(true);
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(false);
+  });
+
+  it('reports an empty apply when nothing is tracked', async () => {
+    const env = await runJson('apply', '--yes');
+    expect(env.ok).toBe(true);
+    expect((env.data as { applied: unknown[] }).applied).toEqual([]);
+  });
+});
+
+describe('tuck rules list --json', () => {
+  it('reports per-tool status transitioning to in-sync after apply', async () => {
+    vol.writeFileSync(AGENTS, '# Rules\n');
+    await runJson('track', AGENTS, '--tool', 'claude');
+
+    let env = await runJson('list');
+    let sets = (env.data as { sets: { tools: { status: string }[] }[] }).sets;
+    expect(sets[0].tools[0].status).toBe('missing');
+
+    await runJson('apply', '--yes', '--force');
+    env = await runJson('list');
+    sets = (env.data as { sets: { tools: { status: string }[] }[] }).sets;
+    expect(sets[0].tools[0].status).toBe('in-sync');
+  });
+});
+
+describe('tuck rules untrack --json', () => {
+  it('removes a set and optionally cleans generated files', async () => {
+    vol.writeFileSync(AGENTS, '# Rules\n');
+    const track = await runJson('track', AGENTS, '--tool', 'claude');
+    const id = (track.data as { id: string }).id;
+    await runJson('apply', '--yes', '--force');
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(true);
+
+    const env = await runJson('untrack', id, '--clean', '--yes');
+    expect(env.ok).toBe(true);
+    expect((env.data as { removed: boolean }).removed).toBe(true);
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(false);
+
+    const list = await runJson('list');
+    expect((list.data as { count: number }).count).toBe(0);
+  });
+
+  it('errors on an unknown id', async () => {
+    await expect(runRules('untrack', 'ghost', '--json')).rejects.toThrow();
+  });
+});

--- a/tests/commands/rules.test.ts
+++ b/tests/commands/rules.test.ts
@@ -161,6 +161,40 @@ describe('tuck rules apply --json', () => {
     expect(env.ok).toBe(true);
     expect((env.data as { applied: unknown[] }).applied).toEqual([]);
   });
+
+  it('isolates a bad set: applies the good one and reports the failure', async () => {
+    await runJson('track', AGENTS, '--tool', 'claude');
+    // Inject a repo-scoped set whose repoRoot does not exist on this machine.
+    const raw = JSON.parse(
+      vol.readFileSync(join(TEST_TUCK_DIR, 'rules.json'), 'utf-8') as string
+    );
+    raw.sets['repo__missing'] = {
+      source: '/no/such/repo/AGENTS.md',
+      scope: 'repo',
+      repoRoot: '/no/such/repo',
+      template: true,
+      tools: [{ tool: 'gemini', strategy: 'materialize' }],
+      variables: {},
+      added: 'n',
+      modified: 'n',
+    };
+    vol.writeFileSync(join(TEST_TUCK_DIR, 'rules.json'), JSON.stringify(raw));
+
+    const prevExit = process.exitCode;
+    try {
+      const env = await runJson('apply', '--yes', '--force');
+      const data = env.data as {
+        applied: { id: string; action: string }[];
+        errors: { id: string }[];
+      };
+      expect(data.applied.some((a) => a.id === 'home__agents.md')).toBe(true);
+      expect(data.errors.map((e) => e.id)).toContain('repo__missing');
+      expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = prevExit;
+    }
+  });
 });
 
 describe('tuck rules list --json', () => {

--- a/tests/commands/secrets-allow.test.ts
+++ b/tests/commands/secrets-allow.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Integration tests for `tuck secrets allow`.
+ *
+ * These run against the global memfs sandbox with the REAL scanner, store, and
+ * allowlist (no module mocks) so they prove the end-to-end contract: a finding
+ * the scanner flags can be marked safe once, after which every scan honors the
+ * committed allowlist — and removing the entry re-arms the finding.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_HOME, TEST_TUCK_DIR, initTestTuck } from '../utils/testHelpers.js';
+import { scanForSecrets } from '../../src/lib/secrets/index.js';
+import {
+  listAllowlistEntries,
+  getAllowlistPath,
+  computeFingerprint,
+} from '../../src/lib/secrets/allowlist.js';
+
+const AWS_LINE = 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n';
+const AWS_VALUE = 'AKIAIOSFODNN7EXAMPLE';
+const CONFIG_PATH = join(TEST_HOME, '.config', 'app.conf');
+
+describe('tuck secrets allow (integration)', () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('add --file marks a scanner finding safe and every later scan honors it', async () => {
+    await initTestTuck();
+    vol.mkdirSync(join(TEST_HOME, '.config'), { recursive: true });
+    vol.writeFileSync(CONFIG_PATH, AWS_LINE);
+
+    // Baseline: the scanner flags the AWS key.
+    const before = await scanForSecrets([CONFIG_PATH], TEST_TUCK_DIR);
+    expect(before.filesWithSecrets).toBe(1);
+    expect(before.totalSecrets).toBeGreaterThanOrEqual(1);
+
+    // Allowlist it non-interactively (no TTY in tests -> allowlists all findings).
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    await secretsCommand.parseAsync(
+      ['allow', 'add', '--file', CONFIG_PATH, '--reason', 'example key from AWS docs'],
+      { from: 'user' }
+    );
+
+    // The committed allowlist now holds a fingerprint-only entry (never the value).
+    const entries = await listAllowlistEntries(TEST_TUCK_DIR);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].fingerprint).toBe(computeFingerprint(AWS_VALUE));
+    expect(entries[0].reason).toBe('example key from AWS docs');
+    const rawAllowlist = vol.readFileSync(getAllowlistPath(TEST_TUCK_DIR), 'utf-8') as string;
+    expect(rawAllowlist).not.toContain(AWS_VALUE);
+
+    // Subsequent scans skip the allowlisted finding.
+    const after = await scanForSecrets([CONFIG_PATH], TEST_TUCK_DIR);
+    expect(after.filesWithSecrets).toBe(0);
+    expect(after.totalSecrets).toBe(0);
+  });
+
+  it('refuses the unscoped bulk path non-interactively without --yes', async () => {
+    await initTestTuck();
+    vol.mkdirSync(join(TEST_HOME, '.config'), { recursive: true });
+    vol.writeFileSync(CONFIG_PATH, AWS_LINE);
+
+    // No --file/--pattern/--fingerprint and no --yes: in a non-TTY context this
+    // would silently disarm the gate for EVERY finding — it must throw instead.
+    // (fresh module: commander instances retain option state across parses)
+    vi.resetModules();
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    await expect(
+      secretsCommand.parseAsync(['allow', 'add', '--reason', 'nope'], { from: 'user' })
+    ).rejects.toMatchObject({ code: 'ALLOW_ALL_REQUIRES_YES' });
+
+    expect(await listAllowlistEntries(TEST_TUCK_DIR)).toHaveLength(0);
+
+    // With explicit --yes the bulk path is allowed... but there are no tracked
+    // files in this sandbox, so it exits cleanly without entries.
+    await secretsCommand.parseAsync(['allow', 'add', '--reason', 'bulk ok', '--yes'], {
+      from: 'user',
+    });
+  });
+
+  it('allow add sees config custom-pattern findings (same scan as the gate)', async () => {
+    await initTestTuck();
+    vol.mkdirSync(join(TEST_HOME, '.config'), { recursive: true });
+    const customPath = join(TEST_HOME, '.config', 'custom.conf');
+    vol.writeFileSync(customPath, 'ACME_TOKEN=acme-zz-123456789\n');
+    // Register a config-level custom pattern (the gate scans with it; the raw
+    // builtin scanner does not know it). Use a fresh module registry so the
+    // command, config cache, and scanner are the SAME instances (earlier tests
+    // call vi.resetModules, which would otherwise split top-level imports from
+    // dynamic ones and leave a stale config cache in play).
+    vi.resetModules();
+    const { getConfigPath } = await import('../../src/lib/paths.js');
+    const { clearConfigCache } = await import('../../src/lib/config.js');
+    const freshSecrets = await import('../../src/lib/secrets/index.js');
+    const configPath = getConfigPath(TEST_TUCK_DIR);
+    const config = JSON.parse(vol.readFileSync(configPath, 'utf-8') as string);
+    config.security = {
+      ...(config.security ?? {}),
+      customPatterns: [{ name: 'ACME token', pattern: 'acme-zz-[0-9]{9}', severity: 'high' }],
+    };
+    vol.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    clearConfigCache();
+
+    const before = await freshSecrets.scanForSecrets([customPath], TEST_TUCK_DIR);
+    expect(before.totalSecrets).toBeGreaterThanOrEqual(1);
+
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    await secretsCommand.parseAsync(
+      ['allow', 'add', '--file', customPath, '--reason', 'test fixture token'],
+      { from: 'user' }
+    );
+
+    // The gate now honors the allowlisted custom-pattern finding.
+    const after = await freshSecrets.scanForSecrets([customPath], TEST_TUCK_DIR);
+    expect(after.totalSecrets).toBe(0);
+  });
+
+  it('remove re-arms the finding', async () => {
+    await initTestTuck();
+    vol.mkdirSync(join(TEST_HOME, '.config'), { recursive: true });
+    vol.writeFileSync(CONFIG_PATH, AWS_LINE);
+
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    await secretsCommand.parseAsync(
+      ['allow', 'add', '--file', CONFIG_PATH, '--reason', 'docs example'],
+      { from: 'user' }
+    );
+    expect((await scanForSecrets([CONFIG_PATH], TEST_TUCK_DIR)).filesWithSecrets).toBe(0);
+
+    const fingerprint = computeFingerprint(AWS_VALUE);
+    await secretsCommand.parseAsync(['allow', 'remove', fingerprint.slice(0, 12)], {
+      from: 'user',
+    });
+
+    expect(await listAllowlistEntries(TEST_TUCK_DIR)).toHaveLength(0);
+    expect((await scanForSecrets([CONFIG_PATH], TEST_TUCK_DIR)).filesWithSecrets).toBe(1);
+  });
+
+  it('add --file --pattern only allowlists the matching pattern', async () => {
+    await initTestTuck();
+    vol.mkdirSync(join(TEST_HOME, '.config'), { recursive: true });
+    vol.writeFileSync(CONFIG_PATH, AWS_LINE);
+
+    const { secretsCommand } = await import('../../src/commands/secrets.js');
+    // A pattern id that does not match the AWS finding -> nothing allowlisted.
+    await secretsCommand.parseAsync(
+      ['allow', 'add', '--file', CONFIG_PATH, '--pattern', 'no-such-pattern', '--reason', 'x'],
+      { from: 'user' }
+    );
+    expect(await listAllowlistEntries(TEST_TUCK_DIR)).toHaveLength(0);
+    expect((await scanForSecrets([CONFIG_PATH], TEST_TUCK_DIR)).filesWithSecrets).toBe(1);
+  });
+});

--- a/tests/commands/secrets-value-encryption.test.ts
+++ b/tests/commands/secrets-value-encryption.test.ts
@@ -74,6 +74,11 @@ import {
   runSecretsEncryptValues,
   runSecretsDecryptValues,
 } from '../../src/commands/secrets.js';
+// The UI module is mocked above; this import yields the mocked prompts object so
+// individual tests can script prompts.password() for the interactive path.
+import { prompts } from '../../src/ui/index.js';
+
+const passwordMock = prompts.password as unknown as ReturnType<typeof vi.fn>;
 
 describe('tuck secrets encrypt/decrypt (integration)', () => {
   const envPath = join(TEST_HOME, '.env');
@@ -138,6 +143,56 @@ describe('tuck secrets encrypt/decrypt (integration)', () => {
     vol.writeFileSync(envPath, 'HOST=localhost\nPORT=8080\n');
     await runSecretsEncryptValues([], { yes: true });
     expect(vol.readFileSync(envPath, 'utf-8')).toBe('HOST=localhost\nPORT=8080\n');
+  });
+
+  it('confirms a newly introduced passphrase (double prompt) before encrypting', async () => {
+    // No env / keystore password + a TTY => the passphrase is introduced here,
+    // so encrypt must prompt for it twice and require a match.
+    delete process.env.TUCK_ENCRYPTION_PASSWORD;
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    getStoredPasswordMock.mockResolvedValue(null);
+    vol.writeFileSync(envPath, 'GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd\n');
+
+    passwordMock.mockReset();
+    passwordMock.mockResolvedValueOnce('s3kret-pass').mockResolvedValueOnce('s3kret-pass');
+
+    await runSecretsEncryptValues([], {}); // interactive: no yes/json
+
+    // Entered once + confirmed once.
+    expect(passwordMock).toHaveBeenCalledTimes(2);
+    const encrypted = vol.readFileSync(envPath, 'utf-8') as string;
+    expect(encrypted).toContain('ENC[tuck:v1:');
+    expect(encrypted).not.toContain('ghp_0123456789abcdefABCDEF0123456789abcd');
+
+    // Decrypt introduces nothing new — a single prompt, no confirmation.
+    passwordMock.mockReset();
+    passwordMock.mockResolvedValue('s3kret-pass');
+    await runSecretsDecryptValues([], {});
+    expect(passwordMock).toHaveBeenCalledTimes(1);
+    expect(vol.readFileSync(envPath, 'utf-8')).toContain(
+      'ghp_0123456789abcdefABCDEF0123456789abcd'
+    );
+  });
+
+  it('re-prompts on a passphrase mismatch, then encrypts once they match', async () => {
+    delete process.env.TUCK_ENCRYPTION_PASSWORD;
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    getStoredPasswordMock.mockResolvedValue(null);
+    vol.writeFileSync(envPath, 'GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd\n');
+
+    passwordMock.mockReset();
+    passwordMock
+      .mockResolvedValueOnce('typo-a') // attempt 1 entry
+      .mockResolvedValueOnce('typo-b') // attempt 1 confirm (mismatch)
+      .mockResolvedValueOnce('good-pass') // attempt 2 entry
+      .mockResolvedValueOnce('good-pass'); // attempt 2 confirm (match)
+
+    await runSecretsEncryptValues([], {});
+
+    expect(passwordMock).toHaveBeenCalledTimes(4);
+    const encrypted = vol.readFileSync(envPath, 'utf-8') as string;
+    expect(encrypted).toContain('ENC[tuck:v1:');
+    expect(encrypted).not.toContain('ghp_0123456789abcdefABCDEF0123456789abcd');
   });
 
   it('emits a JSON envelope without leaking secret values', async () => {

--- a/tests/commands/secrets-value-encryption.test.ts
+++ b/tests/commands/secrets-value-encryption.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration test for `tuck secrets encrypt` / `tuck secrets decrypt`.
+ *
+ * Drives the real command run-functions end to end against memfs temp files
+ * (never the real HOME/keystore). External seams — manifest, config, keystore,
+ * and time-machine snapshots — are mocked; the scanner and value-encryption
+ * crypto are the real implementations, so this exercises the full
+ * scan → encrypt → decrypt round trip.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+
+// --- Mocks for external seams ------------------------------------------------
+
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+const getStoredPasswordMock = vi.fn();
+const createSnapshotMock = vi.fn();
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: (...args: unknown[]) => loadManifestMock(...args),
+  getAllTrackedFiles: (...args: unknown[]) => getAllTrackedFilesMock(...args),
+}));
+
+vi.mock('../../src/lib/crypto/index.js', () => ({
+  getStoredPassword: (...args: unknown[]) => getStoredPasswordMock(...args),
+}));
+
+vi.mock('../../src/lib/timemachine.js', () => ({
+  createSnapshot: (...args: unknown[]) => createSnapshotMock(...args),
+}));
+
+// scanForSecrets loads config; return a minimal built-in-scanner config.
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: vi.fn(async () => ({ security: {} })),
+  saveConfig: vi.fn(async () => {}),
+}));
+
+// Silence UI; the run-functions never prompt in non-interactive mode.
+vi.mock('../../src/ui/index.js', () => {
+  const passthrough = (v: string) => v;
+  const c = Object.assign(passthrough, {
+    bold: Object.assign(passthrough, { cyan: passthrough }),
+    dim: passthrough,
+    cyan: passthrough,
+    green: passthrough,
+    red: passthrough,
+    yellow: passthrough,
+  });
+  return {
+    prompts: {
+      confirm: vi.fn(async () => true),
+      password: vi.fn(async () => ''),
+      spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
+      log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+      intro: vi.fn(),
+      outro: vi.fn(),
+    },
+    logger: {
+      info: vi.fn(),
+      dim: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      success: vi.fn(),
+      heading: vi.fn(),
+    },
+    colors: c,
+  };
+});
+
+import {
+  runSecretsEncryptValues,
+  runSecretsDecryptValues,
+} from '../../src/commands/secrets.js';
+
+describe('tuck secrets encrypt/decrypt (integration)', () => {
+  const envPath = join(TEST_HOME, '.env');
+  const originalIsTty = process.stdout.isTTY;
+  const originalEnvPass = process.env.TUCK_ENCRYPTION_PASSWORD;
+
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+    // Non-interactive: no prompts, passphrase from env.
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    process.env.TUCK_ENCRYPTION_PASSWORD = 'test-passphrase-123';
+
+    loadManifestMock.mockResolvedValue({});
+    getAllTrackedFilesMock.mockResolvedValue({
+      env: { source: envPath },
+    });
+    getStoredPasswordMock.mockResolvedValue(null);
+    createSnapshotMock.mockResolvedValue({ id: 'snap-1' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTty,
+      configurable: true,
+    });
+    if (originalEnvPass === undefined) {
+      delete process.env.TUCK_ENCRYPTION_PASSWORD;
+    } else {
+      process.env.TUCK_ENCRYPTION_PASSWORD = originalEnvPass;
+    }
+    vol.reset();
+  });
+
+  it('encrypts detected values in place and decrypts them back', async () => {
+    const original = [
+      '# app config',
+      'HOST=localhost',
+      'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+      'GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd',
+    ].join('\n');
+    vol.writeFileSync(envPath, original);
+
+    await runSecretsEncryptValues([], { yes: true });
+
+    const encrypted = vol.readFileSync(envPath, 'utf-8') as string;
+    // Structure/keys/comments preserved; secrets replaced with tokens.
+    expect(encrypted).toContain('# app config');
+    expect(encrypted).toContain('HOST=localhost');
+    expect(encrypted).toContain('ENC[tuck:v1:');
+    expect(encrypted).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(encrypted).not.toContain('ghp_0123456789abcdefABCDEF0123456789abcd');
+    // A pre-mutation snapshot was taken.
+    expect(createSnapshotMock).toHaveBeenCalled();
+
+    await runSecretsDecryptValues([], { yes: true });
+
+    expect(vol.readFileSync(envPath, 'utf-8')).toBe(original);
+  });
+
+  it('is a no-op when there are no secret values to encrypt', async () => {
+    vol.writeFileSync(envPath, 'HOST=localhost\nPORT=8080\n');
+    await runSecretsEncryptValues([], { yes: true });
+    expect(vol.readFileSync(envPath, 'utf-8')).toBe('HOST=localhost\nPORT=8080\n');
+  });
+
+  it('emits a JSON envelope without leaking secret values', async () => {
+    vol.writeFileSync(envPath, 'GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd\n');
+    let output = '';
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      await runSecretsEncryptValues([envPath], { json: true, yes: true });
+    } finally {
+      writeSpy.mockRestore();
+    }
+    expect(output).not.toContain('ghp_0123456789abcdefABCDEF0123456789abcd');
+    expect(output).toContain('valuesEncrypted');
+  });
+});

--- a/tests/commands/settings.test.ts
+++ b/tests/commands/settings.test.ts
@@ -1,0 +1,228 @@
+/**
+ * `tuck settings` command integration tests.
+ *
+ * The manifest/state live on memfs (temp dirs, never the real HOME). All macOS
+ * binaries (`defaults`/`sw_vers`/`killall`) are mocked via child_process, so the
+ * backend-driven paths are exercised without touching real system settings.
+ *
+ * Backend-gated subcommands (capture/apply) only run on darwin, where
+ * selectBackend() returns the macOS backend; the cross-platform paths
+ * (list/remove/manual) run everywhere.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { Command } from 'commander';
+import { TEST_TUCK_DIR } from '../setup.js';
+
+vi.mock('../../src/ui/index.js', () => ({
+  banner: vi.fn(),
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    cancel: vi.fn(),
+  },
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    file: vi.fn(),
+    dim: vi.fn(),
+    debug: vi.fn(),
+  },
+  colors: new Proxy({}, { get: () => (x: string) => x }),
+}));
+
+// Mock the macOS CLIs. Keyed on binary + first arg.
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1] as (
+      err: Error | null,
+      result: { stdout: string; stderr: string }
+    ) => void;
+    const cmd = args[0] as string;
+    const argv = (args[1] as string[]) ?? [];
+    let stdout = '';
+    if (cmd === 'sw_vers') stdout = '15.1\n';
+    else if (cmd === 'defaults' && argv[0] === 'domains') stdout = 'com.apple.dock';
+    else if (cmd === 'defaults' && argv[0] === 'export')
+      stdout = '<plist version="1.0"><dict><key>autohide</key><false/></dict></plist>';
+    callback(null, { stdout, stderr: '' });
+  },
+}));
+
+const writeBaseManifest = (): void => {
+  vol.writeFileSync(
+    join(TEST_TUCK_DIR, '.tuckmanifest.json'),
+    JSON.stringify({
+      version: '1',
+      created: '2026-01-01T00:00:00.000Z',
+      updated: '2026-01-01T00:00:00.000Z',
+      files: {},
+    })
+  );
+};
+
+const captureStdout = (): { writes: string[]; restore: () => void } => {
+  const writes: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  return { writes, restore: () => spy.mockRestore() };
+};
+
+const runSettings = async (...args: string[]): Promise<void> => {
+  const { createSettingsCommand } = await import('../../src/commands/settings.js');
+  const { clearManifestCache } = await import('../../src/lib/manifest.js');
+  clearManifestCache();
+  const program = new Command('tuck');
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+  program.addCommand(createSettingsCommand());
+  await program.parseAsync(['node', 'tuck', 'settings', ...args]);
+};
+
+const runJson = async (...args: string[]): Promise<Record<string, unknown>> => {
+  const { writes, restore } = captureStdout();
+  try {
+    await runSettings(...args, '--json');
+  } finally {
+    restore();
+  }
+  return JSON.parse(writes.join('').trim());
+};
+
+beforeEach(async () => {
+  vol.reset();
+  vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  writeBaseManifest();
+  const { __resetJsonEmitState, setJsonMode } = await import('../../src/lib/jsonOutput.js');
+  setJsonMode(false);
+  __resetJsonEmitState();
+});
+
+describe('tuck settings list (cross-platform)', () => {
+  it('emits an ok envelope with empty counts on a fresh manifest', async () => {
+    const env = await runJson('list');
+    expect(env.ok).toBe(true);
+    expect(env.command).toBe('tuck settings list');
+    const data = env.data as Record<string, unknown>;
+    expect(data.settingsCount).toBe(0);
+    expect(data.manualCount).toBe(0);
+  });
+});
+
+describe('tuck settings manual (cross-platform)', () => {
+  it('adds a manual step, lists it, marks it done, and reflects state', async () => {
+    const add = await runJson('manual', 'add', 'Enable FileVault', '-i', 'Privacy pane');
+    const addData = add.data as { id: string; created: boolean };
+    expect(addData.created).toBe(true);
+    const id = addData.id;
+
+    const list = await runJson('manual', 'list');
+    const listData = list.data as { count: number; manualSteps: { id: string; done: boolean }[] };
+    expect(listData.count).toBe(1);
+    expect(listData.manualSteps[0].done).toBe(false);
+
+    const done = await runJson('manual', 'done', id);
+    expect((done.data as { done: boolean }).done).toBe(true);
+
+    const list2 = await runJson('manual', 'list');
+    expect((list2.data as { manualSteps: { done: boolean }[] }).manualSteps[0].done).toBe(true);
+
+    const reset = await runJson('manual', 'reset', id);
+    expect((reset.data as { done: boolean }).done).toBe(false);
+  });
+
+  it('errors when marking a nonexistent manual step done', async () => {
+    await expect(runSettings('manual', 'done', 'macos__manual__nope', '--json')).rejects.toThrow();
+  });
+});
+
+describe('tuck settings remove (cross-platform)', () => {
+  it('errors on an unknown setting id', async () => {
+    await expect(runSettings('remove', 'macos__x__y', '--json')).rejects.toThrow();
+  });
+});
+
+// Backend-gated paths: darwin only (selectBackend returns null elsewhere).
+describe.runIf(process.platform === 'darwin')('tuck settings capture/apply (macOS)', () => {
+  it('captures a setting directly and lists it', async () => {
+    const cap = await runJson(
+      'capture',
+      '--domain',
+      'com.apple.dock',
+      '--key',
+      'autohide',
+      '--type',
+      'boolean',
+      '--value',
+      'true',
+      '--restart',
+      'Dock'
+    );
+    const capData = cap.data as { id: string; entry: { value: string; restartApps: string[] } };
+    expect(capData.id).toBe('macos__com.apple.dock__autohide');
+    expect(capData.entry.value).toBe('true');
+    expect(capData.entry.restartApps).toEqual(['Dock']);
+
+    const list = await runJson('list');
+    expect((list.data as { settingsCount: number }).settingsCount).toBe(1);
+
+    // Remove it again through the command.
+    const rm = await runJson('remove', 'macos__com.apple.dock__autohide');
+    expect((rm.data as { removed: boolean }).removed).toBe(true);
+  });
+
+  it('apply --dry-run reports the planned write without applying', async () => {
+    await runJson(
+      'capture',
+      '--domain',
+      'com.apple.dock',
+      '--key',
+      'autohide',
+      '--type',
+      'boolean',
+      '--value',
+      'true'
+    );
+    const env = await runJson('apply', '--dry-run');
+    const data = env.data as {
+      dryRun: boolean;
+      applied: { display: string }[];
+      backupDir: string | null;
+    };
+    expect(data.dryRun).toBe(true);
+    expect(data.applied[0].display).toBe('defaults write com.apple.dock autohide -bool true');
+    expect(data.backupDir).toBeNull();
+  });
+
+  it('skips a setting whose min-version guard exceeds the current OS', async () => {
+    await runJson(
+      'capture',
+      '--domain',
+      'com.apple.finder',
+      '--key',
+      'ShowPathbar',
+      '--type',
+      'boolean',
+      '--value',
+      'true',
+      '--min-version',
+      '99.0'
+    );
+    const env = await runJson('apply', '--dry-run');
+    const data = env.data as { applied: unknown[]; skipped: { reason: string }[] };
+    expect(data.applied).toHaveLength(0);
+    expect(data.skipped[0].reason).toContain('>= 99.0');
+  });
+});

--- a/tests/commands/settings.test.ts
+++ b/tests/commands/settings.test.ts
@@ -206,6 +206,50 @@ describe.runIf(process.platform === 'darwin')('tuck settings capture/apply (macO
     expect(data.backupDir).toBeNull();
   });
 
+  // ── Finding 3: --json apply is destructive and must carry --yes ──
+  it('apply --json without --yes refuses to apply (non-dry-run)', async () => {
+    await runJson(
+      'capture',
+      '--domain',
+      'com.apple.dock',
+      '--key',
+      'autohide',
+      '--type',
+      'boolean',
+      '--value',
+      'true'
+    );
+    await expect(runSettings('apply', '--json')).rejects.toThrow();
+  });
+
+  it('apply --json --yes applies and reports the backup directory', async () => {
+    await runJson(
+      'capture',
+      '--domain',
+      'com.apple.dock',
+      '--key',
+      'autohide',
+      '--type',
+      'boolean',
+      '--value',
+      'true'
+    );
+    const env = await runJson('apply', '--yes');
+    expect(env.ok).toBe(true);
+    const data = env.data as {
+      dryRun: boolean;
+      applied: { id: string }[];
+      failed: unknown[];
+      backupDir: string | null;
+      restarted: string[];
+      restartRequired: string[];
+    };
+    expect(data.dryRun).toBe(false);
+    expect(data.applied.map((a) => a.id)).toEqual(['macos__com.apple.dock__autohide']);
+    expect(data.failed).toEqual([]);
+    expect(data.backupDir).not.toBeNull();
+  });
+
   it('skips a setting whose min-version guard exceeds the current OS', async () => {
     await runJson(
       'capture',

--- a/tests/commands/sync-json-merge-reconcile.test.ts
+++ b/tests/commands/sync-json-merge-reconcile.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Non-interactive sync-time JSON reconcile (findings 2, 4, 6).
+ *
+ * The `--json` / `--yes` and `-m <msg>` sync paths must pull, capture the
+ * pre-pull repo copy as the merge base, three-way merge every diverged
+ * JSON-policy file, and — on an unresolvable conflict — persist the bases and
+ * throw JsonMergeConflictsError (exit 3) BEFORE any commit/push, so a stale
+ * local value can never be pushed over the remote's version.
+ *
+ * Uses the global memfs fs mock for real file content (live + repo copies) so
+ * captureMergeBases / detectChanges / reconcileJsonMerges run their real logic;
+ * git, manifest, snapshots, and secrets are mocked. jsonMergeSync (base
+ * persistence) is REAL and writes to the memfs-backed state dir.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { JsonMergeConflictsError } from '../../src/errors.js';
+import {
+  loadPendingMergeBases,
+  persistPendingMergeBases,
+  clearPendingMergeBases,
+} from '../../src/lib/jsonMergeSync.js';
+
+const loadManifestMock = vi.fn();
+const getAllTrackedFilesMock = vi.fn();
+const resolveLiveTargetMock = vi.fn();
+const getFileChecksumMock = vi.fn();
+const loadTuckignoreMock = vi.fn();
+
+const stageAllMock = vi.fn();
+const commitMock = vi.fn();
+const getStatusMock = vi.fn();
+const pushMock = vi.fn();
+const hasRemoteMock = vi.fn();
+const fetchMock = vi.fn();
+const pullMock = vi.fn();
+const abortRebaseMock = vi.fn();
+const detectConflictsMock = vi.fn();
+
+const createSnapshotMock = vi.fn();
+const checkLocalModeMock = vi.fn();
+const loadConfigMock = vi.fn();
+const assertRemoteAvailableMock = vi.fn();
+const copyFileOrDirMock = vi.fn();
+
+const SOURCE = '~/.claude/settings.json';
+const DEST_REL = 'files/agent/settings.json';
+const TUCK_DIR = '/test-home/.tuck';
+const DEST_PATH = join(TUCK_DIR, DEST_REL);
+const LIVE_PATH = '/test-home/.claude/settings.json';
+
+vi.mock('../../src/ui/index.js', () => ({
+  prompts: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(false),
+    confirmDangerous: vi.fn().mockResolvedValue(true),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: '' })),
+    log: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      step: vi.fn(),
+      message: vi.fn(),
+    },
+  },
+  logger: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    file: vi.fn(),
+    heading: vi.fn(),
+    blank: vi.fn(),
+    dim: vi.fn(),
+  },
+  withSpinner: vi.fn(async (_label: string, fn: () => Promise<unknown>) => fn()),
+  colors: new Proxy({}, { get: () => (x: string) => x }),
+}));
+
+// paths.js is mocked so getTuckDir/expandPath/pathExists are deterministic.
+// pathExists always-true lets the REAL captureMergeBases/reconcile read the
+// memfs files we set up; realpath (from fs/promises, memfs) still resolves them.
+// NOTE: vitest runs with mockReset:true, which strips `.mockResolvedValue()`
+// overrides from factory mocks but PRESERVES implementations passed as
+// `vi.fn(impl)`. So every factory default that must survive across tests is
+// written as `vi.fn(impl)`, not `vi.fn().mockResolvedValue(...)`.
+vi.mock('../../src/lib/paths.js', () => ({
+  getTuckDir: vi.fn(() => TUCK_DIR),
+  expandPath: vi.fn((p: string) => p.replace(/^~\//, '/test-home/')),
+  pathExists: vi.fn(async () => true),
+  collapsePath: vi.fn((p: string) => p),
+  isDirectory: vi.fn(async () => false),
+  validateSafeSourcePath: vi.fn(),
+  validateSafeManifestDestination: vi.fn(),
+  validatePathWithinRoot: vi.fn(),
+}));
+
+vi.mock('../../src/lib/manifest.js', () => ({
+  loadManifest: loadManifestMock,
+  getAllTrackedFiles: getAllTrackedFilesMock,
+  updateFileInManifest: vi.fn(),
+  removeFileFromManifest: vi.fn(),
+  buildSourceIndex: vi.fn(),
+  clearManifestCache: vi.fn(),
+}));
+
+vi.mock('../../src/lib/repoScope.js', () => ({
+  resolveLiveTarget: resolveLiveTargetMock,
+}));
+
+vi.mock('../../src/lib/git.js', () => ({
+  stageAll: stageAllMock,
+  commit: commitMock,
+  getStatus: getStatusMock,
+  push: pushMock,
+  hasRemote: hasRemoteMock,
+  fetch: fetchMock,
+  pull: pullMock,
+}));
+
+vi.mock('../../src/lib/mergeConflicts.js', () => ({
+  detectConflicts: detectConflictsMock,
+  abortRebase: abortRebaseMock,
+  continueRebase: vi.fn(),
+  applyResolution: vi.fn(),
+}));
+
+vi.mock('../../src/ui/merge.js', () => ({
+  resolveConflictsInteractively: vi.fn(),
+}));
+
+vi.mock('../../src/lib/timemachine.js', () => ({
+  createSnapshot: createSnapshotMock,
+}));
+
+vi.mock('../../src/lib/files.js', () => ({
+  copyFileOrDir: copyFileOrDirMock,
+  getFileChecksum: getFileChecksumMock,
+  deleteFileOrDir: vi.fn(),
+  checkFileSizeThreshold: vi.fn(async () => ({ warn: false, block: false, size: 10 })),
+  formatFileSize: vi.fn((n: number) => `${n} B`),
+  SIZE_BLOCK_THRESHOLD: 100 * 1024 * 1024,
+}));
+
+vi.mock('../../src/lib/tuckignore.js', () => ({
+  addToTuckignore: vi.fn(),
+  loadTuckignore: loadTuckignoreMock,
+  isIgnoredInSet: vi.fn(() => false),
+}));
+
+vi.mock('../../src/lib/hooks.js', () => ({
+  runPreSyncHook: vi.fn(),
+  runPostSyncHook: vi.fn(),
+}));
+
+vi.mock('../../src/lib/detect.js', () => ({
+  detectDotfiles: vi.fn(async () => []),
+  DETECTION_CATEGORIES: {},
+}));
+
+vi.mock('../../src/lib/fileTracking.js', () => ({
+  trackFilesWithProgress: vi.fn(async () => ({
+    succeeded: 0,
+    failed: 0,
+    errors: [],
+    sensitiveFiles: [],
+  })),
+}));
+
+vi.mock('../../src/lib/trackPipeline.js', () => ({
+  preparePathsForTracking: vi.fn(async () => []),
+}));
+
+vi.mock('../../src/lib/secrets/index.js', () => ({
+  scanForSecrets: vi.fn(async () => ({ totalSecrets: 0, results: [] })),
+  isSecretScanningEnabled: vi.fn(async () => false),
+  shouldBlockOnSecrets: vi.fn(async () => true),
+  processSecretsForRedaction: vi.fn(),
+  redactFile: vi.fn(),
+  getStoredValueMap: vi.fn(async () => new Map()),
+  getRedactedChecksum: vi.fn(),
+  addAllowlistEntryByFingerprint: vi.fn(),
+  computeFingerprint: vi.fn(),
+  getAllowlistPath: vi.fn(),
+}));
+
+vi.mock('../../src/commands/secrets.js', () => ({
+  displayScanResults: vi.fn(),
+}));
+
+vi.mock('../../src/lib/audit.js', () => ({
+  logForceSecretBypass: vi.fn(),
+  logSecretAllowlisted: vi.fn(),
+}));
+
+vi.mock('../../src/lib/remoteChecks.js', () => ({
+  checkLocalMode: checkLocalModeMock,
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../src/lib/providers/index.js', () => ({
+  assertRemoteAvailable: assertRemoteAvailableMock,
+}));
+
+const trackedFile = (overrides: Record<string, unknown> = {}) => ({
+  f1: {
+    source: SOURCE,
+    destination: DEST_REL,
+    category: 'misc',
+    strategy: 'copy',
+    encrypted: false,
+    template: false,
+    checksum: 'stored-checksum',
+    added: new Date().toISOString(),
+    modified: new Date().toISOString(),
+    bundle: 'default',
+    ...overrides,
+  },
+});
+
+const writeFiles = (base: string, live: string) => {
+  vol.mkdirSync(join(TUCK_DIR, 'files', 'agent'), { recursive: true });
+  vol.mkdirSync('/test-home/.claude', { recursive: true });
+  // Repo copy = pre-pull base (captureMergeBases reads this before the pull).
+  vol.writeFileSync(DEST_PATH, base);
+  vol.writeFileSync(LIVE_PATH, live);
+};
+
+describe('non-interactive sync JSON reconcile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadManifestMock.mockResolvedValue({ files: {} });
+    loadTuckignoreMock.mockResolvedValue(new Set());
+    getAllTrackedFilesMock.mockResolvedValue(trackedFile());
+    resolveLiveTargetMock.mockResolvedValue(LIVE_PATH);
+    checkLocalModeMock.mockResolvedValue(false);
+    loadConfigMock.mockResolvedValue({ remote: { mode: 'github' } });
+    assertRemoteAvailableMock.mockImplementation(() => {});
+    createSnapshotMock.mockResolvedValue(undefined);
+    abortRebaseMock.mockResolvedValue(undefined);
+    commitMock.mockResolvedValue('abc123def456');
+    hasRemoteMock.mockResolvedValue(true);
+    fetchMock.mockResolvedValue(undefined);
+    detectConflictsMock.mockResolvedValue([]);
+    // The rebase pull "advances" the repo copy to the remote's version.
+  });
+
+  afterEach(async () => {
+    await clearPendingMergeBases();
+  });
+
+  it('throws JsonMergeConflictsError (exit 3), persists bases, and never pushes on --json conflict', async () => {
+    const base = JSON.stringify({ model: 'sonnet' }, null, 2) + '\n';
+    const remote = JSON.stringify({ model: 'opus' }, null, 2) + '\n';
+    const live = JSON.stringify({ model: 'haiku' }, null, 2) + '\n';
+    writeFiles(base, live);
+
+    getStatusMock.mockResolvedValue({ behind: 1, ahead: 0, hasChanges: true });
+    // getFileChecksum ≠ stored ⇒ detectChanges flags the file modified.
+    getFileChecksumMock.mockResolvedValue('live-checksum');
+    // Pull advances the repo copy to the remote's version.
+    pullMock.mockImplementation(async () => {
+      vol.writeFileSync(DEST_PATH, remote);
+    });
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+
+    let caught: unknown;
+    try {
+      await runSyncCommand(undefined, { json: true, scan: false, noHooks: true } as never);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(JsonMergeConflictsError);
+    expect((caught as JsonMergeConflictsError).toJSON().exit_code).toBe(3);
+
+    // Nothing was committed or pushed — the conflicted remote is untouched.
+    expect(commitMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+
+    // The base was persisted so the next sync can re-detect the conflict.
+    const pending = await loadPendingMergeBases();
+    expect(pending.get(SOURCE)).toBe(base);
+  });
+
+  it('throws on the -m message path too (forced non-interactive), persisting bases and not pushing', async () => {
+    const base = JSON.stringify({ model: 'sonnet' }, null, 2) + '\n';
+    const remote = JSON.stringify({ model: 'opus' }, null, 2) + '\n';
+    const live = JSON.stringify({ model: 'haiku' }, null, 2) + '\n';
+    writeFiles(base, live);
+
+    getStatusMock.mockResolvedValue({ behind: 1, ahead: 0, hasChanges: true });
+    getFileChecksumMock.mockResolvedValue('live-checksum');
+    pullMock.mockImplementation(async () => {
+      vol.writeFileSync(DEST_PATH, remote);
+    });
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+
+    await expect(
+      runSyncCommand('update', { message: 'update', scan: false, noHooks: true } as never)
+    ).rejects.toBeInstanceOf(JsonMergeConflictsError);
+
+    expect(commitMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+    const pending = await loadPendingMergeBases();
+    expect(pending.get(SOURCE)).toBe(base);
+  });
+
+  it('auto-applies a clean union to live+repo, pushes, and clears pending bases (--json)', async () => {
+    const base = JSON.stringify({ permissions: { allow: ['Read'] } }, null, 2) + '\n';
+    const remote = JSON.stringify({ permissions: { allow: ['Read', 'WebFetch'] } }, null, 2) + '\n';
+    const live = JSON.stringify({ permissions: { allow: ['Read', 'Bash(git:*)'] } }, null, 2) + '\n';
+    writeFiles(base, live);
+
+    getStatusMock.mockResolvedValue({ behind: 1, ahead: 0, hasChanges: true });
+    getFileChecksumMock.mockResolvedValue('live-checksum');
+    pullMock.mockImplementation(async () => {
+      vol.writeFileSync(DEST_PATH, remote);
+    });
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand(undefined, { json: true, scan: false, noHooks: true } as never);
+
+    // The live file converged to the UNION of all three sides (no data loss).
+    const mergedLive = JSON.parse(vol.readFileSync(LIVE_PATH, 'utf-8') as string) as {
+      permissions: { allow: string[] };
+    };
+    expect(mergedLive.permissions.allow.sort()).toEqual(['Bash(git:*)', 'Read', 'WebFetch']);
+
+    // A clean merge commits + pushes normally.
+    expect(pushMock).toHaveBeenCalled();
+
+    // The base was reconciled ⇒ pending bases cleared.
+    const pending = await loadPendingMergeBases();
+    expect(pending.size).toBe(0);
+  });
+
+  it('clears a stale persisted base when the file no longer diverges (--json)', async () => {
+    // A base left over from a previous run; this run the file is unchanged.
+    const oldBase = JSON.stringify({ permissions: { allow: ['Read'] } }, null, 2) + '\n';
+    await persistPendingMergeBases(new Map([[SOURCE, oldBase]]));
+
+    writeFiles(oldBase, oldBase);
+    // No pull (up to date) and no drift ⇒ file is not in changes.
+    getStatusMock.mockResolvedValue({ behind: 0, ahead: 0, hasChanges: false });
+    getFileChecksumMock.mockResolvedValue('stored-checksum'); // == stored ⇒ unchanged
+
+    const { runSyncCommand } = await import('../../src/commands/sync.js');
+    await runSyncCommand(undefined, { json: true, scan: false, noHooks: true } as never);
+
+    // Stale base dropped so it can never resurface as a spurious conflict.
+    const pending = await loadPendingMergeBases();
+    expect(pending.size).toBe(0);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/e2e/agent-cli.e2e.test.ts
+++ b/tests/e2e/agent-cli.e2e.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { ensureBuilt } from './helpers/build.js';
+import { runCli, makeHome, cleanupHome, seedHomeFile, parseEnvelope } from './helpers/runCli.js';
+import { hasGit, gitIdentityEnv } from './helpers/git.js';
+
+/**
+ * Agent-native CLI contract (IDEAS.md 1.3): every command must expose a
+ * guaranteed non-interactive path, a stable JSON envelope, machine-readable
+ * error codes, and no ANSI when output is not a terminal. A memfs unit test
+ * cannot prove the real binary honors these end to end — this spawns it.
+ */
+describe('e2e: agent-native CLI contract', () => {
+  beforeAll(async () => {
+    await ensureBuilt();
+  }, 180_000);
+
+  const homes: string[] = [];
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(cleanupHome));
+  });
+
+  it('accepts --non-interactive as a global flag on any command', async () => {
+    const home = await makeHome();
+    homes.push(home);
+    // Uninitialized home + bare status: the default dashboard action honors --json.
+    const r = await runCli(['--non-interactive', '--json'], { home });
+    expect(r.code).toBe(0);
+    const env = parseEnvelope(r.stdout);
+    expect(env.ok).toBe(true);
+    expect(env.data).toMatchObject({ initialized: false });
+  });
+
+  it('fails fast with a typed JSON error when a prompt would be required', async () => {
+    if (!(await hasGit())) return;
+    const home = await makeHome();
+    homes.push(home);
+    const env = { ...gitIdentityEnv() };
+    await seedHomeFile(home, '.vimrc', 'set number\n');
+    const init = await runCli(['init', '--bare', '--json'], { home, env });
+    expect(init.code).toBe(0);
+    const add = await runCli(['add', join(home, '.vimrc'), '--json', '--yes'], { home, env });
+    expect(add.code).toBe(0);
+
+    // `tuck remove` with no path opens an interactive picker. Under --json /
+    // non-TTY it must NOT hang — it must fail fast with a typed error envelope.
+    const r = await runCli(['remove', '--json'], { home, env });
+    expect(r.code).not.toBe(0);
+    const parsed = parseEnvelope(r.stdout);
+    expect(parsed.ok).toBe(false);
+    expect((parsed.error as { code?: string }).code).toBe('OPERATION_CANCELLED');
+  });
+
+  it('emits no ANSI escape codes when stdout is not a TTY', async () => {
+    const home = await makeHome();
+    homes.push(home);
+    // Clear the harness's NO_COLOR/FORCE_COLOR so suppression is driven purely by
+    // tuck's own non-TTY detection (configureColor), not the ambient env.
+    const r = await runCli([], { home, env: { NO_COLOR: '', FORCE_COLOR: '' } });
+    expect(r.code).toBe(0);
+    const ansi = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m');
+    expect(ansi.test(r.stdout)).toBe(false);
+    expect(ansi.test(r.stderr)).toBe(false);
+  });
+});

--- a/tests/integration/json-key-tracking.test.ts
+++ b/tests/integration/json-key-tracking.test.ts
@@ -1,0 +1,217 @@
+/**
+ * End-to-end integration for JSON-path-scoped tracking (`tuck add --key`).
+ *
+ * Exercises the full promise on a sandboxed memfs home: only the named subtree
+ * lands in the repo, machine-managed keys alongside it are never captured, sync
+ * re-captures ONLY the subtree, restore deep-merges it back while preserving
+ * every other live key, and the state model reports drift on the subtree only.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import { TEST_TUCK_DIR } from '../utils/testHelpers.js';
+import { initTestTuck, createTestDotfile } from '../utils/testHelpers.js';
+import {
+  loadManifest,
+  getTrackedFileBySource,
+  clearManifestCache,
+} from '../../src/lib/manifest.js';
+import { computeStateModel } from '../../src/lib/stateModel.js';
+import { addFilesFromPaths } from '../../src/commands/add.js';
+import { runSyncCommand } from '../../src/commands/sync.js';
+import { runRestoreCommand } from '../../src/commands/restore.js';
+
+vi.mock('simple-git', () => {
+  const mockGit = {
+    init: vi.fn().mockResolvedValue(undefined),
+    add: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue({ commit: 'abc123' }),
+    status: vi.fn().mockResolvedValue({
+      current: 'main',
+      tracking: null,
+      ahead: 0,
+      behind: 0,
+      staged: [],
+      modified: [],
+      not_added: [],
+      deleted: [],
+      isClean: () => true,
+    }),
+    getRemotes: vi.fn().mockResolvedValue([]),
+    push: vi.fn().mockResolvedValue(undefined),
+    pull: vi.fn().mockResolvedValue(undefined),
+    fetch: vi.fn().mockResolvedValue(undefined),
+    revparse: vi.fn().mockResolvedValue('main'),
+    raw: vi.fn().mockResolvedValue('main'),
+    branch: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: vi.fn(() => mockGit), simpleGit: vi.fn(() => mockGit) };
+});
+
+const CLAUDE_JSON = '~/.claude.json';
+
+/** A realistic mixed config/state file: durable MCP config + machine secrets. */
+const makeLiveFile = (overrides?: {
+  mcpServers?: Record<string, unknown>;
+  oauthToken?: string;
+  numStartups?: number;
+}): string =>
+  JSON.stringify(
+    {
+      numStartups: overrides?.numStartups ?? 5,
+      oauthToken: overrides?.oauthToken ?? 'MACHINE-A-SECRET',
+      mcpServers: overrides?.mcpServers ?? { git: { command: 'git-mcp' } },
+      history: [{ prompt: 'do not track me' }],
+    },
+    null,
+    2
+  );
+
+const repoCopy = async (): Promise<Record<string, unknown>> => {
+  const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, CLAUDE_JSON);
+  const repoPath = join(TEST_TUCK_DIR, tracked!.file.destination);
+  return JSON.parse(vol.readFileSync(repoPath, 'utf-8') as string);
+};
+
+describe('JSON-key-scoped tracking (integration)', () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+    clearManifestCache();
+  });
+  afterEach(() => {
+    vol.reset();
+    clearManifestCache();
+  });
+
+  it('stores ONLY the subtree in the repo and records jsonKey in the manifest', async () => {
+    await initTestTuck();
+    createTestDotfile('.claude.json', makeLiveFile());
+
+    const added = await addFilesFromPaths([CLAUDE_JSON], { key: 'mcpServers', force: true });
+    expect(added).toBe(1);
+
+    const manifest = await loadManifest(TEST_TUCK_DIR);
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, CLAUDE_JSON);
+    expect(tracked?.file.jsonKey).toBe('mcpServers');
+
+    const repo = await repoCopy();
+    // The repo copy is exactly the subtree — no oauthToken, numStartups, history.
+    expect(repo).toEqual({ git: { command: 'git-mcp' } });
+    expect(JSON.stringify(manifest.files)).not.toContain('MACHINE-A-SECRET');
+  });
+
+  it('reports ok when unrelated keys change, drift-local when the subtree changes', async () => {
+    await initTestTuck();
+    const live = createTestDotfile('.claude.json', makeLiveFile());
+    await addFilesFromPaths([CLAUDE_JSON], { key: 'mcpServers', force: true });
+
+    clearManifestCache();
+    expect((await computeStateModel(TEST_TUCK_DIR))[0].state).toBe('ok');
+
+    // Editing a NON-tracked key (a token rotation) is NOT drift.
+    vol.writeFileSync(live, makeLiveFile({ oauthToken: 'ROTATED', numStartups: 99 }));
+    expect((await computeStateModel(TEST_TUCK_DIR))[0].state).toBe('ok');
+
+    // Editing the tracked subtree IS drift.
+    vol.writeFileSync(
+      live,
+      makeLiveFile({ mcpServers: { git: { command: 'git-mcp' }, fs: { command: 'fs-mcp' } } })
+    );
+    expect((await computeStateModel(TEST_TUCK_DIR))[0].state).toBe('drift-local');
+  });
+
+  it('sync captures ONLY the changed subtree back into the repo, never the whole file', async () => {
+    await initTestTuck();
+    const live = createTestDotfile('.claude.json', makeLiveFile());
+    await addFilesFromPaths([CLAUDE_JSON], { key: 'mcpServers', force: true });
+
+    // User adds a new MCP server AND rotates a token in the live file.
+    vol.writeFileSync(
+      live,
+      makeLiveFile({
+        oauthToken: 'ROTATED-SECRET',
+        mcpServers: { git: { command: 'git-mcp' }, fs: { command: 'fs-mcp' } },
+      })
+    );
+
+    await runSyncCommand(undefined, {
+      noCommit: true,
+      noHooks: true,
+      pull: false,
+      push: false,
+      force: true,
+    });
+
+    const repo = await repoCopy();
+    expect(repo).toEqual({ git: { command: 'git-mcp' }, fs: { command: 'fs-mcp' } });
+    // The rotated token must NEVER be captured into the repo copy.
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, CLAUDE_JSON);
+    const repoRaw = vol.readFileSync(
+      join(TEST_TUCK_DIR, tracked!.file.destination),
+      'utf-8'
+    ) as string;
+    expect(repoRaw).not.toContain('ROTATED-SECRET');
+  });
+
+  it('restore deep-merges the subtree back, preserving every other live key', async () => {
+    await initTestTuck();
+    const live = createTestDotfile('.claude.json', makeLiveFile());
+    await addFilesFromPaths([CLAUDE_JSON], { key: 'mcpServers', force: true });
+
+    // Simulate a teammate's pushed update to the tracked subtree (repo copy).
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, CLAUDE_JSON);
+    const repoPath = join(TEST_TUCK_DIR, tracked!.file.destination);
+    vol.writeFileSync(
+      repoPath,
+      JSON.stringify({ git: { command: 'git-mcp' }, shared: { command: 'shared-mcp' } }, null, 2) + '\n'
+    );
+
+    // This machine has its OWN token/state in the live file.
+    vol.writeFileSync(live, makeLiveFile({ oauthToken: 'MACHINE-B-TOKEN', numStartups: 42 }));
+
+    await runRestoreCommand([CLAUDE_JSON], { noHooks: true, backup: false });
+
+    const merged = JSON.parse(vol.readFileSync(live, 'utf-8') as string);
+    // Tracked subtree updated (teammate's server merged in)...
+    expect(merged.mcpServers).toEqual({
+      git: { command: 'git-mcp' },
+      shared: { command: 'shared-mcp' },
+    });
+    // ...while this machine's own keys are untouched.
+    expect(merged.oauthToken).toBe('MACHINE-B-TOKEN');
+    expect(merged.numStartups).toBe(42);
+    expect(merged.history).toEqual([{ prompt: 'do not track me' }]);
+  });
+
+  it('restore creates the key when the live file lacks it entirely', async () => {
+    await initTestTuck();
+    const live = createTestDotfile('.claude.json', makeLiveFile());
+    await addFilesFromPaths([CLAUDE_JSON], { key: 'mcpServers', force: true });
+
+    // Live file on this machine has no mcpServers key at all.
+    vol.writeFileSync(live, JSON.stringify({ oauthToken: 'ONLY-TOKEN' }, null, 2));
+
+    await runRestoreCommand([CLAUDE_JSON], { noHooks: true, backup: false });
+
+    const merged = JSON.parse(vol.readFileSync(live, 'utf-8') as string);
+    expect(merged.mcpServers).toEqual({ git: { command: 'git-mcp' } });
+    expect(merged.oauthToken).toBe('ONLY-TOKEN');
+  });
+
+  it('rejects --key on a non-JSON file at add time', async () => {
+    await initTestTuck();
+    createTestDotfile('.notjson', 'this is not json');
+    await expect(
+      addFilesFromPaths(['~/.notjson'], { key: 'mcpServers', force: true })
+    ).rejects.toThrow(/not valid JSON/i);
+  });
+
+  it('rejects --key when the key path is absent from the file', async () => {
+    await initTestTuck();
+    createTestDotfile('.claude.json', makeLiveFile());
+    await expect(
+      addFilesFromPaths([CLAUDE_JSON], { key: 'doesNotExist', force: true })
+    ).rejects.toThrow(/not found/i);
+  });
+});

--- a/tests/integration/json-merge-sync.test.ts
+++ b/tests/integration/json-merge-sync.test.ts
@@ -18,7 +18,11 @@ vi.unmock('os');
 import { promises as fs, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { captureMergeBases, decideFileMerge } from '../../src/lib/jsonMergeSync.js';
+import {
+  captureMergeBases,
+  decideFileMerge,
+  combineMergeBases,
+} from '../../src/lib/jsonMergeSync.js';
 import { resolveMergePolicy } from '../../src/lib/jsonMerge.js';
 import type { TrackedFileOutput } from '../../src/schemas/manifest.schema.js';
 
@@ -67,6 +71,24 @@ describe('sync-time JSON merge (real temp dirs)', () => {
     };
     const bases = await captureMergeBases(tuckDir, files);
     expect(bases.size).toBe(0);
+  });
+
+  it('NEVER captures a base for a jsonKey (--key) file, even under a merge-policy path', async () => {
+    // The repo copy of a --key file is only the tracked SUBTREE document, while
+    // the live file is the whole config. Whole-file three-way merging it would
+    // splice subtree keys into the live root and transiently write the whole
+    // live file (tokens included) into the repo — data corruption. It must be
+    // skipped so its subtree-aware sync path is the only one that touches it.
+    const subtreeDoc = JSON.stringify({ allow: ['Read'] }, null, 2) + '\n';
+    await fs.writeFile(join(tuckDir, DEST_REL), subtreeDoc, 'utf-8');
+
+    // A source path that WOULD otherwise get a merge policy, but marked jsonKey.
+    const files: Record<string, TrackedFileOutput> = {
+      f1: makeTrackedFile({ source: '~/.claude.json', jsonKey: 'projects.foo' }),
+    };
+    const bases = await captureMergeBases(tuckDir, files);
+    expect(bases.size).toBe(0);
+    expect(bases.has('~/.claude.json')).toBe(false);
   });
 
   it('unions divergent permission allowlists across two machines end to end', async () => {
@@ -127,5 +149,32 @@ describe('sync-time JSON merge (real temp dirs)', () => {
     expect(decision.kind).toBe('conflict');
     if (decision.kind !== 'conflict') throw new Error('expected conflict');
     expect(decision.conflicts.map((c) => c.path)).toContain('model');
+  });
+});
+
+describe('combineMergeBases precedence (persisted wins over fresh)', () => {
+  it('keeps the persisted base on collision, fills gaps from fresh', () => {
+    const fresh = new Map<string, string>([
+      ['~/.claude/settings.json', 'FRESH-WRONG'],
+      ['~/.gitconfig', 'FRESH-ONLY'],
+    ]);
+    const persisted = new Map<string, string>([['~/.claude/settings.json', 'PERSISTED-RIGHT']]);
+
+    const combined = combineMergeBases(fresh, persisted);
+
+    // Persisted ancestor wins — after an abort the repo copy already holds the
+    // previously-pulled remote, so a fresh base captured this run is the wrong
+    // (post-pull) ancestor.
+    expect(combined.get('~/.claude/settings.json')).toBe('PERSISTED-RIGHT');
+    // Files with no pending base still get the fresh base.
+    expect(combined.get('~/.gitconfig')).toBe('FRESH-ONLY');
+    expect(combined.size).toBe(2);
+  });
+
+  it('returns the fresh map contents when nothing is persisted', () => {
+    const fresh = new Map<string, string>([['~/.zshrc', 'BASE']]);
+    const combined = combineMergeBases(fresh, new Map());
+    expect(combined.get('~/.zshrc')).toBe('BASE');
+    expect(combined.size).toBe(1);
   });
 });

--- a/tests/integration/json-merge-sync.test.ts
+++ b/tests/integration/json-merge-sync.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Sandboxed integration test for the sync-time structured JSON merge.
+ *
+ * Exercises the real filesystem pipeline `tuck sync` uses when a merge-policy
+ * file diverges: capture the pre-pull repo copy (the common ancestor), then
+ * three-way merge base × live(ours) × post-pull-repo(theirs) and converge both
+ * copies. Uses fresh OS temp dirs only — never the real HOME, no git, no
+ * network. The global memfs mocks are unmocked so real fs.readFile/writeFile
+ * run, mirroring what `captureMergeBases` does at runtime.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.unmock('fs');
+vi.unmock('fs/promises');
+vi.unmock('fs-extra');
+vi.unmock('os');
+
+import { promises as fs, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { captureMergeBases, decideFileMerge } from '../../src/lib/jsonMergeSync.js';
+import { resolveMergePolicy } from '../../src/lib/jsonMerge.js';
+import type { TrackedFileOutput } from '../../src/schemas/manifest.schema.js';
+
+const DEST_REL = 'files/agent/settings.json';
+
+const makeTrackedFile = (overrides: Partial<TrackedFileOutput> = {}): TrackedFileOutput => ({
+  source: '~/.claude/settings.json',
+  destination: DEST_REL,
+  category: 'misc',
+  strategy: 'copy',
+  encrypted: false,
+  template: false,
+  added: new Date().toISOString(),
+  modified: new Date().toISOString(),
+  checksum: 'deadbeef',
+  bundle: 'default',
+  ...overrides,
+});
+
+describe('sync-time JSON merge (real temp dirs)', () => {
+  let tuckDir: string;
+
+  beforeEach(async () => {
+    tuckDir = mkdtempSync(join(tmpdir(), 'tuck-jsonmerge-'));
+    await fs.mkdir(join(tuckDir, 'files', 'agent'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tuckDir, { recursive: true, force: true });
+  });
+
+  it('captures the repo copy of auto-detected agent config files as the merge base', async () => {
+    const base = JSON.stringify({ permissions: { allow: ['Read'] } }, null, 2) + '\n';
+    await fs.writeFile(join(tuckDir, DEST_REL), base, 'utf-8');
+
+    const files: Record<string, TrackedFileOutput> = { f1: makeTrackedFile() };
+    const bases = await captureMergeBases(tuckDir, files);
+
+    expect(bases.get('~/.claude/settings.json')).toBe(base);
+  });
+
+  it('does NOT capture bases for files without a merge policy', async () => {
+    await fs.writeFile(join(tuckDir, DEST_REL), '{}', 'utf-8');
+    const files: Record<string, TrackedFileOutput> = {
+      f1: makeTrackedFile({ source: '~/.zshrc' }),
+    };
+    const bases = await captureMergeBases(tuckDir, files);
+    expect(bases.size).toBe(0);
+  });
+
+  it('unions divergent permission allowlists across two machines end to end', async () => {
+    // 1. Last-synced state = repo copy before pull (the base).
+    const base = JSON.stringify({ permissions: { allow: ['Read'] } }, null, 2) + '\n';
+    const destPath = join(tuckDir, DEST_REL);
+    await fs.writeFile(destPath, base, 'utf-8');
+
+    const file = makeTrackedFile();
+    const bases = await captureMergeBases(tuckDir, { f1: file });
+    const baseText = bases.get(file.source);
+    expect(baseText).toBeDefined();
+
+    // 2. Remote (machine A) added WebFetch; the pull advanced the repo copy.
+    const remoteText = JSON.stringify({ permissions: { allow: ['Read', 'WebFetch'] } }, null, 2) + '\n';
+    await fs.writeFile(destPath, remoteText, 'utf-8');
+
+    // 3. Local agent (machine B) added Bash to the live file.
+    const livePath = join(tuckDir, 'live-settings.json');
+    const liveText = JSON.stringify({ permissions: { allow: ['Read', 'Bash(git:*)'] } }, null, 2) + '\n';
+    await fs.writeFile(livePath, liveText, 'utf-8');
+
+    // 4. Reconcile.
+    const policy = resolveMergePolicy(file.source, file.merge);
+    expect(policy).not.toBeNull();
+    const decision = decideFileMerge(baseText!, liveText, remoteText, policy!);
+    expect(decision.kind).toBe('clean');
+
+    if (decision.kind !== 'clean') throw new Error('expected clean merge');
+
+    // 5. Converge both copies (what sync writes).
+    await fs.writeFile(livePath, decision.text, 'utf-8');
+    await fs.writeFile(destPath, decision.text, 'utf-8');
+
+    const merged = JSON.parse(await fs.readFile(livePath, 'utf-8')) as {
+      permissions: { allow: string[] };
+    };
+    expect(merged.permissions.allow.sort()).toEqual(['Bash(git:*)', 'Read', 'WebFetch']);
+    // Both machines converged to the identical document.
+    expect(await fs.readFile(destPath, 'utf-8')).toBe(decision.text);
+  });
+
+  it('skips reconciliation when the pull brought no change to the file', async () => {
+    const base = JSON.stringify({ a: 1 }, null, 2) + '\n';
+    const live = JSON.stringify({ a: 2 }, null, 2) + '\n';
+    const policy = resolveMergePolicy('~/.claude/settings.json')!;
+    // remote === base → nothing to reconcile; normal copy captures local edit.
+    const decision = decideFileMerge(base, live, base, policy);
+    expect(decision.kind).toBe('skip');
+  });
+
+  it('surfaces a conflict when both machines set the same scalar differently', async () => {
+    const base = JSON.stringify({ model: 'sonnet' }, null, 2) + '\n';
+    const remote = JSON.stringify({ model: 'opus' }, null, 2) + '\n';
+    const live = JSON.stringify({ model: 'haiku' }, null, 2) + '\n';
+    const policy = resolveMergePolicy('~/.claude/settings.json')!;
+    const decision = decideFileMerge(base, live, remote, policy);
+    expect(decision.kind).toBe('conflict');
+    if (decision.kind !== 'conflict') throw new Error('expected conflict');
+    expect(decision.conflicts.map((c) => c.path)).toContain('model');
+  });
+});

--- a/tests/lib/agentMode.test.ts
+++ b/tests/lib/agentMode.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Agent / non-interactive mode unit tests.
+ *
+ * These signals are the contract that lets an agent safely drive tuck:
+ *  - `isNonInteractive()` gates every prompt (explicit flag, JSON mode, or no TTY);
+ *  - `configureColor()` strips ANSI for machine consumers while honoring FORCE_COLOR.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import chalk from 'chalk';
+import {
+  setNonInteractive,
+  isNonInteractive,
+  isNonInteractiveFlagSet,
+  configureColor,
+} from '../../src/lib/agentMode.js';
+import { setJsonMode } from '../../src/lib/jsonOutput.js';
+
+const originalStdinTTY = process.stdin.isTTY;
+const originalStdoutTTY = process.stdout.isTTY;
+const originalChalkLevel = chalk.level;
+const originalNoColor = process.env.NO_COLOR;
+const originalForceColor = process.env.FORCE_COLOR;
+
+const setTTY = (stream: NodeJS.WriteStream | NodeJS.ReadStream, value: boolean): void => {
+  Object.defineProperty(stream, 'isTTY', { value, writable: true, configurable: true });
+};
+
+beforeEach(() => {
+  setNonInteractive(false);
+  setJsonMode(false);
+  delete process.env.NO_COLOR;
+  delete process.env.FORCE_COLOR;
+  chalk.level = 3;
+});
+
+afterEach(() => {
+  setNonInteractive(false);
+  setJsonMode(false);
+  setTTY(process.stdin, originalStdinTTY as boolean);
+  setTTY(process.stdout, originalStdoutTTY as boolean);
+  chalk.level = originalChalkLevel;
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+  if (originalForceColor === undefined) delete process.env.FORCE_COLOR;
+  else process.env.FORCE_COLOR = originalForceColor;
+  vi.restoreAllMocks();
+});
+
+describe('isNonInteractive', () => {
+  it('is false when stdin is a TTY and no flag / json mode is set', () => {
+    setTTY(process.stdin, true);
+    expect(isNonInteractive()).toBe(false);
+  });
+
+  it('is true when the explicit --non-interactive flag is set, even on a TTY', () => {
+    setTTY(process.stdin, true);
+    setNonInteractive(true);
+    expect(isNonInteractive()).toBe(true);
+    expect(isNonInteractiveFlagSet()).toBe(true);
+  });
+
+  it('is true in JSON mode even on a TTY (a prompt would corrupt the envelope)', () => {
+    setTTY(process.stdin, true);
+    setJsonMode(true);
+    expect(isNonInteractive()).toBe(true);
+    // JSON mode is not the explicit flag.
+    expect(isNonInteractiveFlagSet()).toBe(false);
+  });
+
+  it('is true when stdin is not a TTY (piped / agent / CI)', () => {
+    setTTY(process.stdin, false);
+    expect(isNonInteractive()).toBe(true);
+  });
+});
+
+describe('configureColor', () => {
+  it('suppresses ANSI when stdout is not a TTY', () => {
+    setTTY(process.stdout, false);
+    configureColor();
+    expect(chalk.level).toBe(0);
+  });
+
+  it('suppresses ANSI in JSON mode even on a TTY', () => {
+    setTTY(process.stdout, true);
+    setJsonMode(true);
+    configureColor();
+    expect(chalk.level).toBe(0);
+  });
+
+  it('suppresses ANSI when --non-interactive is set', () => {
+    setTTY(process.stdout, true);
+    setNonInteractive(true);
+    configureColor();
+    expect(chalk.level).toBe(0);
+  });
+
+  it('suppresses ANSI when NO_COLOR is set', () => {
+    setTTY(process.stdout, true);
+    process.env.NO_COLOR = '1';
+    configureColor();
+    expect(chalk.level).toBe(0);
+  });
+
+  it('leaves color enabled on an interactive TTY with no suppression signal', () => {
+    setTTY(process.stdout, true);
+    chalk.level = 2;
+    configureColor();
+    expect(chalk.level).toBe(2);
+  });
+
+  it('honors an explicit FORCE_COLOR even when stdout is not a TTY', () => {
+    setTTY(process.stdout, false);
+    process.env.FORCE_COLOR = '1';
+    chalk.level = 2;
+    configureColor();
+    expect(chalk.level).toBe(2);
+  });
+});

--- a/tests/lib/applyDiff.test.ts
+++ b/tests/lib/applyDiff.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarizeApplyDiff,
+  formatApplyDiffLine,
+  type ApplyDiffItem,
+} from '../../src/lib/applyDiff.js';
+
+const item = (
+  destination: string,
+  status: 'new' | 'modify',
+  category = 'shell'
+): ApplyDiffItem => ({ destination, category, status });
+
+describe('summarizeApplyDiff', () => {
+  it('counts new and modify entries separately', () => {
+    const summary = summarizeApplyDiff([
+      item('~/.zshrc', 'new'),
+      item('~/.gitconfig', 'modify'),
+      item('~/.vimrc', 'new'),
+    ]);
+
+    expect(summary.newCount).toBe(2);
+    expect(summary.modifyCount).toBe(1);
+    expect(summary.total).toBe(3);
+    expect(summary.items).toHaveLength(3);
+  });
+
+  it('returns zero counts for an empty diff', () => {
+    const summary = summarizeApplyDiff([]);
+    expect(summary).toEqual({ items: [], newCount: 0, modifyCount: 0, total: 0 });
+  });
+});
+
+describe('formatApplyDiffLine', () => {
+  it('renders both new and update counts', () => {
+    const summary = summarizeApplyDiff([item('~/.zshrc', 'new'), item('~/.gitconfig', 'modify')]);
+    expect(formatApplyDiffLine(summary)).toBe('1 new, 1 to update');
+  });
+
+  it('renders only the new count when nothing is modified', () => {
+    const summary = summarizeApplyDiff([item('~/.zshrc', 'new'), item('~/.vimrc', 'new')]);
+    expect(formatApplyDiffLine(summary)).toBe('2 new');
+  });
+
+  it('renders only the update count when nothing is new', () => {
+    const summary = summarizeApplyDiff([item('~/.gitconfig', 'modify')]);
+    expect(formatApplyDiffLine(summary)).toBe('1 to update');
+  });
+
+  it('reports no changes for an empty diff', () => {
+    expect(formatApplyDiffLine(summarizeApplyDiff([]))).toBe('No changes');
+  });
+});

--- a/tests/lib/driftCache.test.ts
+++ b/tests/lib/driftCache.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getDriftKey,
+  computePlaintextHmac,
+  recordDriftEntry,
+  getDriftEntry,
+  compareLiveToCache,
+  readDriftCache,
+  resetDriftKeyCache,
+} from '../../src/lib/crypto/driftCache.js';
+
+// memfs + mocked homedir come from tests/setup.ts. The drift key/cache live
+// under the per-machine state dir, which resolves inside the mocked home.
+
+describe('driftCache', () => {
+  beforeEach(() => {
+    // The HMAC key is memoized in-process; memfs is reset per test, so drop the
+    // stale in-memory key too or a later test would reuse a key whose file is gone.
+    resetDriftKeyCache();
+  });
+
+  describe('getDriftKey', () => {
+    it('returns null when absent and create=false (read-only never writes)', async () => {
+      expect(await getDriftKey(false)).toBeNull();
+    });
+
+    it('generates and persists a 32-byte key when create=true', async () => {
+      const key = await getDriftKey(true);
+      expect(key).not.toBeNull();
+      expect(key!.length).toBe(32);
+      // Persisted: a fresh in-process load (create=false) now finds it.
+      resetDriftKeyCache();
+      const again = await getDriftKey(false);
+      expect(again).not.toBeNull();
+      expect(again!.equals(key!)).toBe(true);
+    });
+  });
+
+  describe('computePlaintextHmac', () => {
+    it('is deterministic for the same key + input', () => {
+      const key = Buffer.alloc(32, 7);
+      expect(computePlaintextHmac('hello', key)).toBe(computePlaintextHmac('hello', key));
+    });
+
+    it('differs for different keys (keyed, not a bare checksum)', () => {
+      const a = computePlaintextHmac('hello', Buffer.alloc(32, 1));
+      const b = computePlaintextHmac('hello', Buffer.alloc(32, 2));
+      expect(a).not.toBe(b);
+    });
+
+    it('treats a utf8 string and its Buffer identically', () => {
+      const key = Buffer.alloc(32, 3);
+      expect(computePlaintextHmac('body', key)).toBe(
+        computePlaintextHmac(Buffer.from('body', 'utf8'), key)
+      );
+    });
+  });
+
+  describe('record + compare round-trip', () => {
+    it('reports match for unchanged live bytes, mismatch after an edit', async () => {
+      await recordDriftEntry('file1', 'plaintext-body', 'repo-sum-1');
+
+      expect(await compareLiveToCache('file1', 'plaintext-body', 'repo-sum-1')).toBe('match');
+      expect(await compareLiveToCache('file1', 'EDITED-body', 'repo-sum-1')).toBe('mismatch');
+    });
+
+    it('reports unknown when the repo copy moved on (stale fingerprint)', async () => {
+      await recordDriftEntry('file1', 'body', 'repo-sum-1');
+      // Same live bytes, but the repo checksum changed (e.g. git pull).
+      expect(await compareLiveToCache('file1', 'body', 'repo-sum-2')).toBe('unknown');
+    });
+
+    it('reports unknown for an unrecorded file id', async () => {
+      await recordDriftEntry('file1', 'body', 'repo-sum-1');
+      expect(await compareLiveToCache('other', 'body', 'repo-sum-1')).toBe('unknown');
+    });
+
+    it('reports unknown when no key exists yet (nothing recorded)', async () => {
+      expect(await compareLiveToCache('file1', 'body', 'repo-sum-1')).toBe('unknown');
+    });
+
+    it('persists the entry with a pinned repo checksum', async () => {
+      await recordDriftEntry('file1', 'body', 'repo-sum-1');
+      const entry = await getDriftEntry('file1');
+      expect(entry).not.toBeNull();
+      expect(entry!.repoChecksum).toBe('repo-sum-1');
+      expect(typeof entry!.plaintextHmac).toBe('string');
+    });
+
+    it('recording twice refreshes the fingerprint in place', async () => {
+      await recordDriftEntry('file1', 'v1', 'repo-sum-1');
+      const first = (await getDriftEntry('file1'))!.plaintextHmac;
+      await recordDriftEntry('file1', 'v2', 'repo-sum-2');
+      const second = await getDriftEntry('file1');
+      expect(second!.plaintextHmac).not.toBe(first);
+      expect(second!.repoChecksum).toBe('repo-sum-2');
+    });
+  });
+
+  describe('concurrency (single-flight key, serialized writes)', () => {
+    it('concurrent first-warm getDriftKey(true) callers all receive the SAME key', async () => {
+      const [a, b, ...rest] = await Promise.all(
+        Array.from({ length: 6 }, () => getDriftKey(true))
+      );
+      expect(a).not.toBeNull();
+      for (const k of [b, ...rest]) {
+        expect(k?.equals(a as Buffer)).toBe(true);
+      }
+    });
+
+    it('concurrent recordDriftEntry calls never lose entries', async () => {
+      await Promise.all(
+        Array.from({ length: 8 }, (_, i) =>
+          recordDriftEntry(`file-${i}`, `plaintext-${i}`, `repo-${i}`)
+        )
+      );
+      const cache = await readDriftCache();
+      for (let i = 0; i < 8; i++) {
+        expect(cache.entries[`file-${i}`]).toBeDefined();
+      }
+    });
+  });
+
+  describe('readDriftCache', () => {
+    it('returns an empty cache when none exists', async () => {
+      const cache = await readDriftCache();
+      expect(cache.version).toBe(1);
+      expect(cache.entries).toEqual({});
+    });
+  });
+});

--- a/tests/lib/fileTracking.test.ts
+++ b/tests/lib/fileTracking.test.ts
@@ -6,6 +6,7 @@ import { clearManifestCache, getTrackedFileBySource, loadManifest } from '../../
 import { initTestTuck, createTestDotfile, TEST_TUCK_DIR } from '../utils/testHelpers.js';
 import { isEncryptedFile, decryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
 import { setJsonMode } from '../../src/lib/jsonOutput.js';
+import { clearSessionKeyCache } from '../../src/lib/crypto/sessionKeyCache.js';
 
 const retrieveMock = vi.fn();
 vi.mock('../../src/lib/crypto/keystore/index.js', () => ({
@@ -18,11 +19,16 @@ describe('fileTracking symlink strategy', () => {
   beforeEach(() => {
     vol.reset();
     clearManifestCache();
+    // The keystore passphrase is cached per session (one prompt per session). In
+    // one process each test must start with a cold cache, or a passphrase unlocked
+    // by an earlier test would satisfy a later "no password configured" case.
+    clearSessionKeyCache();
   });
 
   afterEach(() => {
     vol.reset();
     clearManifestCache();
+    clearSessionKeyCache();
     vi.restoreAllMocks();
   });
 

--- a/tests/lib/fileTracking.test.ts
+++ b/tests/lib/fileTracking.test.ts
@@ -200,6 +200,29 @@ describe('fileTracking symlink strategy', () => {
     logSpy.mockRestore();
   });
 
+  it('rejects --key combined with --template up front, leaving no orphan repo file', async () => {
+    await initTestTuck();
+    createTestDotfile('.claude.json', '{"mcpServers":{"git":{"command":"g"}}}');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // The guard fires BEFORE the per-file loop (which would otherwise write the
+    // subtree to the repo before addFileToManifest's zod validation rejects the
+    // combo, orphaning the repo file). The whole call must reject.
+    await expect(
+      trackFilesWithProgress(
+        [{ path: '~/.claude.json', category: 'misc', jsonKey: 'mcpServers' }],
+        TEST_TUCK_DIR,
+        { strategy: 'copy', template: true, showCategory: false, delayBetween: 0 }
+      )
+    ).rejects.toThrow(/--template cannot be combined with --key/);
+
+    // Nothing was tracked and no repo copy was written.
+    const tracked = await getTrackedFileBySource(TEST_TUCK_DIR, '~/.claude.json');
+    expect(tracked).toBeNull();
+
+    logSpy.mockRestore();
+  });
+
   it('supports custom destination names while preserving source subdirectories', async () => {
     await initTestTuck();
     createTestDotfile('.aws/config', 'region = us-east-1');

--- a/tests/lib/git-error-describe.test.ts
+++ b/tests/lib/git-error-describe.test.ts
@@ -1,0 +1,93 @@
+/**
+ * describeGitError classification tests (issue #52).
+ *
+ * Git stderr is terse; tuck names the likely cause and the fix. These tests pin
+ * the classification so the machine-readable suggestions stay stable for agents.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeGitError } from '../../src/lib/git.js';
+import { GitError } from '../../src/errors.js';
+
+describe('describeGitError', () => {
+  it('classifies a non-fast-forward push rejection with pull/force suggestions', () => {
+    const raw =
+      '! [rejected]        main -> main (non-fast-forward)\nerror: failed to push some refs to ...';
+    const err = describeGitError('push', raw);
+    expect(err).toBeInstanceOf(GitError);
+    expect(err.code).toBe('GIT_ERROR');
+    expect(err.message).toContain('remote has commits you do not have locally');
+    expect(err.suggestions?.join(' ')).toContain('tuck pull');
+    expect(err.suggestions?.join(' ')).toContain('tuck push --force');
+    // Raw output is preserved for debugging.
+    expect(err.gitOutput).toBe(raw);
+  });
+
+  it('classifies a missing upstream on push', () => {
+    const err = describeGitError('push', 'fatal: The current branch main has no upstream branch.');
+    expect(err.message).toContain('no upstream configured');
+    expect(err.suggestions?.join(' ')).toContain('upstream');
+  });
+
+  it('classifies authentication failure on push', () => {
+    const err = describeGitError('push', 'remote: Invalid username or password.\nfatal: Authentication failed');
+    expect(err.message).toContain('authentication with the remote was rejected');
+    expect(err.suggestions?.join(' ')).toContain('gh auth login');
+  });
+
+  it('classifies an unreachable host on fetch', () => {
+    const err = describeGitError('fetch', "fatal: unable to access 'https://...': Could not resolve host: github.com");
+    expect(err.message).toContain('could not reach the remote');
+    expect(err.suggestions?.join(' ')).toContain('network');
+  });
+
+  it('classifies merge conflicts on pull', () => {
+    const err = describeGitError('pull', 'CONFLICT (content): Merge conflict in .zshrc');
+    expect(err.message).toContain('merge conflicts');
+    expect(err.suggestions?.join(' ')).toContain('git status');
+  });
+
+  it('classifies divergent branches on pull', () => {
+    const err = describeGitError('pull', 'fatal: Need to specify how to reconcile divergent branches.');
+    expect(err.message).toContain('diverged');
+  });
+
+  it('classifies uncommitted local changes on pull', () => {
+    const err = describeGitError(
+      'pull',
+      'error: Your local changes to the following files would be overwritten by merge'
+    );
+    expect(err.message).toContain('uncommitted local changes');
+    expect(err.suggestions?.join(' ')).toContain('tuck sync');
+  });
+
+  it('falls back to a generic message with the raw output preserved', () => {
+    const raw = 'fatal: some entirely novel git failure';
+    const err = describeGitError('push', raw);
+    expect(err.message).toContain('Failed to push');
+    expect(err.gitOutput).toBe(raw);
+    // Generic path still ships actionable suggestions.
+    expect(err.suggestions && err.suggestions.length).toBeGreaterThan(0);
+  });
+
+  it('surfaces the raw first line as a suggestion on the generic fallback', () => {
+    const raw = "fatal: '/nowhere/repo' does not appear to be a git repository\nfatal: Could not read from remote repository.";
+    for (const op of ['push', 'pull', 'fetch'] as const) {
+      const err = describeGitError(op, raw);
+      expect(err.suggestions?.join(' ')).toContain("does not appear to be a git repository");
+    }
+  });
+
+  it('serializes git_output in the JSON envelope', () => {
+    const raw = 'fatal: some entirely novel git failure';
+    const err = describeGitError('push', raw);
+    expect(err.toJSON().git_output).toBe(raw);
+  });
+
+  it('classified auth failures do not leak into substring re-classification traps', () => {
+    // The message deliberately contains the word "rejected" — command layers
+    // must not remap it to "push rejected" (they rethrow GitError as-is now).
+    const err = describeGitError('push', 'remote: Invalid credentials');
+    expect(err.message).toContain('authentication');
+    expect(err.message).not.toContain('commits you do not have');
+  });
+});

--- a/tests/lib/git-error-describe.test.ts
+++ b/tests/lib/git-error-describe.test.ts
@@ -5,7 +5,7 @@
  * the classification so the machine-readable suggestions stay stable for agents.
  */
 import { describe, it, expect } from 'vitest';
-import { describeGitError } from '../../src/lib/git.js';
+import { describeGitError, scrubCredentials } from '../../src/lib/git.js';
 import { GitError } from '../../src/errors.js';
 
 describe('describeGitError', () => {
@@ -89,5 +89,70 @@ describe('describeGitError', () => {
     const err = describeGitError('push', 'remote: Invalid credentials');
     expect(err.message).toContain('authentication');
     expect(err.message).not.toContain('commits you do not have');
+  });
+});
+
+describe('scrubCredentials', () => {
+  it('redacts userinfo (user:token@) from an https URL', () => {
+    const out = scrubCredentials('https://alice:ghp_secretTOKEN123@github.com/alice/dotfiles.git');
+    expect(out).toBe('https://***@github.com/alice/dotfiles.git');
+    expect(out).not.toContain('ghp_secretTOKEN123');
+    expect(out).not.toContain('alice:');
+  });
+
+  it('redacts a bare token embedded as userinfo', () => {
+    const out = scrubCredentials('fatal: unable to access https://ghp_abc123DEF@github.com/x/y.git');
+    expect(out).toContain('https://***@github.com/x/y.git');
+    expect(out).not.toContain('ghp_abc123DEF');
+  });
+
+  it('redacts a standalone ghp_ token even without a URL', () => {
+    const out = scrubCredentials('token was ghp_ABCdef0123456789 rejected');
+    expect(out).toBe('token was ghp_*** rejected');
+  });
+
+  it('redacts github_pat_ fine-grained tokens', () => {
+    const out = scrubCredentials('using github_pat_11ABCDEFG_someMoreChars99 here');
+    expect(out).not.toContain('github_pat_11ABCDEFG_someMoreChars99');
+    expect(out).toContain('github_pat_***');
+  });
+
+  it('redacts glpat- GitLab tokens', () => {
+    const out = scrubCredentials('remote glpat-XYZ-123-abc denied');
+    expect(out).not.toContain('glpat-XYZ-123-abc');
+    expect(out).toContain('glpat-***');
+  });
+
+  it('leaves credential-free text unchanged', () => {
+    const raw = 'https://github.com/user/repo.git\n! [rejected] main -> main (non-fast-forward)';
+    expect(scrubCredentials(raw)).toBe(raw);
+  });
+});
+
+describe('describeGitError credential scrubbing', () => {
+  it('scrubs userinfo from gitOutput and its JSON projection', () => {
+    const raw =
+      "fatal: unable to access 'https://bob:ghp_LEAKED12345@github.com/bob/dotfiles.git/': The requested URL returned error: 403";
+    const err = describeGitError('push', raw);
+    expect(err.gitOutput).not.toContain('ghp_LEAKED12345');
+    expect(err.gitOutput).not.toContain('bob:ghp_');
+    expect(err.gitOutput).toContain('https://***@github.com');
+    // ...and the serialized envelope an agent parses.
+    expect(err.toJSON().git_output).not.toContain('ghp_LEAKED12345');
+  });
+
+  it('scrubs the token out of the raw-first-line suggestion on the generic fallback', () => {
+    // A novel (unclassified) failure that carries a token in the URL falls
+    // through to the generic branch, which copies the first raw line into a
+    // suggestion (and thus the hint). That copy must be scrubbed too.
+    const raw =
+      'fatal: weird breakage talking to https://ghp_TOKENinSuggestion@github.com/x/y.git during the operation';
+    const err = describeGitError('fetch', raw);
+    const suggestions = (err.suggestions ?? []).join(' ');
+    // Confirm we actually exercised the raw-first-line path.
+    expect(suggestions).toContain('git said:');
+    expect(suggestions).not.toContain('ghp_TOKENinSuggestion');
+    expect(suggestions).toContain('https://***@github.com');
+    expect(err.toJSON().hint ?? '').not.toContain('ghp_TOKENinSuggestion');
   });
 });

--- a/tests/lib/git-errors.test.ts
+++ b/tests/lib/git-errors.test.ts
@@ -27,6 +27,9 @@ const createErrorMockGit = (errorMessage: string) => ({
   revparse: vi.fn().mockRejectedValue(new Error(errorMessage)),
   branch: vi.fn().mockRejectedValue(new Error(errorMessage)),
   raw: vi.fn().mockRejectedValue(new Error(errorMessage)),
+  // Real simple-git exposes .env() (chainable). createGit configures a
+  // non-interactive env under non-TTY/JSON mode, so the double must provide it.
+  env: vi.fn().mockReturnThis(),
 });
 
 // Store mock git instance

--- a/tests/lib/git-errors.test.ts
+++ b/tests/lib/git-errors.test.ts
@@ -226,17 +226,29 @@ describe('git-errors', () => {
   // ============================================================================
 
   describe('push errors', () => {
-    it('should throw GitError when push fails', async () => {
+    it('should throw a contextual GitError for auth failures (issue #52)', async () => {
       mockGitInstance = createErrorMockGit('authentication failed');
 
-      await expect(push(TEST_TUCK_DIR)).rejects.toThrow('Failed to push');
+      // describeGitError classifies the raw git output into an actionable message.
+      await expect(push(TEST_TUCK_DIR)).rejects.toThrow('authentication with the remote was rejected');
     }, 30000); // Longer timeout for Windows CI
 
-    it('should throw GitError for non-fast-forward push', async () => {
+    it('should throw a contextual GitError for non-fast-forward push (issue #52)', async () => {
       mockGitInstance = createErrorMockGit('non-fast-forward');
 
-      await expect(push(TEST_TUCK_DIR)).rejects.toThrow('Failed to push');
+      await expect(push(TEST_TUCK_DIR)).rejects.toThrow('remote has commits you do not have locally');
     }, 30000); // Longer timeout for Windows CI
+
+    it('preserves the raw git output on the GitError for debugging', async () => {
+      mockGitInstance = createErrorMockGit('non-fast-forward');
+      try {
+        await push(TEST_TUCK_DIR);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GitError);
+        expect((error as GitError).gitOutput).toContain('non-fast-forward');
+      }
+    }, 30000);
   });
 
   // ============================================================================
@@ -244,10 +256,10 @@ describe('git-errors', () => {
   // ============================================================================
 
   describe('pull errors', () => {
-    it('should throw GitError when pull fails', async () => {
+    it('should throw a contextual GitError for merge conflicts (issue #52)', async () => {
       mockGitInstance = createErrorMockGit('merge conflict');
 
-      await expect(pull(TEST_TUCK_DIR)).rejects.toThrow('Failed to pull');
+      await expect(pull(TEST_TUCK_DIR)).rejects.toThrow('pull produced merge conflicts');
     });
 
     it('should throw GitError for diverged branches', async () => {
@@ -268,10 +280,10 @@ describe('git-errors', () => {
       await expect(fetch(TEST_TUCK_DIR)).rejects.toThrow('Failed to fetch');
     });
 
-    it('should throw GitError for network errors', async () => {
+    it('should throw a contextual GitError for network errors (issue #52)', async () => {
       mockGitInstance = createErrorMockGit('unable to access');
 
-      await expect(fetch(TEST_TUCK_DIR, 'origin')).rejects.toThrow('Failed to fetch');
+      await expect(fetch(TEST_TUCK_DIR, 'origin')).rejects.toThrow('could not reach the remote');
     });
   });
 

--- a/tests/lib/hooks.test.ts
+++ b/tests/lib/hooks.test.ts
@@ -43,6 +43,7 @@ import {
 } from '../../src/lib/hooks.js';
 import { loadConfig } from '../../src/lib/config.js';
 import { prompts } from '../../src/ui/prompts.js';
+import { setNonInteractive } from '../../src/lib/agentMode.js';
 
 describe('hooks', () => {
   beforeEach(() => {
@@ -128,6 +129,38 @@ describe('hooks', () => {
         // Must take the skip path, never attempt a prompt on a non-TTY stdin.
         expect(prompts.confirm).not.toHaveBeenCalled();
       } finally {
+        process.stdout.isTTY = origStdout;
+        process.stdin.isTTY = origStdin;
+      }
+    });
+
+    it('skips an untrusted hook under --non-interactive even on a full TTY', async () => {
+      // Regression (finding 7): the gate read isJsonMode()/TTY only and ignored
+      // the explicit --non-interactive flag. On a PTY (both std streams TTY),
+      // `tuck sync --non-interactive` with a configured hook then hit the prompt
+      // and died OPERATION_CANCELLED instead of skipping with a warning.
+      vi.mocked(loadConfig).mockResolvedValue({
+        repository: { path: TEST_TUCK_DIR },
+        files: { backupDir: 'backups', symlink: false },
+        hooks: { preSync: 'echo "test"' },
+        templates: {},
+        encryption: {},
+        ui: { color: true, verbose: false },
+      } as never);
+
+      const origStdout = process.stdout.isTTY;
+      const origStdin = process.stdin.isTTY;
+      process.stdout.isTTY = true;
+      process.stdin.isTTY = true;
+      setNonInteractive(true);
+      try {
+        const result = await runHook('preSync', TEST_TUCK_DIR, { silent: true });
+        expect(result.success).toBe(true);
+        expect(result.skipped).toBe(true);
+        // The flag alone must force the skip path — never a prompt.
+        expect(prompts.confirm).not.toHaveBeenCalled();
+      } finally {
+        setNonInteractive(false);
         process.stdout.isTTY = origStdout;
         process.stdin.isTTY = origStdin;
       }

--- a/tests/lib/jsonKey.test.ts
+++ b/tests/lib/jsonKey.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseJsonKeyPath,
+  canonicalJson,
+  deepMergeJson,
+  extractSubtree,
+  hasSubtree,
+  mergeSubtreeIntoLive,
+  isPlainObject,
+} from '../../src/lib/jsonKey.js';
+import { JsonKeyError } from '../../src/errors.js';
+
+describe('parseJsonKeyPath', () => {
+  it('splits a dotted path into segments', () => {
+    expect(parseJsonKeyPath('a.b.c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns a single segment for a top-level key', () => {
+    expect(parseJsonKeyPath('mcpServers')).toEqual(['mcpServers']);
+  });
+
+  it.each(['', '   ', '.a', 'a.', 'a..b'])('rejects malformed path %j', (bad) => {
+    expect(() => parseJsonKeyPath(bad)).toThrow(JsonKeyError);
+  });
+});
+
+describe('isPlainObject', () => {
+  it('is true only for non-null non-array objects', () => {
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({ a: 1 })).toBe(true);
+    expect(isPlainObject(null)).toBe(false);
+    expect(isPlainObject([])).toBe(false);
+    expect(isPlainObject('x')).toBe(false);
+    expect(isPlainObject(3)).toBe(false);
+  });
+});
+
+describe('canonicalJson', () => {
+  it('sorts object keys deterministically regardless of input order', () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe(canonicalJson({ a: 2, b: 1 }));
+  });
+
+  it('sorts nested object keys and preserves array order', () => {
+    const out = canonicalJson({ z: { y: 1, x: 2 }, list: [3, 1, 2] });
+    expect(out).toBe('{\n  "list": [\n    3,\n    1,\n    2\n  ],\n  "z": {\n    "x": 2,\n    "y": 1\n  }\n}\n');
+  });
+
+  it('ends with a trailing newline', () => {
+    expect(canonicalJson({ a: 1 }).endsWith('}\n')).toBe(true);
+  });
+});
+
+describe('deepMergeJson', () => {
+  it('recursively merges plain objects, preserving base keys absent from patch', () => {
+    const base = { a: 1, nested: { keep: true, override: 'old' } };
+    const patch = { b: 2, nested: { override: 'new' } };
+    expect(deepMergeJson(base, patch)).toEqual({
+      a: 1,
+      b: 2,
+      nested: { keep: true, override: 'new' },
+    });
+  });
+
+  it('replaces arrays wholesale rather than element-merging', () => {
+    expect(deepMergeJson({ list: [1, 2, 3] }, { list: [9] })).toEqual({ list: [9] });
+  });
+
+  it('replaces a scalar base with a patch object', () => {
+    expect(deepMergeJson(5, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it('does not mutate its inputs', () => {
+    const base = { nested: { a: 1 } };
+    const patch = { nested: { b: 2 } };
+    deepMergeJson(base, patch);
+    expect(base).toEqual({ nested: { a: 1 } });
+    expect(patch).toEqual({ nested: { b: 2 } });
+  });
+});
+
+describe('extractSubtree', () => {
+  const file = JSON.stringify({
+    mcpServers: { git: { command: 'git-mcp' } },
+    oauthToken: 'secret-abc',
+    numStartups: 42,
+  });
+
+  it('extracts only the named subtree as canonical JSON', () => {
+    expect(extractSubtree(file, 'mcpServers')).toBe(
+      canonicalJson({ git: { command: 'git-mcp' } })
+    );
+  });
+
+  it('extracts a nested key path', () => {
+    expect(extractSubtree(file, 'mcpServers.git')).toBe(canonicalJson({ command: 'git-mcp' }));
+  });
+
+  it('extracts scalar leaf values', () => {
+    expect(extractSubtree(file, 'numStartups')).toBe(canonicalJson(42));
+  });
+
+  it('is stable across key ordering of the source file', () => {
+    const a = JSON.stringify({ mcpServers: { a: 1, b: 2 }, x: 1 });
+    const b = JSON.stringify({ x: 1, mcpServers: { b: 2, a: 1 } });
+    expect(extractSubtree(a, 'mcpServers')).toBe(extractSubtree(b, 'mcpServers'));
+  });
+
+  it('throws when the key path is missing', () => {
+    expect(() => extractSubtree(file, 'doesNotExist')).toThrow(JsonKeyError);
+  });
+
+  it('throws when an intermediate node is not an object', () => {
+    expect(() => extractSubtree(file, 'oauthToken.deeper')).toThrow(JsonKeyError);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => extractSubtree('{ not json', 'a')).toThrow(JsonKeyError);
+  });
+
+  it('throws when the top level is not an object', () => {
+    expect(() => extractSubtree('[1,2,3]', 'a')).toThrow(JsonKeyError);
+  });
+});
+
+describe('hasSubtree', () => {
+  const file = JSON.stringify({ mcpServers: { git: {} }, token: 'x' });
+  it('returns true when the key path exists', () => {
+    expect(hasSubtree(file, 'mcpServers')).toBe(true);
+    expect(hasSubtree(file, 'mcpServers.git')).toBe(true);
+  });
+  it('returns false for a missing key, invalid json, or malformed path', () => {
+    expect(hasSubtree(file, 'nope')).toBe(false);
+    expect(hasSubtree('{ bad', 'mcpServers')).toBe(false);
+    expect(hasSubtree(file, 'a..b')).toBe(false);
+  });
+});
+
+describe('mergeSubtreeIntoLive', () => {
+  it('REPLACES the tracked subtree while leaving every other key untouched', () => {
+    const live = JSON.stringify(
+      {
+        oauthToken: 'MACHINE-SECRET',
+        numStartups: 99,
+        mcpServers: { git: { command: 'OLD' }, stale: { command: 'x' } },
+      },
+      null,
+      2
+    );
+    const repoSubtree = canonicalJson({ git: { command: 'NEW' }, added: { command: 'y' } });
+
+    const merged = JSON.parse(mergeSubtreeIntoLive(live, repoSubtree, 'mcpServers'));
+
+    // Machine-managed keys are preserved verbatim.
+    expect(merged.oauthToken).toBe('MACHINE-SECRET');
+    expect(merged.numStartups).toBe(99);
+    // The tracked subtree is REPLACED wholesale: entries deleted from the repo
+    // copy ('stale') must NOT survive on the live machine — a deep-merge here
+    // would resurrect them and the next sync would push them back to the repo,
+    // reverting the deletion globally.
+    expect(merged.mcpServers).toEqual({
+      git: { command: 'NEW' },
+      added: { command: 'y' },
+    });
+  });
+
+  it('propagates deletions inside the tracked subtree (no resurrection loop)', () => {
+    const live = JSON.stringify({ mcpServers: { removed: { command: 'gone' } }, other: 1 });
+    const repoSubtree = canonicalJson({ kept: { command: 'k' } });
+    const merged = JSON.parse(mergeSubtreeIntoLive(live, repoSubtree, 'mcpServers'));
+    expect(merged.mcpServers.removed).toBeUndefined();
+    expect(merged.mcpServers.kept).toEqual({ command: 'k' });
+    expect(merged.other).toBe(1);
+  });
+
+  it('rejects prototype-named key path segments', () => {
+    for (const bad of ['__proto__', 'constructor', 'a.prototype.b']) {
+      expect(() => parseJsonKeyPath(bad)).toThrow(/reserved property/);
+    }
+  });
+
+  it('never matches inherited properties during navigation', () => {
+    // 'toString' exists on every object via the prototype chain; extraction
+    // must treat it as ABSENT when it is not an own key (previously inherited
+    // lookups "succeeded" and wrote literal `undefined` — invalid JSON — to
+    // the repo). ('constructor'/'__proto__' are rejected at parse time.)
+    expect(() => extractSubtree(JSON.stringify({ a: 1 }), 'toString')).toThrow(/not found/);
+  });
+
+  it('a "__proto__" data key in live JSON never pollutes Object.prototype', () => {
+    const live = JSON.stringify({ '__proto__': { polluted: true }, mcpServers: {} });
+    const repoSubtree = canonicalJson({ s: { command: 'x' } });
+    const merged = mergeSubtreeIntoLive(live, repoSubtree, 'mcpServers');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(JSON.parse(merged).mcpServers).toEqual({ s: { command: 'x' } });
+  });
+
+  it('creates the key (and intermediate objects) when absent from live', () => {
+    const live = JSON.stringify({ token: 'keep' });
+    const repoSubtree = canonicalJson({ enabled: true });
+    const merged = JSON.parse(mergeSubtreeIntoLive(live, repoSubtree, 'editor.settings'));
+    expect(merged).toEqual({ token: 'keep', editor: { settings: { enabled: true } } });
+  });
+
+  it('treats a null/empty live file as a fresh object', () => {
+    const repoSubtree = canonicalJson({ a: 1 });
+    expect(JSON.parse(mergeSubtreeIntoLive(null, repoSubtree, 'k'))).toEqual({ k: { a: 1 } });
+    expect(JSON.parse(mergeSubtreeIntoLive('   ', repoSubtree, 'k'))).toEqual({ k: { a: 1 } });
+  });
+
+  it('round-trips: extract then merge reproduces the tracked subtree', () => {
+    const live = JSON.stringify({ mcpServers: { git: { command: 'a' } }, token: 't' });
+    const sub = extractSubtree(live, 'mcpServers');
+    const merged = JSON.parse(mergeSubtreeIntoLive(live, sub, 'mcpServers'));
+    expect(merged.mcpServers).toEqual({ git: { command: 'a' } });
+    expect(merged.token).toBe('t');
+  });
+
+  it('replaces a conflicting non-object node at the exact path only', () => {
+    const live = JSON.stringify({ mcpServers: 'was-a-string', other: 1 });
+    const repoSubtree = canonicalJson({ git: {} });
+    const merged = JSON.parse(mergeSubtreeIntoLive(live, repoSubtree, 'mcpServers'));
+    expect(merged.mcpServers).toEqual({ git: {} });
+    expect(merged.other).toBe(1);
+  });
+
+  it('throws when the live file is not valid JSON', () => {
+    expect(() => mergeSubtreeIntoLive('{ bad', canonicalJson({ a: 1 }), 'k')).toThrow(JsonKeyError);
+  });
+
+  it('throws when the live top level is not an object', () => {
+    expect(() => mergeSubtreeIntoLive('[1,2]', canonicalJson({ a: 1 }), 'k')).toThrow(JsonKeyError);
+  });
+});

--- a/tests/lib/jsonKey.test.ts
+++ b/tests/lib/jsonKey.test.ts
@@ -230,4 +230,164 @@ describe('mergeSubtreeIntoLive', () => {
   it('throws when the live top level is not an object', () => {
     expect(() => mergeSubtreeIntoLive('[1,2]', canonicalJson({ a: 1 }), 'k')).toThrow(JsonKeyError);
   });
+
+  it('throws when an INTERMEDIATE node on the write path is not an object', () => {
+    // Tracking a.b when live has "a": [1,2,3] must fail loudly rather than
+    // silently replace the whole array (which would discard untracked data).
+    const live = JSON.stringify({ a: [1, 2, 3], keep: 1 });
+    expect(() => mergeSubtreeIntoLive(live, canonicalJson({ x: 1 }), 'a.b')).toThrow(JsonKeyError);
+    expect(() => mergeSubtreeIntoLive(live, canonicalJson({ x: 1 }), 'a.b')).toThrow(
+      /not an object/i
+    );
+  });
+});
+
+describe('parseJsonKeyPath escaping', () => {
+  it('treats a backslash-escaped dot as a literal character in a single key name', () => {
+    // `servers.github\.copilot` addresses servers -> "github.copilot"
+    expect(parseJsonKeyPath('servers.github\\.copilot')).toEqual(['servers', 'github.copilot']);
+  });
+
+  it('unescapes a literal backslash (\\\\ -> \\)', () => {
+    expect(parseJsonKeyPath('a\\\\b')).toEqual(['a\\b']);
+  });
+
+  it('still splits on UNESCAPED dots', () => {
+    expect(parseJsonKeyPath('a.b\\.c.d')).toEqual(['a', 'b.c', 'd']);
+  });
+
+  it('applies the empty-segment guard to the unescaped result', () => {
+    expect(() => parseJsonKeyPath('a..b')).toThrow(JsonKeyError);
+  });
+
+  it('applies the prototype-pollution guard to the UNESCAPED segment names', () => {
+    expect(() => parseJsonKeyPath('a.__proto__')).toThrow(/reserved property/);
+  });
+});
+
+describe('mergeSubtreeIntoLive span-splice (byte preservation)', () => {
+  it('preserves a large integer in the UNTRACKED remainder byte-for-byte', () => {
+    const live = [
+      '{',
+      '  "bigId": 1234567890123456789,',
+      '  "mcpServers": {',
+      '    "git": { "command": "OLD" }',
+      '  }',
+      '}',
+    ].join('\n');
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ git: { command: 'NEW' } }), 'mcpServers');
+    // The untracked big int must survive verbatim — a JSON.parse round-trip would
+    // corrupt it to ...800.
+    expect(out).toContain('1234567890123456789');
+    expect(out).not.toContain('1234567890123456800');
+    // And the tracked subtree is actually replaced.
+    expect(JSON.parse(out).mcpServers).toEqual({ git: { command: 'NEW' } });
+  });
+
+  it('preserves the textual key order of the untracked remainder', () => {
+    const live = ['{', '  "z": 1,', '  "a": 2,', '  "tracked": {},', '  "m": 3', '}'].join('\n');
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ v: 1 }), 'tracked');
+    expect(out.indexOf('"z"')).toBeLessThan(out.indexOf('"a"'));
+    expect(out.indexOf('"a"')).toBeLessThan(out.indexOf('"tracked"'));
+    expect(out.indexOf('"tracked"')).toBeLessThan(out.indexOf('"m"'));
+  });
+
+  it('does not reorder integer-like keys in the untracked remainder', () => {
+    // JSON.parse/stringify reorders numeric string keys ascending (1,2,10); the
+    // span-splice must keep the original textual order (10,2,1).
+    const live = ['{', '  "10": "a",', '  "2": "b",', '  "1": "c",', '  "tracked": {}', '}'].join(
+      '\n'
+    );
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ v: 1 }), 'tracked');
+    expect(out.indexOf('"10"')).toBeLessThan(out.indexOf('"2"'));
+    expect(out.indexOf('"2"')).toBeLessThan(out.indexOf('"1"'));
+  });
+
+  it('preserves tab indentation of untracked lines and re-indents the value with tabs', () => {
+    const live = '{\n\t"tracked": {\n\t\t"old": 1\n\t},\n\t"keep": 2\n}';
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ fresh: true }), 'tracked');
+    expect(out).toContain('\t"keep": 2');
+    expect(out).toContain('\t"tracked": {');
+    expect(JSON.parse(out)).toEqual({ tracked: { fresh: true }, keep: 2 });
+  });
+
+  it('preserves 4-space indentation', () => {
+    const live = [
+      '{',
+      '    "tracked": {',
+      '        "old": 1',
+      '    },',
+      '    "keep": 2',
+      '}',
+    ].join('\n');
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ nested: { deep: true } }), 'tracked');
+    expect(JSON.parse(out)).toEqual({ tracked: { nested: { deep: true } }, keep: 2 });
+    expect(out).toContain('    "tracked": {');
+    expect(out).toContain('        "nested": {');
+    expect(out).toContain('            "deep": true');
+  });
+
+  it('replaces the subtree correctly at a deeply nested path', () => {
+    const live = [
+      '{',
+      '  "a": {',
+      '    "b": {',
+      '      "c": { "old": 1 }',
+      '    }',
+      '  },',
+      '  "keep": 9',
+      '}',
+    ].join('\n');
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ fresh: true }), 'a.b.c');
+    const parsed = JSON.parse(out);
+    expect(parsed.a.b.c).toEqual({ fresh: true });
+    expect(parsed.keep).toBe(9);
+  });
+
+  it('inserts the key into the nearest existing ancestor object when the path is missing', () => {
+    const live = ['{', '  "editor": {},', '  "keep": 1', '}'].join('\n');
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ enabled: true }), 'editor.settings');
+    const parsed = JSON.parse(out);
+    expect(parsed.editor.settings).toEqual({ enabled: true });
+    expect(parsed.keep).toBe(1);
+  });
+
+  it('handles unicode escapes and braces inside string values without confusing nesting', () => {
+    const live = JSON.stringify(
+      { weird: 'a{[}] " brace A \\ end', tracked: { old: 1 } },
+      null,
+      2
+    );
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ fresh: true }), 'tracked');
+    const parsed = JSON.parse(out);
+    expect(parsed.weird).toBe('a{[}] " brace A \\ end');
+    expect(parsed.tracked).toEqual({ fresh: true });
+  });
+
+  it('touches only the tracked value in a compact file, leaving other bytes intact', () => {
+    const live = '{"tracked":{"old":1},"keep":2}';
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ new: 1 }), 'tracked');
+    expect(out).toBe('{"tracked":{"new":1},"keep":2}');
+  });
+
+  it('preserves a trailing newline in the untouched remainder', () => {
+    const live = '{\n  "tracked": {},\n  "keep": 1\n}\n';
+    const out = mergeSubtreeIntoLive(live, canonicalJson({ a: 1 }), 'tracked');
+    expect(out.endsWith('}\n')).toBe(true);
+    expect(JSON.parse(out)).toEqual({ tracked: { a: 1 }, keep: 1 });
+  });
+
+  it('round-trips an escaped-dot key through extract then write-back', () => {
+    const live = JSON.stringify(
+      { servers: { 'github.copilot': { on: true }, other: 1 } },
+      null,
+      2
+    );
+    const sub = extractSubtree(live, 'servers.github\\.copilot');
+    expect(JSON.parse(sub)).toEqual({ on: true });
+    const merged = mergeSubtreeIntoLive(live, canonicalJson({ on: false }), 'servers.github\\.copilot');
+    const parsed = JSON.parse(merged);
+    expect(parsed.servers['github.copilot']).toEqual({ on: false });
+    expect(parsed.servers.other).toBe(1);
+  });
 });

--- a/tests/lib/jsonMerge.test.ts
+++ b/tests/lib/jsonMerge.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeJsonValues,
+  threeWayMergeJsonText,
+  canonicalize,
+  detectJsonIndent,
+  resolveMergePolicy,
+  hasMergePolicy,
+  DEFAULT_JSON_MERGE_POLICY,
+  type MergePolicy,
+  type JsonValue,
+} from '../../src/lib/jsonMerge.js';
+import { mergePolicySchema } from '../../src/schemas/manifest.schema.js';
+
+const union: MergePolicy = { format: 'json', arrays: 'union', conflict: 'manual' };
+
+describe('canonicalize', () => {
+  it('is order-independent for object keys', () => {
+    expect(canonicalize({ a: 1, b: 2 })).toBe(canonicalize({ b: 2, a: 1 }));
+  });
+
+  it('preserves array order', () => {
+    expect(canonicalize([1, 2] as JsonValue)).not.toBe(canonicalize([2, 1] as JsonValue));
+  });
+});
+
+describe('detectJsonIndent', () => {
+  it('detects two-space indent', () => {
+    expect(detectJsonIndent('{\n  "a": 1\n}')).toBe(2);
+  });
+  it('detects four-space indent', () => {
+    expect(detectJsonIndent('{\n    "a": 1\n}')).toBe(4);
+  });
+  it('detects tab indent', () => {
+    expect(detectJsonIndent('{\n\t"a": 1\n}')).toBe('\t');
+  });
+  it('defaults to two spaces', () => {
+    expect(detectJsonIndent('{}')).toBe(2);
+  });
+});
+
+describe('mergeJsonValues — non-diverging fast paths', () => {
+  it('takes theirs when only remote changed', () => {
+    const { merged, conflicts } = mergeJsonValues({ a: 1 }, { a: 1 }, { a: 2 }, union);
+    expect(merged).toEqual({ a: 2 });
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it('keeps ours when only local changed', () => {
+    const { merged, conflicts } = mergeJsonValues({ a: 1 }, { a: 3 }, { a: 1 }, union);
+    expect(merged).toEqual({ a: 3 });
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it('returns the identical value when both sides agree', () => {
+    const { merged, conflicts } = mergeJsonValues({ a: 1 }, { a: 9 }, { a: 9 }, union);
+    expect(merged).toEqual({ a: 9 });
+    expect(conflicts).toHaveLength(0);
+  });
+});
+
+describe('mergeJsonValues — deep object merge (both changed different keys)', () => {
+  it('merges disjoint key edits from both sides', () => {
+    const base = { theme: 'dark', font: 'mono' };
+    const ours = { theme: 'dark', font: 'mono', localOnly: true };
+    const theirs = { theme: 'light', font: 'mono' };
+    const { merged, conflicts } = mergeJsonValues(base, ours, theirs, union);
+    expect(merged).toEqual({ theme: 'light', font: 'mono', localOnly: true });
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it('recurses into nested objects', () => {
+    const base = { permissions: { allow: [], deny: [] } };
+    const ours = { permissions: { allow: ['Bash'], deny: [] } };
+    const theirs = { permissions: { allow: ['Read'], deny: [] } };
+    const { merged, conflicts } = mergeJsonValues(base, ours, theirs, union);
+    expect(merged).toEqual({ permissions: { allow: ['Bash', 'Read'], deny: [] } });
+    expect(conflicts).toHaveLength(0);
+  });
+});
+
+describe('mergeJsonValues — array strategies', () => {
+  it('unions allowlists and drops duplicates (the Claude settings case)', () => {
+    const base = { allow: ['Read'] };
+    const ours = { allow: ['Read', 'Bash(git:*)'] };
+    const theirs = { allow: ['Read', 'WebFetch'] };
+    const { merged } = mergeJsonValues(base, ours, theirs, union);
+    expect(merged).toEqual({ allow: ['Read', 'Bash(git:*)', 'WebFetch'] });
+  });
+
+  it('unions arrays of objects by deep equality', () => {
+    const base = { servers: [] as JsonValue };
+    const ours = { servers: [{ name: 'a' }] };
+    const theirs = { servers: [{ name: 'a' }, { name: 'b' }] };
+    const { merged } = mergeJsonValues(base, ours, theirs, union);
+    expect(merged).toEqual({ servers: [{ name: 'a' }, { name: 'b' }] });
+  });
+
+  it('concat keeps duplicates', () => {
+    const concat: MergePolicy = { format: 'json', arrays: 'concat', conflict: 'manual' };
+    const { merged } = mergeJsonValues({ a: [] as JsonValue }, { a: [1] }, { a: [1, 2] }, concat);
+    expect(merged).toEqual({ a: [1, 1, 2] });
+  });
+
+  it('replace degrades a diverged array to a conflict under manual', () => {
+    const replace: MergePolicy = { format: 'json', arrays: 'replace', conflict: 'manual' };
+    const { conflicts } = mergeJsonValues({ a: [] as JsonValue }, { a: [1] }, { a: [2] }, replace);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].path).toBe('a');
+  });
+});
+
+describe('mergeJsonValues — scalar conflicts', () => {
+  it('records a conflict when both sides change a leaf differently (manual)', () => {
+    const { merged, conflicts } = mergeJsonValues({ model: 'a' }, { model: 'b' }, { model: 'c' }, union);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({ path: 'model', ours: 'b', theirs: 'c', base: 'a' });
+    // The document stays valid: ours is retained as the placeholder.
+    expect(merged).toEqual({ model: 'b' });
+  });
+
+  it('resolves conflicts to ours', () => {
+    const ours: MergePolicy = { format: 'json', arrays: 'union', conflict: 'ours' };
+    const { merged, conflicts } = mergeJsonValues({ x: 1 }, { x: 2 }, { x: 3 }, ours);
+    expect(conflicts).toHaveLength(0);
+    expect(merged).toEqual({ x: 2 });
+  });
+
+  it('resolves conflicts to theirs', () => {
+    const theirs: MergePolicy = { format: 'json', arrays: 'union', conflict: 'theirs' };
+    const { merged, conflicts } = mergeJsonValues({ x: 1 }, { x: 2 }, { x: 3 }, theirs);
+    expect(conflicts).toHaveLength(0);
+    expect(merged).toEqual({ x: 3 });
+  });
+
+  it('reports nested conflict paths', () => {
+    const base = { a: { b: 1 } };
+    const { conflicts } = mergeJsonValues(base, { a: { b: 2 } }, { a: { b: 3 } }, union);
+    expect(conflicts[0].path).toBe('a.b');
+  });
+});
+
+describe('mergeJsonValues — key additions and deletions', () => {
+  it('keeps a key added only on one side', () => {
+    const { merged } = mergeJsonValues({}, { added: 1 }, {}, union);
+    expect(merged).toEqual({ added: 1 });
+  });
+
+  it('honors a deletion on one side when the other did not touch it', () => {
+    // theirs deleted `old`; ours left it untouched → deletion wins.
+    const { merged, conflicts } = mergeJsonValues({ old: 1, keep: 1 }, { old: 1, keep: 1 }, { keep: 1 }, union);
+    expect(merged).toEqual({ keep: 1 });
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it('flags delete-vs-modify as a conflict (manual)', () => {
+    // ours modified `k`; theirs deleted it.
+    const { conflicts } = mergeJsonValues({ k: 1 }, { k: 2 }, {}, union);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({ path: 'k', ours: 2, theirs: undefined });
+  });
+});
+
+describe('threeWayMergeJsonText', () => {
+  it('re-serializes with the local file indentation and trailing newline', () => {
+    const base = '{\n  "allow": ["Read"]\n}\n';
+    const ours = '{\n  "allow": ["Read", "Bash"]\n}\n';
+    const theirs = '{\n  "allow": ["Read", "WebFetch"]\n}\n';
+    const result = threeWayMergeJsonText(base, ours, theirs, union);
+    expect(result.unparsable).toBe(false);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.text).toBe('{\n  "allow": [\n    "Read",\n    "Bash",\n    "WebFetch"\n  ]\n}\n');
+  });
+
+  it('flags unparsable input', () => {
+    const result = threeWayMergeJsonText('{', '{}', '{}', union);
+    expect(result.unparsable).toBe(true);
+    expect(result.text).toBeNull();
+  });
+
+  it('preserves absence of trailing newline', () => {
+    const result = threeWayMergeJsonText('{"a":1}', '{"a":2}', '{"a":1}', union);
+    expect(result.text?.endsWith('\n')).toBe(false);
+  });
+});
+
+describe('resolveMergePolicy / hasMergePolicy', () => {
+  it('auto-applies the default policy to Claude settings.json', () => {
+    expect(resolveMergePolicy('~/.claude/settings.json')).toEqual(DEFAULT_JSON_MERGE_POLICY);
+    expect(hasMergePolicy('~/.claude/settings.json')).toBe(true);
+  });
+
+  it('auto-applies to .mcp.json', () => {
+    expect(resolveMergePolicy('~/project/.mcp.json')).toEqual(DEFAULT_JSON_MERGE_POLICY);
+  });
+
+  it('returns null for ordinary files', () => {
+    expect(resolveMergePolicy('~/.zshrc')).toBeNull();
+    expect(hasMergePolicy('~/.zshrc')).toBe(false);
+  });
+
+  it('lets an explicit manifest policy win over auto-detection', () => {
+    const explicit: MergePolicy = { format: 'json', arrays: 'concat', conflict: 'ours' };
+    expect(resolveMergePolicy('~/.zshrc', explicit)).toEqual(explicit);
+    expect(resolveMergePolicy('~/.claude/settings.json', explicit)).toEqual(explicit);
+  });
+});
+
+describe('mergePolicySchema', () => {
+  it('fills defaults for a bare json policy', () => {
+    const parsed = mergePolicySchema.parse({ format: 'json' });
+    expect(parsed).toEqual({ format: 'json', arrays: 'union', conflict: 'manual' });
+  });
+
+  it('rejects unknown array strategies', () => {
+    expect(() => mergePolicySchema.parse({ format: 'json', arrays: 'bogus' })).toThrow();
+  });
+});
+
+describe('pending merge-base persistence (abort recovery)', () => {
+  it('round-trips bases through the state dir and clears them', async () => {
+    const { persistPendingMergeBases, loadPendingMergeBases, clearPendingMergeBases } =
+      await import('../../src/lib/jsonMergeSync.js');
+    const bases = new Map([['~/.claude/settings.json', '{"a":1}']]);
+    await persistPendingMergeBases(bases);
+    const loaded = await loadPendingMergeBases();
+    expect(loaded.get('~/.claude/settings.json')).toBe('{"a":1}');
+    await clearPendingMergeBases();
+    expect((await loadPendingMergeBases()).size).toBe(0);
+  });
+
+  it('returns an empty map on corrupt or absent state (never blocks sync)', async () => {
+    const { getPendingMergeBasesPath, loadPendingMergeBases, clearPendingMergeBases } =
+      await import('../../src/lib/jsonMergeSync.js');
+    await clearPendingMergeBases();
+    expect((await loadPendingMergeBases()).size).toBe(0);
+    const { vol } = await import('memfs');
+    const { dirname } = await import('path');
+    vol.mkdirSync(dirname(getPendingMergeBasesPath()), { recursive: true });
+    vol.writeFileSync(getPendingMergeBasesPath(), 'not json{');
+    expect((await loadPendingMergeBases()).size).toBe(0);
+  });
+});

--- a/tests/lib/jsonMerge.test.ts
+++ b/tests/lib/jsonMerge.test.ts
@@ -161,6 +161,131 @@ describe('mergeJsonValues — key additions and deletions', () => {
   });
 });
 
+describe('mergeJsonValues — base-aware array union (revocation safety)', () => {
+  it('honors a locally-revoked permission instead of resurrecting it', () => {
+    // base grants Read, Bash, WebFetch. Ours revokes Bash. Theirs adds Glob.
+    const base = { allow: ['Read', 'Bash', 'WebFetch'] };
+    const ours = { allow: ['Read', 'WebFetch'] };
+    const theirs = { allow: ['Read', 'Bash', 'WebFetch', 'Glob'] };
+    const { merged, conflicts } = mergeJsonValues(base, ours, theirs, union);
+    // Bash stays revoked (deletion wins); Glob is a genuine addition.
+    expect(merged).toEqual({ allow: ['Read', 'WebFetch', 'Glob'] });
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it('honors a remotely-revoked item even though ours still carries it', () => {
+    const base = { allow: ['Read', 'Bash', 'WebFetch'] };
+    const ours = { allow: ['Read', 'Bash', 'WebFetch'] };
+    const theirs = { allow: ['Read', 'WebFetch'] };
+    const { merged } = mergeJsonValues(base, ours, theirs, union);
+    expect(merged).toEqual({ allow: ['Read', 'WebFetch'] });
+  });
+
+  it('keeps genuine additions from both sides while honoring a deletion', () => {
+    const base = { allow: ['A', 'B'] };
+    const ours = { allow: ['A', 'OurAdd'] }; // dropped B, added OurAdd
+    const theirs = { allow: ['A', 'B', 'TheirAdd'] }; // kept B, added TheirAdd
+    const { merged } = mergeJsonValues(base, ours, theirs, union);
+    // B was deleted by ours → stays gone; both additions survive.
+    expect(merged).toEqual({ allow: ['A', 'OurAdd', 'TheirAdd'] });
+  });
+
+  it('drops an item deleted by both sides', () => {
+    const base = { allow: ['A', 'B', 'C'] };
+    const ours = { allow: ['A', 'C'] };
+    const theirs = { allow: ['A'] };
+    const { merged } = mergeJsonValues(base, ours, theirs, union);
+    expect(merged).toEqual({ allow: ['A'] });
+  });
+
+  it('treats a delete-vs-modify on an array item as delete-old + add-new', () => {
+    // Union arrays have no element identity: base "Bash" is deleted by ours and
+    // "modified" to "Bash(git:*)" by theirs. Old value drops; new value is added.
+    const base = { allow: ['Read', 'Bash'] };
+    const ours = { allow: ['Read'] }; // deleted Bash
+    const theirs = { allow: ['Read', 'Bash(git:*)'] }; // modified Bash
+    const { merged } = mergeJsonValues(base, ours, theirs, union);
+    expect(merged).toEqual({ allow: ['Read', 'Bash(git:*)'] });
+  });
+
+  it('base-aware union works for arrays of objects', () => {
+    const base = { servers: [{ name: 'a' }, { name: 'b' }] };
+    const ours = { servers: [{ name: 'a' }] }; // dropped b
+    const theirs = { servers: [{ name: 'a' }, { name: 'b' }, { name: 'c' }] };
+    const { merged } = mergeJsonValues(base, ours, theirs, union);
+    // b was revoked locally → stays gone; c is a new addition.
+    expect(merged).toEqual({ servers: [{ name: 'a' }, { name: 'c' }] });
+  });
+});
+
+describe('mergeJsonValues — prototype-shadowing keys', () => {
+  const parse = (text: string): JsonValue => JSON.parse(text) as JsonValue;
+
+  it('keeps theirs-only keys named toString / constructor / valueOf', () => {
+    const base = parse('{}');
+    const ours = parse('{"keep": 1}');
+    const theirs = parse('{"toString": "t", "constructor": "c", "valueOf": "v"}');
+    const { merged } = mergeJsonValues(base, ours, theirs, union) as {
+      merged: { [k: string]: JsonValue };
+    };
+    expect(Object.hasOwn(merged, 'toString')).toBe(true);
+    expect(Object.hasOwn(merged, 'constructor')).toBe(true);
+    expect(Object.hasOwn(merged, 'valueOf')).toBe(true);
+    expect(merged.toString).toBe('t');
+    expect(merged.constructor).toBe('c');
+    expect(merged.valueOf).toBe('v');
+    // And they serialize.
+    const round = JSON.parse(JSON.stringify(merged)) as { [k: string]: JsonValue };
+    expect(round.toString).toBe('t');
+    expect(round.constructor).toBe('c');
+    expect(round.valueOf).toBe('v');
+  });
+
+  it('keeps a theirs-only __proto__ key without hijacking the prototype', () => {
+    const base = parse('{}');
+    const ours = parse('{"a": 1}');
+    // JSON.parse creates __proto__ as an OWN data property.
+    const theirs = parse('{"__proto__": {"polluted": true}}');
+    const { merged } = mergeJsonValues(base, ours, theirs, union) as {
+      merged: object;
+    };
+    // No prototype hijack: nothing leaked onto the merged object's chain, and
+    // a plain object's prototype is untouched (contained, no global pollution).
+    expect(('polluted' in ({} as Record<string, unknown>))).toBe(false);
+    expect(Object.hasOwn(merged, '__proto__')).toBe(true);
+    // The __proto__ key survives serialization as a plain data property.
+    const serialized = JSON.stringify(merged);
+    expect(serialized).toContain('__proto__');
+    const round = JSON.parse(serialized) as { [k: string]: JsonValue };
+    expect(Object.hasOwn(round, '__proto__')).toBe(true);
+  });
+
+  it('does not let an own __proto__ on ours hijack the merged prototype', () => {
+    const base = parse('{}');
+    const ours = parse('{"__proto__": {"a": 1}, "keep": 1}');
+    const theirs = parse('{"other": 2}');
+    const { merged } = mergeJsonValues(base, ours, theirs, union) as {
+      merged: { [k: string]: JsonValue };
+    };
+    expect(Object.hasOwn(merged, '__proto__')).toBe(true);
+    expect(merged.keep).toBe(1);
+    expect(merged.other).toBe(2);
+    // The __proto__ key is preserved in serialized output.
+    expect(JSON.stringify(merged)).toContain('__proto__');
+  });
+
+  it('merges a hasOwnProperty key changed on both sides as a normal leaf', () => {
+    const base = parse('{"hasOwnProperty": 1}');
+    const ours = parse('{"hasOwnProperty": 2}');
+    const theirs = parse('{"hasOwnProperty": 1}');
+    const { merged } = mergeJsonValues(base, ours, theirs, union) as {
+      merged: { [k: string]: JsonValue };
+    };
+    // Only ours changed → ours wins; the shadowing key is not dropped.
+    expect(merged.hasOwnProperty).toBe(2);
+  });
+});
+
 describe('threeWayMergeJsonText', () => {
   it('re-serializes with the local file indentation and trailing newline', () => {
     const base = '{\n  "allow": ["Read"]\n}\n';

--- a/tests/lib/manifest-schema.test.ts
+++ b/tests/lib/manifest-schema.test.ts
@@ -80,3 +80,29 @@ describe('trackedFileSchema repo scope', () => {
     expect(trackedFileSchema.safeParse({ ...homeEntry, repoKey: 'k' }).success).toBe(false);
   });
 });
+
+describe('trackedFileSchema jsonKey', () => {
+  it('does not inject a jsonKey key into a legacy entry', () => {
+    const parsed = trackedFileSchema.parse(homeEntry);
+    expect('jsonKey' in parsed).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('"jsonKey"');
+  });
+
+  it('parses a valid JSON-key entry', () => {
+    const parsed = trackedFileSchema.parse({ ...homeEntry, jsonKey: 'mcpServers' });
+    expect(parsed.jsonKey).toBe('mcpServers');
+  });
+
+  it('rejects an empty jsonKey', () => {
+    expect(trackedFileSchema.safeParse({ ...homeEntry, jsonKey: '   ' }).success).toBe(false);
+  });
+
+  it('rejects jsonKey combined with template or encrypted', () => {
+    expect(
+      trackedFileSchema.safeParse({ ...homeEntry, jsonKey: 'a', template: true }).success
+    ).toBe(false);
+    expect(
+      trackedFileSchema.safeParse({ ...homeEntry, jsonKey: 'a', encrypted: true }).success
+    ).toBe(false);
+  });
+});

--- a/tests/lib/osSettings/capture.test.ts
+++ b/tests/lib/osSettings/capture.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  inferWriteFromValue,
+  diffSnapshots,
+  diffDomains,
+  settingId,
+} from '../../../src/lib/osSettings/capture.js';
+import type { PlistValue } from '../../../src/lib/osSettings/plist.js';
+import type { DomainSnapshot } from '../../../src/lib/osSettings/types.js';
+
+const snap = (domain: string, entries: Record<string, PlistValue>): DomainSnapshot => ({
+  domain,
+  entries: new Map(Object.entries(entries)),
+});
+
+describe('inferWriteFromValue', () => {
+  it('maps scalars to defaults types and string forms', () => {
+    expect(inferWriteFromValue({ kind: 'boolean', value: true })).toEqual({
+      type: 'boolean',
+      value: 'true',
+    });
+    expect(inferWriteFromValue({ kind: 'integer', value: 48 })).toEqual({
+      type: 'integer',
+      value: '48',
+    });
+    expect(inferWriteFromValue({ kind: 'real', value: 1.5 })).toEqual({
+      type: 'float',
+      value: '1.5',
+    });
+    expect(inferWriteFromValue({ kind: 'string', value: 'Dark' })).toEqual({
+      type: 'string',
+      value: 'Dark',
+    });
+  });
+
+  it('returns null for containers and opaque data', () => {
+    expect(inferWriteFromValue({ kind: 'array', value: [] })).toBeNull();
+    expect(inferWriteFromValue({ kind: 'dict', value: new Map() })).toBeNull();
+    expect(inferWriteFromValue({ kind: 'data', value: 'AAAA' })).toBeNull();
+  });
+});
+
+describe('diffSnapshots', () => {
+  it('detects an added key as a write change', () => {
+    const before = snap('com.apple.dock', {});
+    const after = snap('com.apple.dock', { autohide: { kind: 'boolean', value: true } });
+    expect(diffSnapshots(before, after)).toEqual([
+      {
+        domain: 'com.apple.dock',
+        key: 'autohide',
+        action: 'write',
+        type: 'boolean',
+        value: 'true',
+      },
+    ]);
+  });
+
+  it('detects a changed value', () => {
+    const before = snap('d', { tilesize: { kind: 'integer', value: 48 } });
+    const after = snap('d', { tilesize: { kind: 'integer', value: 64 } });
+    expect(diffSnapshots(before, after)).toEqual([
+      { domain: 'd', key: 'tilesize', action: 'write', type: 'integer', value: '64' },
+    ]);
+  });
+
+  it('ignores unchanged keys', () => {
+    const same = { autohide: { kind: 'boolean', value: true } as PlistValue };
+    expect(diffSnapshots(snap('d', same), snap('d', same))).toEqual([]);
+  });
+
+  it('detects a removed key as a delete change', () => {
+    const before = snap('d', { orient: { kind: 'string', value: 'left' } });
+    const after = snap('d', {});
+    expect(diffSnapshots(before, after)).toEqual([
+      { domain: 'd', key: 'orient', action: 'delete' },
+    ]);
+  });
+
+  it('flags an unsupported (container) new value', () => {
+    const before = snap('d', {});
+    const after = snap('d', { persistent: { kind: 'array', value: [] } });
+    expect(diffSnapshots(before, after)).toEqual([
+      { domain: 'd', key: 'persistent', action: 'write', unsupported: true },
+    ]);
+  });
+
+  it('throws on a domain mismatch', () => {
+    expect(() => diffSnapshots(snap('a', {}), snap('b', {}))).toThrow(/domain mismatch/);
+  });
+});
+
+describe('diffDomains', () => {
+  it('treats a domain absent in the before set as empty', () => {
+    const after = [snap('new.domain', { k: { kind: 'boolean', value: false } })];
+    expect(diffDomains([], after)).toEqual([
+      { domain: 'new.domain', key: 'k', action: 'write', type: 'boolean', value: 'false' },
+    ]);
+  });
+});
+
+describe('settingId', () => {
+  it('is stable and slugified per (os, domain, key)', () => {
+    expect(settingId('macos', 'com.apple.dock', 'autohide')).toBe(
+      'macos__com.apple.dock__autohide'
+    );
+  });
+});

--- a/tests/lib/osSettings/defaults.test.ts
+++ b/tests/lib/osSettings/defaults.test.ts
@@ -1,0 +1,171 @@
+/**
+ * MacOsDefaultsBackend tests. The `defaults`, `sw_vers`, and `killall` binaries
+ * are fully mocked via child_process — no real macOS CLI is invoked, so these
+ * pass on any platform.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execFileMock = vi.fn();
+
+// Per-test control over stdout/errors keyed by the invoked binary + first arg.
+let responder: (cmd: string, args: string[]) => { stdout: string } | Error = () => ({
+  stdout: '',
+});
+
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1] as (
+      err: Error | null,
+      result: { stdout: string; stderr: string }
+    ) => void;
+    const cmd = args[0] as string;
+    const argv = (args[1] as string[]) ?? [];
+    execFileMock(cmd, argv);
+    const res = responder(cmd, argv);
+    if (res instanceof Error) {
+      callback(res, { stdout: '', stderr: '' });
+      return;
+    }
+    callback(null, { stdout: res.stdout, stderr: '' });
+  },
+}));
+
+const EXPORT_DOCK = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>autohide</key>
+\t<true/>
+\t<key>tilesize</key>
+\t<integer>48</integer>
+</dict>
+</plist>`;
+
+describe('MacOsDefaultsBackend', () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+    responder = () => ({ stdout: '' });
+  });
+
+  it('currentOsVersion reads `sw_vers -productVersion`', async () => {
+    responder = (cmd) => (cmd === 'sw_vers' ? { stdout: '15.1\n' } : { stdout: '' });
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    const backend = new MacOsDefaultsBackend();
+    expect(await backend.currentOsVersion()).toBe('15.1');
+    expect(execFileMock).toHaveBeenCalledWith('sw_vers', ['-productVersion']);
+  });
+
+  it('currentOsVersion returns empty string when sw_vers fails', async () => {
+    responder = () => new Error('not found');
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    expect(await new MacOsDefaultsBackend().currentOsVersion()).toBe('');
+  });
+
+  it('listDomains parses comma output and always includes the global domain', async () => {
+    responder = (cmd, argv) =>
+      cmd === 'defaults' && argv[0] === 'domains'
+        ? { stdout: 'com.apple.dock, com.apple.finder' }
+        : { stdout: '' };
+    const { MacOsDefaultsBackend, GLOBAL_DOMAIN } =
+      await import('../../../src/lib/osSettings/defaults.js');
+    const domains = await new MacOsDefaultsBackend().listDomains();
+    expect(domains).toContain('com.apple.dock');
+    expect(domains).toContain('com.apple.finder');
+    expect(domains).toContain(GLOBAL_DOMAIN);
+    expect(domains[0]).toBe(GLOBAL_DOMAIN);
+  });
+
+  it('snapshotDomain exports and parses a domain plist', async () => {
+    responder = (cmd, argv) =>
+      cmd === 'defaults' && argv[0] === 'export' ? { stdout: EXPORT_DOCK } : { stdout: '' };
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    const snap = await new MacOsDefaultsBackend().snapshotDomain('com.apple.dock');
+    expect(execFileMock).toHaveBeenCalledWith('defaults', ['export', 'com.apple.dock', '-']);
+    expect(snap.entries.get('autohide')).toEqual({ kind: 'boolean', value: true });
+    expect(snap.entries.get('tilesize')).toEqual({ kind: 'integer', value: 48 });
+  });
+
+  it('snapshotDomain returns an empty snapshot when export fails', async () => {
+    responder = () => new Error('domain does not exist');
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    const snap = await new MacOsDefaultsBackend().snapshotDomain('nope');
+    expect(snap.entries.size).toBe(0);
+  });
+
+  it('apply runs `defaults write` with the typed flag and value', async () => {
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    const backend = new MacOsDefaultsBackend();
+    await backend.apply({
+      id: 'macos__com.apple.dock__autohide',
+      os: 'macos',
+      description: '',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+      capturedOsVersion: '15.1',
+      minVersion: null,
+      maxVersion: null,
+      restartApps: [],
+      added: 'x',
+      modified: 'x',
+    });
+    expect(execFileMock).toHaveBeenCalledWith('defaults', [
+      'write',
+      'com.apple.dock',
+      'autohide',
+      '-bool',
+      'true',
+    ]);
+  });
+
+  it('apply runs `defaults delete` for a delete action', async () => {
+    const { MacOsDefaultsBackend, buildDefaultsArgv } =
+      await import('../../../src/lib/osSettings/defaults.js');
+    const entry = {
+      id: 'macos__d__k',
+      os: 'macos' as const,
+      description: '',
+      domain: 'd',
+      key: 'k',
+      action: 'delete' as const,
+      capturedOsVersion: '',
+      minVersion: null,
+      maxVersion: null,
+      restartApps: [],
+      added: 'x',
+      modified: 'x',
+    };
+    expect(buildDefaultsArgv(entry)).toEqual(['delete', 'd', 'k']);
+    await new MacOsDefaultsBackend().apply(entry);
+    expect(execFileMock).toHaveBeenCalledWith('defaults', ['delete', 'd', 'k']);
+  });
+
+  it('plan builds a human-readable display string', async () => {
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    const plan = new MacOsDefaultsBackend().plan({
+      id: 'x',
+      os: 'macos',
+      description: '',
+      domain: 'com.apple.dock',
+      key: 'tilesize',
+      action: 'write',
+      type: 'integer',
+      value: '64',
+      capturedOsVersion: '',
+      minVersion: null,
+      maxVersion: null,
+      restartApps: [],
+      added: 'x',
+      modified: 'x',
+    });
+    expect(plan.display).toBe('defaults write com.apple.dock tilesize -int 64');
+  });
+
+  it('restartApp swallows a killall failure (app not running)', async () => {
+    responder = () => new Error('No matching processes');
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    await expect(new MacOsDefaultsBackend().restartApp('Dock')).resolves.toBeUndefined();
+    expect(execFileMock).toHaveBeenCalledWith('killall', ['Dock']);
+  });
+});

--- a/tests/lib/osSettings/defaults.test.ts
+++ b/tests/lib/osSettings/defaults.test.ts
@@ -6,6 +6,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const execFileMock = vi.fn();
+// Separately records the options object passed to each execFile call so tests
+// can assert maxBuffer without changing execFileMock's (cmd, argv) signature.
+const execOptionsMock = vi.fn();
 
 // Per-test control over stdout/errors keyed by the invoked binary + first arg.
 let responder: (cmd: string, args: string[]) => { stdout: string } | Error = () => ({
@@ -20,7 +23,10 @@ vi.mock('child_process', () => ({
     ) => void;
     const cmd = args[0] as string;
     const argv = (args[1] as string[]) ?? [];
+    // execFile(file, args, options, callback): options sits between argv and cb.
+    const options = args.length > 3 ? args[2] : undefined;
     execFileMock(cmd, argv);
+    execOptionsMock(cmd, options);
     const res = responder(cmd, argv);
     if (res instanceof Error) {
       callback(res, { stdout: '', stderr: '' });
@@ -43,6 +49,7 @@ const EXPORT_DOCK = `<?xml version="1.0" encoding="UTF-8"?>
 describe('MacOsDefaultsBackend', () => {
   beforeEach(() => {
     execFileMock.mockClear();
+    execOptionsMock.mockClear();
     responder = () => ({ stdout: '' });
   });
 
@@ -167,5 +174,40 @@ describe('MacOsDefaultsBackend', () => {
     const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
     await expect(new MacOsDefaultsBackend().restartApp('Dock')).resolves.toBeUndefined();
     expect(execFileMock).toHaveBeenCalledWith('killall', ['Dock']);
+  });
+
+  // ── Finding 1: large maxBuffer + no silent-empty on export failure ──
+
+  it('exportRaw passes a large maxBuffer so multi-MB domains are not truncated', async () => {
+    responder = (cmd, argv) =>
+      cmd === 'defaults' && argv[0] === 'export' ? { stdout: EXPORT_DOCK } : { stdout: '' };
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    await new MacOsDefaultsBackend().exportRaw('com.apple.dock');
+    const exportCall = execOptionsMock.mock.calls.find(
+      ([cmd]) => cmd === 'defaults'
+    ) as [string, { maxBuffer?: number } | undefined] | undefined;
+    expect(exportCall?.[1]?.maxBuffer).toBeGreaterThanOrEqual(64 * 1024 * 1024);
+  });
+
+  it('exportRaw returns empty string for a domain that does not exist', async () => {
+    responder = () => new Error('Domain com.apple.nope does not exist');
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    expect(await new MacOsDefaultsBackend().exportRaw('com.apple.nope')).toBe('');
+  });
+
+  it('exportRaw throws (never silently empties) on a real export failure', async () => {
+    responder = () => new Error('stdout maxBuffer length exceeded');
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    await expect(new MacOsDefaultsBackend().exportRaw('com.apple.finder')).rejects.toThrow(
+      /Failed to export defaults domain "com.apple.finder"/
+    );
+  });
+
+  it('snapshotDomain propagates a real export failure instead of reporting empty', async () => {
+    responder = () => new Error('stdout maxBuffer length exceeded');
+    const { MacOsDefaultsBackend } = await import('../../../src/lib/osSettings/defaults.js');
+    await expect(new MacOsDefaultsBackend().snapshotDomain('com.apple.finder')).rejects.toThrow(
+      /Failed to export/
+    );
   });
 });

--- a/tests/lib/osSettings/manifest.test.ts
+++ b/tests/lib/osSettings/manifest.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the OS-settings manifest loader's corrupt-file protection:
+ * mutators do load->mutate->save, so a corrupt manifest must throw, never
+ * silently degrade to empty (which would wipe all tracked settings).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vol } from 'memfs';
+import { TEST_TUCK_DIR } from '../../setup.js';
+
+beforeEach(() => {
+  vol.reset();
+});
+
+describe('corrupt-manifest protection', () => {
+  it('throws (not empty) when the file exists but is invalid JSON', async () => {
+    const { loadOsSettingsManifest, osSettingsManifestPath } = await import(
+      '../../../src/lib/osSettings/manifest.js'
+    );
+    const { vol } = await import('memfs');
+    const { dirname } = await import('path');
+    const p = osSettingsManifestPath(TEST_TUCK_DIR);
+    vol.mkdirSync(dirname(p), { recursive: true });
+    vol.writeFileSync(p, 'not-json{');
+    await expect(loadOsSettingsManifest(TEST_TUCK_DIR)).rejects.toMatchObject({
+      code: 'OS_SETTINGS_MANIFEST_ERROR',
+    });
+  });
+
+  it('throws on an unknown/newer manifest version instead of wiping settings', async () => {
+    const { loadOsSettingsManifest, osSettingsManifestPath } = await import(
+      '../../../src/lib/osSettings/manifest.js'
+    );
+    const { vol } = await import('memfs');
+    const { dirname } = await import('path');
+    const p = osSettingsManifestPath(TEST_TUCK_DIR);
+    vol.mkdirSync(dirname(p), { recursive: true });
+    vol.writeFileSync(p, JSON.stringify({ version: '2', settings: { x: {} } }));
+    await expect(loadOsSettingsManifest(TEST_TUCK_DIR)).rejects.toMatchObject({
+      code: 'OS_SETTINGS_MANIFEST_ERROR',
+    });
+  });
+});

--- a/tests/lib/osSettings/operations.test.ts
+++ b/tests/lib/osSettings/operations.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the stateful settings operations (manifest + state on memfs). The
+ * backend is a hand-written fake implementing OsSettingsBackend, so apply logic
+ * (version guards, backups, restarts, manual reminders) is exercised without any
+ * real `defaults` call.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vol } from 'memfs';
+import { TEST_TUCK_DIR } from '../../setup.js';
+import {
+  recordSetting,
+  removeSetting,
+  applySettings,
+  addManualStep,
+  removeManualStep,
+  setManualDone,
+} from '../../../src/lib/osSettings/operations.js';
+import {
+  loadOsSettingsManifest,
+  loadOsSettingsState,
+  osSettingsBackupsDir,
+} from '../../../src/lib/osSettings/manifest.js';
+import type {
+  OsSettingsBackend,
+  DomainSnapshot,
+  ApplyOutcome,
+} from '../../../src/lib/osSettings/types.js';
+import type { SettingEntry } from '../../../src/schemas/osSettings.schema.js';
+
+class FakeBackend implements OsSettingsBackend {
+  readonly os = 'macos' as const;
+  public applied: string[] = [];
+  public restarted: string[] = [];
+  public exported: string[] = [];
+  constructor(private version = '15.1') {}
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+  async currentOsVersion(): Promise<string> {
+    return this.version;
+  }
+  async listDomains(): Promise<string[]> {
+    return [];
+  }
+  async snapshotDomain(domain: string): Promise<DomainSnapshot> {
+    return { domain, entries: new Map() };
+  }
+  async exportRaw(domain: string): Promise<string> {
+    this.exported.push(domain);
+    return `<plist><dict><key>x</key><string>${domain}</string></dict></plist>`;
+  }
+  plan(entry: SettingEntry): ApplyOutcome {
+    const argv =
+      entry.action === 'delete'
+        ? ['delete', entry.domain, entry.key]
+        : ['write', entry.domain, entry.key, `-${entry.type}`, entry.value ?? ''];
+    return { argv, display: `defaults ${argv.join(' ')}` };
+  }
+  async apply(entry: SettingEntry): Promise<void> {
+    this.applied.push(entry.id);
+  }
+  async restartApp(app: string): Promise<void> {
+    this.restarted.push(app);
+  }
+}
+
+beforeEach(() => {
+  vol.reset();
+  vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+});
+
+describe('recordSetting', () => {
+  it('creates a new setting and persists it to the manifest', async () => {
+    const { id, created, entry } = await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+      capturedOsVersion: '15.1',
+      restartApps: ['Dock'],
+    });
+    expect(created).toBe(true);
+    expect(id).toBe('macos__com.apple.dock__autohide');
+    expect(entry.restartApps).toEqual(['Dock']);
+
+    const manifest = await loadOsSettingsManifest(TEST_TUCK_DIR);
+    expect(manifest.settings[id].value).toBe('true');
+  });
+
+  it('updates an existing setting in place and preserves added timestamp', async () => {
+    const first = await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'd',
+      key: 'k',
+      action: 'write',
+      type: 'integer',
+      value: '48',
+    });
+    const second = await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'd',
+      key: 'k',
+      action: 'write',
+      type: 'integer',
+      value: '64',
+    });
+    expect(second.created).toBe(false);
+    expect(second.entry.added).toBe(first.entry.added);
+    expect(second.entry.value).toBe('64');
+  });
+});
+
+describe('removeSetting', () => {
+  it('removes a tracked setting and reports whether it existed', async () => {
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'd',
+      key: 'k',
+      action: 'delete',
+    });
+    expect(await removeSetting(TEST_TUCK_DIR, 'macos__d__k')).toBe(true);
+    expect(await removeSetting(TEST_TUCK_DIR, 'macos__d__k')).toBe(false);
+  });
+});
+
+describe('applySettings', () => {
+  const seed = async (): Promise<void> => {
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+      restartApps: ['Dock'],
+    });
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.finder',
+      key: 'ShowPathbar',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+      minVersion: '99.0', // guard: never applies on 15.1
+      restartApps: ['Finder'],
+    });
+  };
+
+  it('applies passing settings, skips version-guarded ones, and restarts apps', async () => {
+    await seed();
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      restart: true,
+    });
+
+    expect(result.applied.map((a) => a.id)).toEqual(['macos__com.apple.dock__autohide']);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toContain('>= 99.0');
+    expect(backend.applied).toEqual(['macos__com.apple.dock__autohide']);
+    expect(backend.restarted).toEqual(['Dock']);
+    expect(result.backupDir).not.toBeNull();
+  });
+
+  it('backs up affected domains before writing', async () => {
+    await seed();
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      restart: false,
+    });
+    // Only the dock domain passes its guard, so only it is backed up.
+    expect(backend.exported).toEqual(['com.apple.dock']);
+    expect(result.backupDir).toContain(osSettingsBackupsDir());
+    const files = vol.readdirSync(result.backupDir as string);
+    expect(files).toContain('com.apple.dock.plist');
+  });
+
+  it('does not write or back up in dry-run mode', async () => {
+    await seed();
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      dryRun: true,
+      restart: true,
+    });
+    expect(result.applied).toHaveLength(1);
+    expect(backend.applied).toEqual([]); // nothing actually applied
+    expect(backend.exported).toEqual([]); // no backups
+    expect(result.backupDir).toBeNull();
+  });
+
+  it('honors the `only` filter', async () => {
+    await seed();
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      only: ['macos__com.apple.finder__ShowPathbar'],
+    });
+    // The finder entry is filtered in, but its version guard fails at 15.1.
+    expect(result.applied).toHaveLength(0);
+    expect(result.skipped.map((s) => s.id)).toEqual(['macos__com.apple.finder__ShowPathbar']);
+  });
+
+  it('reports pending manual steps not yet done on this machine', async () => {
+    await seed();
+    await addManualStep(TEST_TUCK_DIR, { os: 'macos', title: 'Enable FileVault' });
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, { currentVersion: '15.1' });
+    expect(result.pendingManual.map((m) => m.title)).toEqual(['Enable FileVault']);
+
+    // Once marked done on this machine, it drops out of the reminder.
+    await setManualDone('macos__manual__enable-filevault', true);
+    const after = await applySettings(backend, TEST_TUCK_DIR, { currentVersion: '15.1' });
+    expect(after.pendingManual).toHaveLength(0);
+  });
+});
+
+describe('manual steps', () => {
+  it('adds, updates, marks done per machine, and removes', async () => {
+    const { id, created } = await addManualStep(TEST_TUCK_DIR, {
+      os: 'macos',
+      title: 'Grant Full Disk Access',
+      instructions: 'System Settings > Privacy',
+    });
+    expect(created).toBe(true);
+
+    const update = await addManualStep(TEST_TUCK_DIR, {
+      os: 'macos',
+      title: 'Grant Full Disk Access',
+    });
+    expect(update.created).toBe(false);
+
+    await setManualDone(id, true);
+    let state = await loadOsSettingsState();
+    expect(state.manualDone[id]).toBeTruthy();
+
+    await setManualDone(id, false);
+    state = await loadOsSettingsState();
+    expect(state.manualDone[id]).toBeUndefined();
+
+    expect(await removeManualStep(TEST_TUCK_DIR, id)).toBe(true);
+    expect(await removeManualStep(TEST_TUCK_DIR, id)).toBe(false);
+  });
+});

--- a/tests/lib/osSettings/operations.test.ts
+++ b/tests/lib/osSettings/operations.test.ts
@@ -27,12 +27,22 @@ import type {
 } from '../../../src/lib/osSettings/types.js';
 import type { SettingEntry } from '../../../src/schemas/osSettings.schema.js';
 
+interface FakeBackendOpts {
+  /** Domains whose exportRaw should throw (simulates a backup export failure). */
+  failExportDomains?: string[];
+  /** Setting ids whose apply() should throw (simulates a `defaults` failure). */
+  failApplyIds?: string[];
+}
+
 class FakeBackend implements OsSettingsBackend {
   readonly os = 'macos' as const;
   public applied: string[] = [];
   public restarted: string[] = [];
   public exported: string[] = [];
-  constructor(private version = '15.1') {}
+  constructor(
+    private version = '15.1',
+    private opts: FakeBackendOpts = {}
+  ) {}
   async isAvailable(): Promise<boolean> {
     return true;
   }
@@ -46,6 +56,9 @@ class FakeBackend implements OsSettingsBackend {
     return { domain, entries: new Map() };
   }
   async exportRaw(domain: string): Promise<string> {
+    if (this.opts.failExportDomains?.includes(domain)) {
+      throw new Error(`Failed to export defaults domain "${domain}": maxBuffer exceeded`);
+    }
     this.exported.push(domain);
     return `<plist><dict><key>x</key><string>${domain}</string></dict></plist>`;
   }
@@ -57,6 +70,9 @@ class FakeBackend implements OsSettingsBackend {
     return { argv, display: `defaults ${argv.join(' ')}` };
   }
   async apply(entry: SettingEntry): Promise<void> {
+    if (this.opts.failApplyIds?.includes(entry.id)) {
+      throw new Error(`defaults write failed for ${entry.id}`);
+    }
     this.applied.push(entry.id);
   }
   async restartApp(app: string): Promise<void> {
@@ -215,6 +231,128 @@ describe('applySettings', () => {
     await setManualDone('macos__manual__enable-filevault', true);
     const after = await applySettings(backend, TEST_TUCK_DIR, { currentVersion: '15.1' });
     expect(after.pendingManual).toHaveLength(0);
+  });
+
+  // ── Finding 4: --no-restart must not claim apps were restarted ──
+  it('does not restart apps when restart is disabled, but reports restartRequired', async () => {
+    await seed();
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      restart: false,
+    });
+    // Nothing was actually restarted…
+    expect(result.restarted).toEqual([]);
+    expect(backend.restarted).toEqual([]);
+    // …but the applied dock setting still needs Dock restarted to take effect.
+    expect(result.restartRequired).toEqual(['Dock']);
+  });
+
+  // ── Finding 2: a defaults failure mid-replay is captured, not thrown away ──
+  it('records per-entry apply failures and still reports applied + backup', async () => {
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+    });
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.finder',
+      key: 'ShowPathbar',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+    });
+    const backend = new FakeBackend('15.1', {
+      failApplyIds: ['macos__com.apple.finder__ShowPathbar'],
+    });
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      restart: true,
+    });
+    expect(result.applied.map((a) => a.id)).toEqual(['macos__com.apple.dock__autohide']);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].id).toBe('macos__com.apple.finder__ShowPathbar');
+    expect(result.failed[0].error).toContain('defaults write failed');
+    expect(result.backupDir).not.toBeNull();
+  });
+
+  // ── Finding 1c: a failed pre-apply backup fails closed (nothing applied) ──
+  it('aborts before applying when a domain backup cannot be taken', async () => {
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+    });
+    const backend = new FakeBackend('15.1', { failExportDomains: ['com.apple.dock'] });
+    await expect(
+      applySettings(backend, TEST_TUCK_DIR, { currentVersion: '15.1' })
+    ).rejects.toThrow(/back up domain "com.apple.dock"/);
+    // Nothing was applied — fail closed.
+    expect(backend.applied).toEqual([]);
+  });
+
+  it('applies without a backup when --force overrides a failed backup', async () => {
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+    });
+    const backend = new FakeBackend('15.1', { failExportDomains: ['com.apple.dock'] });
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      force: true,
+    });
+    expect(result.applied.map((a) => a.id)).toEqual(['macos__com.apple.dock__autohide']);
+    expect(backend.applied).toEqual(['macos__com.apple.dock__autohide']);
+  });
+
+  // ── Finding 5: warn when captured on a different OS major version ──
+  it('flags applied settings captured on a different OS major version', async () => {
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+      capturedOsVersion: '14.0',
+    });
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      dryRun: true,
+    });
+    expect(result.osVersionMismatch).toEqual([
+      { id: 'macos__com.apple.dock__autohide', capturedOsVersion: '14.0' },
+    ]);
+  });
+
+  it('does not flag settings captured on the same OS major version', async () => {
+    await recordSetting(TEST_TUCK_DIR, {
+      os: 'macos',
+      domain: 'com.apple.dock',
+      key: 'autohide',
+      action: 'write',
+      type: 'boolean',
+      value: 'true',
+      capturedOsVersion: '15.0',
+    });
+    const backend = new FakeBackend('15.1');
+    const result = await applySettings(backend, TEST_TUCK_DIR, {
+      currentVersion: '15.1',
+      dryRun: true,
+    });
+    expect(result.osVersionMismatch).toEqual([]);
   });
 });
 

--- a/tests/lib/osSettings/plist.test.ts
+++ b/tests/lib/osSettings/plist.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePlist,
+  topLevelEntries,
+  stableStringify,
+  type PlistValue,
+} from '../../../src/lib/osSettings/plist.js';
+
+const SAMPLE = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>AppleInterfaceStyle</key>
+\t<string>Dark</string>
+\t<key>autohide</key>
+\t<true/>
+\t<key>showhidden</key>
+\t<false/>
+\t<key>tilesize</key>
+\t<integer>48</integer>
+\t<key>ratio</key>
+\t<real>1.5</real>
+\t<key>nested</key>
+\t<dict>
+\t\t<key>inner</key>
+\t\t<integer>1</integer>
+\t</dict>
+\t<key>list</key>
+\t<array>
+\t\t<string>a</string>
+\t\t<integer>2</integer>
+\t</array>
+\t<key>amp</key>
+\t<string>a &amp; b &lt;c&gt;</string>
+</dict>
+</plist>`;
+
+describe('parsePlist / topLevelEntries', () => {
+  it('parses all standard scalar and container types', () => {
+    const entries = topLevelEntries(SAMPLE);
+    expect(entries.get('AppleInterfaceStyle')).toEqual({ kind: 'string', value: 'Dark' });
+    expect(entries.get('autohide')).toEqual({ kind: 'boolean', value: true });
+    expect(entries.get('showhidden')).toEqual({ kind: 'boolean', value: false });
+    expect(entries.get('tilesize')).toEqual({ kind: 'integer', value: 48 });
+    expect(entries.get('ratio')).toEqual({ kind: 'real', value: 1.5 });
+
+    const nested = entries.get('nested');
+    expect(nested?.kind).toBe('dict');
+
+    const list = entries.get('list');
+    expect(list?.kind).toBe('array');
+  });
+
+  it('decodes XML entities in string values', () => {
+    const entries = topLevelEntries(SAMPLE);
+    expect(entries.get('amp')).toEqual({ kind: 'string', value: 'a & b <c>' });
+  });
+
+  it('returns an empty map for an empty (self-closing) root dict', () => {
+    const empty = `<?xml version="1.0"?><plist version="1.0"><dict/></plist>`;
+    expect(topLevelEntries(empty).size).toBe(0);
+  });
+
+  it('returns an empty map when the root is not a dict', () => {
+    const arr = `<plist version="1.0"><array><string>x</string></array></plist>`;
+    expect(topLevelEntries(arr).size).toBe(0);
+  });
+});
+
+describe('stableStringify', () => {
+  it('is order-independent for dicts', () => {
+    const a: PlistValue = {
+      kind: 'dict',
+      value: new Map<string, PlistValue>([
+        ['b', { kind: 'integer', value: 2 }],
+        ['a', { kind: 'integer', value: 1 }],
+      ]),
+    };
+    const b: PlistValue = {
+      kind: 'dict',
+      value: new Map<string, PlistValue>([
+        ['a', { kind: 'integer', value: 1 }],
+        ['b', { kind: 'integer', value: 2 }],
+      ]),
+    };
+    expect(stableStringify(a)).toBe(stableStringify(b));
+  });
+
+  it('distinguishes changed scalar values', () => {
+    const before = topLevelEntries(SAMPLE).get('tilesize')!;
+    const after: PlistValue = { kind: 'integer', value: 64 };
+    expect(stableStringify(before)).not.toBe(stableStringify(after));
+  });
+
+  it('round-trips a document through parsePlist without throwing', () => {
+    expect(() => parsePlist(SAMPLE)).not.toThrow();
+  });
+});

--- a/tests/lib/osSettings/version.test.ts
+++ b/tests/lib/osSettings/version.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseVersion,
+  compareVersions,
+  isVersionInRange,
+} from '../../../src/lib/osSettings/version.js';
+
+describe('parseVersion', () => {
+  it('parses dotted numeric versions into integer tuples', () => {
+    expect(parseVersion('15.1')).toEqual([15, 1]);
+    expect(parseVersion('13.6.1')).toEqual([13, 6, 1]);
+    expect(parseVersion('26')).toEqual([26]);
+  });
+
+  it('coerces non-numeric components to 0 rather than throwing', () => {
+    expect(parseVersion('15.beta')).toEqual([15, 0]);
+    expect(parseVersion('')).toEqual([0]);
+  });
+});
+
+describe('compareVersions', () => {
+  it('orders versions component-wise', () => {
+    expect(compareVersions('15.1', '15.0')).toBeGreaterThan(0);
+    expect(compareVersions('15.0', '15.1')).toBeLessThan(0);
+    expect(compareVersions('15', '15.0.0')).toBe(0);
+    expect(compareVersions('13.6.1', '13.6')).toBeGreaterThan(0);
+    expect(compareVersions('14', '9')).toBeGreaterThan(0);
+  });
+});
+
+describe('isVersionInRange', () => {
+  it('passes when there are no bounds', () => {
+    expect(isVersionInRange('15.1').ok).toBe(true);
+    expect(isVersionInRange('15.1', null, null).ok).toBe(true);
+  });
+
+  it('fails below the minimum', () => {
+    const res = isVersionInRange('12.0', '13.0');
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('>= 13.0');
+  });
+
+  it('fails above the maximum', () => {
+    const res = isVersionInRange('15.0', null, '14.0');
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('<= 14.0');
+  });
+
+  it('passes at the inclusive boundaries', () => {
+    expect(isVersionInRange('13.0', '13.0', '15.0').ok).toBe(true);
+    expect(isVersionInRange('15.0', '13.0', '15.0').ok).toBe(true);
+  });
+
+  it('passes an empty current version (undetectable OS must not block apply)', () => {
+    expect(isVersionInRange('', '13.0', '14.0').ok).toBe(true);
+  });
+});

--- a/tests/lib/readOnlyMode.test.ts
+++ b/tests/lib/readOnlyMode.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  enterReadOnlyMode,
+  isReadOnlyMode,
+  resetReadOnlyMode,
+  assertNotReadOnly,
+  withReadOnlyMode,
+} from '../../src/lib/readOnlyMode.js';
+import { ReadOnlyViolationError } from '../../src/errors.js';
+
+describe('readOnlyMode', () => {
+  afterEach(() => resetReadOnlyMode());
+
+  it('starts off and flips on via enterReadOnlyMode', () => {
+    expect(isReadOnlyMode()).toBe(false);
+    enterReadOnlyMode();
+    expect(isReadOnlyMode()).toBe(true);
+  });
+
+  it('is idempotent and reset restores the off state', () => {
+    enterReadOnlyMode();
+    enterReadOnlyMode();
+    expect(isReadOnlyMode()).toBe(true);
+    resetReadOnlyMode();
+    expect(isReadOnlyMode()).toBe(false);
+  });
+
+  it('assertNotReadOnly is a no-op when off', () => {
+    expect(() => assertNotReadOnly('read backend')).not.toThrow();
+  });
+
+  it('assertNotReadOnly throws ReadOnlyViolationError when on', () => {
+    enterReadOnlyMode();
+    expect(() => assertNotReadOnly('resolve secret "X"')).toThrow(ReadOnlyViolationError);
+  });
+
+  it('the violation error names the blocked operation and carries a stable code', () => {
+    enterReadOnlyMode();
+    try {
+      assertNotReadOnly('resolve secret "API_KEY"');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ReadOnlyViolationError);
+      const e = err as ReadOnlyViolationError;
+      expect(e.code).toBe('READ_ONLY_VIOLATION');
+      expect(e.message).toContain('resolve secret "API_KEY"');
+    }
+  });
+
+  it('withReadOnlyMode forces read-only for the callback then restores', async () => {
+    expect(isReadOnlyMode()).toBe(false);
+    const seen = await withReadOnlyMode(async () => isReadOnlyMode());
+    expect(seen).toBe(true);
+    expect(isReadOnlyMode()).toBe(false);
+  });
+
+  it('withReadOnlyMode restores the previous state even on throw', async () => {
+    await expect(
+      withReadOnlyMode(async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+    expect(isReadOnlyMode()).toBe(false);
+  });
+});

--- a/tests/lib/resolver-readonly.test.ts
+++ b/tests/lib/resolver-readonly.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The secret resolver must refuse to reach a backend while a read-only command
+ * is running — but a CACHE HIT (which touches no backend) is still allowed.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createResolver } from '../../src/lib/secretBackends/resolver.js';
+import { getGlobalCache, resetGlobalCache } from '../../src/lib/secretBackends/cache.js';
+import { enterReadOnlyMode, resetReadOnlyMode } from '../../src/lib/readOnlyMode.js';
+import { ReadOnlyViolationError } from '../../src/errors.js';
+import { securityConfigSchema } from '../../src/schemas/secrets.schema.js';
+
+const config = securityConfigSchema.parse({});
+
+describe('SecretResolver read-only guard', () => {
+  beforeEach(() => {
+    resetGlobalCache();
+    resetReadOnlyMode();
+  });
+  afterEach(() => {
+    resetReadOnlyMode();
+    resetGlobalCache();
+  });
+
+  it('throws ReadOnlyViolationError before touching any backend', async () => {
+    const resolver = createResolver('/test-home/.tuck', config);
+    enterReadOnlyMode();
+    await expect(resolver.resolveSecret('API_KEY')).rejects.toBeInstanceOf(ReadOnlyViolationError);
+  });
+
+  it('still serves a cached secret in read-only mode (no backend access)', async () => {
+    // Seed the shared cache the resolver reads from.
+    getGlobalCache().set('API_KEY', 'cached-value', 'local');
+    const resolver = createResolver('/test-home/.tuck', config);
+    enterReadOnlyMode();
+    const result = await resolver.resolveSecret('API_KEY');
+    expect(result?.value).toBe('cached-value');
+    expect(result?.cached).toBe(true);
+  });
+});

--- a/tests/lib/rulesFanout.test.ts
+++ b/tests/lib/rulesFanout.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Rules fan-out unit tests — the core library that turns one canonical rules
+ * file into many per-tool variants (CLAUDE.md, .cursorrules, GEMINI.md, …).
+ *
+ * All I/O runs against memfs (mocked in tests/setup.ts); os.homedir() is
+ * TEST_HOME. Writes go through resolveWriteTarget, so home-scoped variants land
+ * under TEST_HOME and repo-scoped variants under the repo root.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import {
+  trackRuleSet,
+  untrackRuleSet,
+  loadRulesManifest,
+  applyRuleSets,
+  computeSetStatus,
+  removeToolVariants,
+  defaultToolsForSource,
+  renderToolContent,
+  ruleSetId,
+  isKnownTool,
+  TOOL_TARGETS,
+  ALL_TOOLS,
+} from '../../src/lib/rulesFanout.js';
+import { defaultTemplateContext } from '../../src/lib/template.js';
+import { resetWriteContext } from '../../src/lib/writeContext.js';
+import { rulesManifestSchema } from '../../src/schemas/rules.schema.js';
+import { TEST_HOME, TEST_TUCK_DIR } from '../setup.js';
+
+const ctx = defaultTemplateContext({});
+
+const readManifest = (): unknown =>
+  JSON.parse(vol.readFileSync(join(TEST_TUCK_DIR, 'rules.json'), 'utf-8') as string);
+
+beforeEach(() => {
+  vol.reset();
+  resetWriteContext();
+  vol.mkdirSync(TEST_HOME, { recursive: true });
+  vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  resetWriteContext();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema + pure helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('rulesManifestSchema', () => {
+  it('rejects a repo-scoped set with no repoRoot', () => {
+    const bad = {
+      version: '1',
+      sets: {
+        x: {
+          source: '/repo/AGENTS.md',
+          scope: 'repo',
+          template: true,
+          tools: [{ tool: 'claude', strategy: 'materialize' }],
+          variables: {},
+          added: 'now',
+          modified: 'now',
+        },
+      },
+    };
+    expect(rulesManifestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects an unsafe tool path override (`..` escape)', () => {
+    const bad = {
+      version: '1',
+      sets: {
+        x: {
+          source: '~/AGENTS.md',
+          scope: 'home',
+          template: true,
+          tools: [{ tool: 'claude', strategy: 'materialize', path: '../../etc/evil' }],
+          variables: {},
+          added: 'now',
+          modified: 'now',
+        },
+      },
+    };
+    expect(rulesManifestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('accepts a minimal valid home-scoped set and applies strategy default', () => {
+    const good = {
+      version: '1',
+      sets: {
+        x: {
+          source: '~/AGENTS.md',
+          scope: 'home',
+          tools: [{ tool: 'gemini' }],
+          added: 'now',
+          modified: 'now',
+        },
+      },
+    };
+    const parsed = rulesManifestSchema.safeParse(good);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.sets.x.tools[0].strategy).toBe('materialize');
+      expect(parsed.data.sets.x.template).toBe(true);
+    }
+  });
+});
+
+describe('isKnownTool / defaultToolsForSource', () => {
+  it('recognizes exactly the registered tools', () => {
+    expect(ALL_TOOLS.every(isKnownTool)).toBe(true);
+    expect(isKnownTool('notatool')).toBe(false);
+  });
+
+  it('excludes the tool whose default target IS the canonical source', () => {
+    const root = TEST_HOME;
+    const tools = defaultToolsForSource(join(root, 'AGENTS.md'), root);
+    // `agents` maps to AGENTS.md, so it must be dropped to avoid self-fan-out.
+    expect(tools).not.toContain('agents');
+    expect(tools).toContain('claude');
+  });
+});
+
+describe('renderToolContent per-tool templating', () => {
+  const source = [
+    '# Rules',
+    '{{#if tool == "cursor"}}CURSOR-ONLY{{/if}}',
+    '{{#if tool == "claude"}}CLAUDE-ONLY{{/if}}',
+  ].join('\n');
+  const set = {
+    source: '~/AGENTS.md',
+    scope: 'home' as const,
+    template: true,
+    tools: [],
+    variables: {},
+    added: 'n',
+    modified: 'n',
+  };
+
+  it('binds `tool` so each variant keeps only its own block', () => {
+    const cursor = renderToolContent(source, set, 'cursor', ctx);
+    const claude = renderToolContent(source, set, 'claude', ctx);
+    expect(cursor).toContain('CURSOR-ONLY');
+    expect(cursor).not.toContain('CLAUDE-ONLY');
+    expect(claude).toContain('CLAUDE-ONLY');
+    expect(claude).not.toContain('CURSOR-ONLY');
+  });
+
+  it('returns the source verbatim when template=false', () => {
+    const raw = renderToolContent(source, { ...set, template: false }, 'cursor', ctx);
+    expect(raw).toBe(source);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// track
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('trackRuleSet', () => {
+  it('tracks a home-scoped source with default tools and persists rules.json', async () => {
+    vol.writeFileSync(join(TEST_HOME, 'AGENTS.md'), '# Rules\n');
+    const { id, set } = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'));
+
+    expect(set.scope).toBe('home');
+    expect(set.source).toBe('~/AGENTS.md');
+    expect(id).toBe('home__agents.md');
+    // Default tools = all except `agents` (its default target is the source).
+    expect(set.tools.map((t) => t.tool)).not.toContain('agents');
+    expect(set.tools.length).toBe(ALL_TOOLS.length - 1);
+
+    const onDisk = rulesManifestSchema.safeParse(readManifest());
+    expect(onDisk.success).toBe(true);
+  });
+
+  it('honors an explicit tool list and the symlink strategy', async () => {
+    vol.writeFileSync(join(TEST_HOME, 'AGENTS.md'), '# Rules\n');
+    const { set } = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), {
+      tools: ['claude', 'gemini'],
+      strategy: 'symlink',
+    });
+    expect(set.tools.map((t) => t.tool)).toEqual(['claude', 'gemini']);
+    expect(set.tools.every((t) => t.strategy === 'symlink')).toBe(true);
+  });
+
+  it('detects repo scope when the source is inside a git tree', async () => {
+    const repo = join(TEST_HOME, 'proj');
+    vol.mkdirSync(join(repo, '.git'), { recursive: true });
+    vol.writeFileSync(join(repo, 'AGENTS.md'), '# Rules\n');
+    const { set } = await trackRuleSet(TEST_TUCK_DIR, join(repo, 'AGENTS.md'), {
+      tools: ['claude'],
+    });
+    expect(set.scope).toBe('repo');
+    expect(set.repoRoot).toBe(repo);
+  });
+
+  it('throws FileNotFound for a missing source', async () => {
+    await expect(
+      trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'nope.md'))
+    ).rejects.toThrow();
+  });
+
+  it('re-tracking updates tools but preserves the original added timestamp', async () => {
+    vol.writeFileSync(join(TEST_HOME, 'AGENTS.md'), '# Rules\n');
+    const first = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), {
+      tools: ['claude'],
+    });
+    const second = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), {
+      tools: ['gemini'],
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.set.tools.map((t) => t.tool)).toEqual(['gemini']);
+    expect(second.set.added).toBe(first.set.added);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apply
+// ─────────────────────────────────────────────────────────────────────────────
+
+const trackHome = async (
+  content: string,
+  opts?: Parameters<typeof trackRuleSet>[2]
+): Promise<string> => {
+  vol.writeFileSync(join(TEST_HOME, 'AGENTS.md'), content);
+  const { id } = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), opts);
+  return id;
+};
+
+describe('applyRuleSets (materialize)', () => {
+  it('creates each tool variant with per-tool rendered content', async () => {
+    await trackHome(
+      '# R\n{{#if tool == "cursor"}}C{{/if}}{{#if tool == "gemini"}}G{{/if}}\n',
+      { tools: ['cursor', 'gemini'] }
+    );
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    const actions = results[0].applied.map((a) => [a.tool, a.action]);
+    expect(actions).toEqual([
+      ['cursor', 'created'],
+      ['gemini', 'created'],
+    ]);
+    expect(vol.readFileSync(join(TEST_HOME, '.cursorrules'), 'utf-8')).toContain('C');
+    expect(vol.readFileSync(join(TEST_HOME, '.cursorrules'), 'utf-8')).not.toContain('G');
+    expect(vol.readFileSync(join(TEST_HOME, 'GEMINI.md'), 'utf-8')).toContain('G');
+  });
+
+  it('is idempotent: a second apply skips up-to-date variants', async () => {
+    await trackHome('# R\n', { tools: ['claude'] });
+    await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    const second = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    expect(second[0].applied[0].action).toBe('skipped');
+    expect(second[0].applied[0].reason).toBe('up to date');
+  });
+
+  it('does not touch a differing variant without consent (non-interactive, no force)', async () => {
+    await trackHome('# NEW\n', { tools: ['claude'] });
+    vol.writeFileSync(join(TEST_HOME, 'CLAUDE.md'), '# HAND-EDITED\n');
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx });
+    expect(results[0].applied[0].action).toBe('skipped');
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).toBe('# HAND-EDITED\n');
+  });
+
+  it('overwrites a differing variant with force, snapshotting first', async () => {
+    await trackHome('# NEW\n', { tools: ['claude'] });
+    vol.writeFileSync(join(TEST_HOME, 'CLAUDE.md'), '# OLD\n');
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    expect(results[0].applied[0].action).toBe('updated');
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).toBe('# NEW\n');
+  });
+
+  it('overwrites when confirmOverwrite returns true', async () => {
+    await trackHome('# NEW\n', { tools: ['claude'] });
+    vol.writeFileSync(join(TEST_HOME, 'CLAUDE.md'), '# OLD\n');
+    const results = await applyRuleSets(TEST_TUCK_DIR, {
+      context: ctx,
+      confirmOverwrite: async () => true,
+    });
+    expect(results[0].applied[0].action).toBe('updated');
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).toBe('# NEW\n');
+  });
+
+  it('dry-run writes nothing', async () => {
+    await trackHome('# R\n', { tools: ['claude'] });
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, dryRun: true, force: true });
+    expect(results[0].applied[0].action).toBe('created');
+    expect(results[0].applied[0].reason).toBe('dry-run');
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(false);
+  });
+
+  it('restricts to a single set via id', async () => {
+    await trackHome('# R\n', { tools: ['claude'] });
+    // A second, repo-scoped set that must NOT be applied.
+    const repo = join(TEST_HOME, 'proj');
+    vol.mkdirSync(join(repo, '.git'), { recursive: true });
+    vol.writeFileSync(join(repo, 'AGENTS.md'), '# repo\n');
+    await trackRuleSet(TEST_TUCK_DIR, join(repo, 'AGENTS.md'), { tools: ['gemini'] });
+
+    const results = await applyRuleSets(TEST_TUCK_DIR, {
+      context: ctx,
+      force: true,
+      id: 'home__agents.md',
+    });
+    expect(results).toHaveLength(1);
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(true);
+    expect(vol.existsSync(join(repo, 'GEMINI.md'))).toBe(false);
+  });
+
+  it('throws when the id does not match any set', async () => {
+    await trackHome('# R\n', { tools: ['claude'] });
+    await expect(
+      applyRuleSets(TEST_TUCK_DIR, { context: ctx, id: 'nope' })
+    ).rejects.toThrow(/No tracked rule set/);
+  });
+});
+
+describe('applyRuleSets (symlink)', () => {
+  it('symlinks the variant at the canonical source', async () => {
+    await trackHome('# R\n', { tools: ['claude'], strategy: 'symlink' });
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    expect(results[0].applied[0].action).toBe('symlinked');
+    const target = join(TEST_HOME, 'CLAUDE.md');
+    expect(vol.lstatSync(target).isSymbolicLink()).toBe(true);
+    // Reading through the link yields the source content.
+    expect(vol.readFileSync(target, 'utf-8')).toBe('# R\n');
+  });
+
+  it('skips an already-correct symlink on re-apply', async () => {
+    await trackHome('# R\n', { tools: ['claude'], strategy: 'symlink' });
+    await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    const second = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    expect(second[0].applied[0].action).toBe('skipped');
+    expect(second[0].applied[0].reason).toBe('already linked');
+  });
+});
+
+describe('repo-scoped apply writes into the repo root', () => {
+  it('materializes variants under the repo, not $HOME', async () => {
+    const repo = join(TEST_HOME, 'proj');
+    vol.mkdirSync(join(repo, '.git'), { recursive: true });
+    vol.writeFileSync(join(repo, 'AGENTS.md'), '# repo rules\n');
+    const { id } = await trackRuleSet(TEST_TUCK_DIR, join(repo, 'AGENTS.md'), {
+      tools: ['claude', 'copilot'],
+    });
+    await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true, id });
+    expect(vol.readFileSync(join(repo, 'CLAUDE.md'), 'utf-8')).toBe('# repo rules\n');
+    // copilot nests under .github/ — the parent dir is created.
+    expect(vol.readFileSync(join(repo, '.github', 'copilot-instructions.md'), 'utf-8')).toBe(
+      '# repo rules\n'
+    );
+    // Nothing leaked into $HOME.
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// status / untrack
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computeSetStatus', () => {
+  it('reports missing → in-sync → drift across an edit', async () => {
+    const id = await trackHome('# v1\n', { tools: ['claude'] });
+    const manifest = await loadRulesManifest(TEST_TUCK_DIR);
+    const set = manifest.sets[id];
+
+    let status = await computeSetStatus(set, ctx);
+    expect(status.tools[0].status).toBe('missing');
+
+    await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true, id });
+    status = await computeSetStatus(set, ctx);
+    expect(status.tools[0].status).toBe('in-sync');
+
+    vol.writeFileSync(join(TEST_HOME, 'AGENTS.md'), '# v2 CHANGED\n');
+    status = await computeSetStatus(set, ctx);
+    expect(status.tools[0].status).toBe('drift');
+  });
+
+  it('flags a real file where a symlink is expected as foreign', async () => {
+    const id = await trackHome('# R\n', { tools: ['claude'], strategy: 'symlink' });
+    vol.writeFileSync(join(TEST_HOME, 'CLAUDE.md'), '# a real file\n');
+    const manifest = await loadRulesManifest(TEST_TUCK_DIR);
+    const status = await computeSetStatus(manifest.sets[id], ctx);
+    expect(status.tools[0].status).toBe('foreign');
+  });
+});
+
+describe('untrackRuleSet / removeToolVariants', () => {
+  it('removes the set from the manifest', async () => {
+    const id = await trackHome('# R\n', { tools: ['claude'] });
+    const removed = await untrackRuleSet(TEST_TUCK_DIR, id);
+    expect(removed).not.toBeNull();
+    const manifest = await loadRulesManifest(TEST_TUCK_DIR);
+    expect(Object.keys(manifest.sets)).toHaveLength(0);
+  });
+
+  it('removeToolVariants deletes generated files', async () => {
+    const id = await trackHome('# R\n', { tools: ['claude', 'gemini'] });
+    await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true, id });
+    const manifest = await loadRulesManifest(TEST_TUCK_DIR);
+    const removed = await removeToolVariants(manifest.sets[id]);
+    expect(removed).toHaveLength(2);
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(false);
+    expect(vol.existsSync(join(TEST_HOME, 'GEMINI.md'))).toBe(false);
+  });
+
+  it('untrack returns null for an unknown id', async () => {
+    expect(await untrackRuleSet(TEST_TUCK_DIR, 'ghost')).toBeNull();
+  });
+});
+
+describe('ruleSetId / TOOL_TARGETS invariants', () => {
+  it('gives home and repo sources distinct id namespaces', () => {
+    const home = ruleSetId({ scope: 'home', source: '~/AGENTS.md' });
+    expect(home.startsWith('home__')).toBe(true);
+  });
+
+  it('maps every tool to a distinct destination', () => {
+    const dests = Object.values(TOOL_TARGETS);
+    expect(new Set(dests).size).toBe(dests.length);
+  });
+});

--- a/tests/lib/rulesFanout.test.ts
+++ b/tests/lib/rulesFanout.test.ts
@@ -13,6 +13,7 @@ import {
   trackRuleSet,
   untrackRuleSet,
   loadRulesManifest,
+  saveRulesManifest,
   applyRuleSets,
   computeSetStatus,
   removeToolVariants,
@@ -23,6 +24,7 @@ import {
   TOOL_TARGETS,
   ALL_TOOLS,
 } from '../../src/lib/rulesFanout.js';
+import type { RuleSet } from '../../src/schemas/rules.schema.js';
 import { defaultTemplateContext } from '../../src/lib/template.js';
 import { resetWriteContext } from '../../src/lib/writeContext.js';
 import { rulesManifestSchema } from '../../src/schemas/rules.schema.js';
@@ -396,7 +398,7 @@ describe('untrackRuleSet / removeToolVariants', () => {
     const id = await trackHome('# R\n', { tools: ['claude', 'gemini'] });
     await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true, id });
     const manifest = await loadRulesManifest(TEST_TUCK_DIR);
-    const removed = await removeToolVariants(manifest.sets[id]);
+    const { removed } = await removeToolVariants(manifest.sets[id]);
     expect(removed).toHaveLength(2);
     expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(false);
     expect(vol.existsSync(join(TEST_HOME, 'GEMINI.md'))).toBe(false);
@@ -404,6 +406,189 @@ describe('untrackRuleSet / removeToolVariants', () => {
 
   it('untrack returns null for an unknown id', async () => {
     expect(await untrackRuleSet(TEST_TUCK_DIR, 'ghost')).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression: verified code-review findings
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('trackRuleSet self-target rejection (explicit --tool)', () => {
+  it('rejects materializing a tool onto its own canonical source', async () => {
+    vol.writeFileSync(join(TEST_HOME, 'AGENTS.md'), '# canonical\n');
+    // `agents` maps to AGENTS.md — fanning it onto AGENTS.md would clobber it.
+    await expect(
+      trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), { tools: ['agents'] })
+    ).rejects.toThrow(/canonical source itself/);
+    // Nothing tracked, source untouched.
+    expect(vol.existsSync(join(TEST_TUCK_DIR, 'rules.json'))).toBe(false);
+    expect(vol.readFileSync(join(TEST_HOME, 'AGENTS.md'), 'utf-8')).toBe('# canonical\n');
+  });
+
+  it('rejects symlinking a tool onto its own canonical source', async () => {
+    vol.writeFileSync(join(TEST_HOME, 'CLAUDE.md'), '# canonical\n');
+    await expect(
+      trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'CLAUDE.md'), {
+        tools: ['claude'],
+        strategy: 'symlink',
+      })
+    ).rejects.toThrow(/canonical source itself/);
+    // The source is not turned into a self-referencing symlink.
+    expect(vol.lstatSync(join(TEST_HOME, 'CLAUDE.md')).isSymbolicLink()).toBe(false);
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).toBe('# canonical\n');
+  });
+});
+
+describe('re-track cleans up variants of dropped tools', () => {
+  it('removes the dropped tool variant when consent is given (force)', async () => {
+    const id = await trackHome('# R\n', { tools: ['claude', 'gemini'] });
+    await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true, id });
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(true);
+    expect(vol.existsSync(join(TEST_HOME, 'GEMINI.md'))).toBe(true);
+
+    const res = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), {
+      tools: ['claude'],
+      force: true,
+    });
+    expect(res.orphansRemoved).toHaveLength(1);
+    expect(res.orphansSkipped).toHaveLength(0);
+    // Dropped tool's variant gone; retained tool's variant untouched.
+    expect(vol.existsSync(join(TEST_HOME, 'GEMINI.md'))).toBe(false);
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(true);
+  });
+
+  it('leaves the orphan in place (reported) when non-interactive without consent', async () => {
+    const id = await trackHome('# R\n', { tools: ['claude', 'gemini'] });
+    await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true, id });
+
+    const res = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), {
+      tools: ['claude'],
+    });
+    expect(res.orphansRemoved).toHaveLength(0);
+    expect(res.orphansSkipped).toHaveLength(1);
+    expect(vol.existsSync(join(TEST_HOME, 'GEMINI.md'))).toBe(true);
+  });
+
+  it('never deletes a foreign variant of a dropped tool, even with consent', async () => {
+    await trackHome('# R\n', { tools: ['claude', 'gemini'] });
+    // A symlink where a materialized GEMINI.md is expected → status 'foreign'
+    // (clearly not a file tuck generated), so cleanup must preserve it.
+    vol.writeFileSync(join(TEST_HOME, 'other.md'), '# elsewhere\n');
+    vol.symlinkSync(join(TEST_HOME, 'other.md'), join(TEST_HOME, 'GEMINI.md'));
+    const res = await trackRuleSet(TEST_TUCK_DIR, join(TEST_HOME, 'AGENTS.md'), {
+      tools: ['claude'],
+      force: true, // even WITH consent, a foreign entry is preserved
+    });
+    expect(res.orphansRemoved).toHaveLength(0);
+    expect(res.orphansSkipped).toContain(join(TEST_HOME, 'GEMINI.md'));
+    expect(vol.lstatSync(join(TEST_HOME, 'GEMINI.md')).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe('applyRuleSets per-set error isolation', () => {
+  const injectBadRepoSet = async (id: string, repoRoot: string): Promise<void> => {
+    const manifest = await loadRulesManifest(TEST_TUCK_DIR);
+    const bad: RuleSet = {
+      source: join(repoRoot, 'AGENTS.md'),
+      scope: 'repo',
+      repoRoot,
+      template: true,
+      tools: [{ tool: 'gemini', strategy: 'materialize' }],
+      variables: {},
+      added: 'n',
+      modified: 'n',
+    };
+    manifest.sets[id] = bad;
+    await saveRulesManifest(TEST_TUCK_DIR, manifest);
+  };
+
+  it('applies a valid home set even when another set has a missing repoRoot', async () => {
+    await trackHome('# home\n', { tools: ['claude'] });
+    await injectBadRepoSet('repo__missing', '/no/such/repo');
+
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    const home = results.find((r) => r.id === 'home__agents.md');
+    const bad = results.find((r) => r.id === 'repo__missing');
+    expect(home?.applied[0]?.action).toBe('created');
+    expect(bad?.error).toBeTruthy();
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(true);
+  });
+
+  it('rejects repoRoot "/" and a non-git directory, writing nothing for them', async () => {
+    await trackHome('# home\n', { tools: ['claude'] });
+    await injectBadRepoSet('repo__root', '/');
+    vol.mkdirSync(join(TEST_HOME, 'plaindir'), { recursive: true });
+    await injectBadRepoSet('repo__nogit', join(TEST_HOME, 'plaindir'));
+
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true });
+    const rootSet = results.find((r) => r.id === 'repo__root');
+    const nogit = results.find((r) => r.id === 'repo__nogit');
+    expect(rootSet?.error).toMatch(/too broad|root/i);
+    expect(nogit?.error).toMatch(/git/i);
+    // No variant leaked into "/" or the non-git dir; the valid set still applied.
+    expect(vol.existsSync(join(TEST_HOME, 'plaindir', 'GEMINI.md'))).toBe(false);
+    expect(vol.existsSync(join(TEST_HOME, 'CLAUDE.md'))).toBe(true);
+  });
+
+  it('accepts a genuine git repoRoot', async () => {
+    const repo = join(TEST_HOME, 'proj');
+    vol.mkdirSync(join(repo, '.git'), { recursive: true });
+    vol.writeFileSync(join(repo, 'AGENTS.md'), '# repo\n');
+    const { id } = await trackRuleSet(TEST_TUCK_DIR, join(repo, 'AGENTS.md'), {
+      tools: ['gemini'],
+    });
+    const results = await applyRuleSets(TEST_TUCK_DIR, { context: ctx, force: true, id });
+    expect(results[0].error).toBeUndefined();
+    expect(vol.existsSync(join(repo, 'GEMINI.md'))).toBe(true);
+  });
+});
+
+describe('applyRuleSets dry-run never prompts', () => {
+  it('does not call confirmOverwrite for a differing materialize variant', async () => {
+    await trackHome('# NEW\n', { tools: ['claude'] });
+    vol.writeFileSync(join(TEST_HOME, 'CLAUDE.md'), '# OLD\n');
+    let prompted = false;
+    const results = await applyRuleSets(TEST_TUCK_DIR, {
+      context: ctx,
+      dryRun: true,
+      confirmOverwrite: async () => {
+        prompted = true;
+        return true;
+      },
+    });
+    expect(prompted).toBe(false);
+    expect(results[0].applied[0].action).toBe('skipped');
+    expect(results[0].applied[0].reason).toBe('would prompt to overwrite');
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).toBe('# OLD\n');
+  });
+
+  it('does not call confirmOverwrite for a symlink variant replacing a real file', async () => {
+    await trackHome('# R\n', { tools: ['claude'], strategy: 'symlink' });
+    vol.writeFileSync(join(TEST_HOME, 'CLAUDE.md'), '# real\n');
+    let prompted = false;
+    const results = await applyRuleSets(TEST_TUCK_DIR, {
+      context: ctx,
+      dryRun: true,
+      confirmOverwrite: async () => {
+        prompted = true;
+        return true;
+      },
+    });
+    expect(prompted).toBe(false);
+    expect(results[0].applied[0].action).toBe('skipped');
+    expect(results[0].applied[0].reason).toBe('would prompt to overwrite');
+    expect(vol.readFileSync(join(TEST_HOME, 'CLAUDE.md'), 'utf-8')).toBe('# real\n');
+  });
+});
+
+describe('computeSetStatus survives an unreadable variant', () => {
+  it('reports a directory at the variant path as foreign instead of throwing', async () => {
+    const id = await trackHome('# R\n', { tools: ['claude'] });
+    // A directory where a materialized file is expected → readFile would EISDIR.
+    vol.mkdirSync(join(TEST_HOME, 'CLAUDE.md'), { recursive: true });
+    const manifest = await loadRulesManifest(TEST_TUCK_DIR);
+    const status = await computeSetStatus(manifest.sets[id], ctx);
+    expect(status.tools[0].status).toBe('foreign');
   });
 });
 

--- a/tests/lib/scanner.test.ts
+++ b/tests/lib/scanner.test.ts
@@ -470,3 +470,17 @@ MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn
     });
   });
 });
+
+describe('unquoted generic assignment capture (value-encryption regression)', () => {
+  it('captures only the value, never the KEY= prefix, for unquoted assignments', async () => {
+    const { scanContent } = await import('../../src/lib/secrets/scanner.js');
+    const line = 'GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789';
+    const matches = scanContent(line);
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    for (const m of matches) {
+      // A whole-span fallback would include the key text; rewriting that span
+      // (redaction or value encryption) would destroy the `GITHUB_TOKEN=` key.
+      expect(m.value).not.toContain('GITHUB_TOKEN=');
+    }
+  });
+});

--- a/tests/lib/secrets/allowlist.test.ts
+++ b/tests/lib/secrets/allowlist.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for the centralized secret allowlist.
+ *
+ * The allowlist is a committed `secrets.allow.json` file that suppresses
+ * scanner findings the user has marked safe. These tests exercise the lib in
+ * isolation over the memfs sandbox: fingerprinting, CRUD, scoped matching, and
+ * the summary filter that every scan path runs through.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { readFileSync } from 'fs';
+import { TEST_TUCK_DIR } from '../../setup.js';
+import {
+  computeFingerprint,
+  getAllowlistPath,
+  loadAllowlist,
+  addAllowlistEntryByFingerprint,
+  addAllowlistEntryForValue,
+  removeAllowlistEntries,
+  listAllowlistEntries,
+  isMatchAllowed,
+  filterSummaryWithAllowlist,
+} from '../../../src/lib/secrets/allowlist.js';
+import type { ScanSummary, SecretMatch } from '../../../src/lib/secrets/scanner.js';
+
+const SECRET = 'AKIAIOSFODNN7EXAMPLE';
+
+const makeMatch = (over: Partial<SecretMatch> = {}): SecretMatch => ({
+  patternId: 'aws-access-key-id',
+  patternName: 'AWS Access Key ID',
+  severity: 'high',
+  value: SECRET,
+  redactedValue: '[REDACTED]',
+  line: 1,
+  column: 1,
+  context: 'key = [REDACTED]',
+  placeholder: 'AWS_ACCESS_KEY_ID',
+  ...over,
+});
+
+const makeSummary = (matches: SecretMatch[], collapsedPath = '~/.config/app'): ScanSummary => ({
+  totalFiles: 1,
+  scannedFiles: 1,
+  skippedFiles: 0,
+  filesWithSecrets: matches.length > 0 ? 1 : 0,
+  totalSecrets: matches.length,
+  bySeverity: {
+    critical: matches.filter((m) => m.severity === 'critical').length,
+    high: matches.filter((m) => m.severity === 'high').length,
+    medium: matches.filter((m) => m.severity === 'medium').length,
+    low: matches.filter((m) => m.severity === 'low').length,
+  },
+  results: [
+    {
+      path: '/test-home/.config/app',
+      collapsedPath,
+      hasSecrets: matches.length > 0,
+      matches,
+      criticalCount: matches.filter((m) => m.severity === 'critical').length,
+      highCount: matches.filter((m) => m.severity === 'high').length,
+      mediumCount: matches.filter((m) => m.severity === 'medium').length,
+      lowCount: matches.filter((m) => m.severity === 'low').length,
+      skipped: false,
+    },
+  ],
+});
+
+describe('secret allowlist lib', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_TUCK_DIR, { recursive: true });
+  });
+  afterEach(() => {
+    vol.reset();
+  });
+
+  describe('computeFingerprint', () => {
+    it('produces a stable 64-char sha256 hex digest', () => {
+      const fp = computeFingerprint(SECRET);
+      expect(fp).toMatch(/^[a-f0-9]{64}$/);
+      expect(fp).toBe(computeFingerprint(SECRET));
+    });
+
+    it('differs for different values', () => {
+      expect(computeFingerprint('a')).not.toBe(computeFingerprint('b'));
+    });
+  });
+
+  describe('load/save', () => {
+    it('returns an empty store when the file is absent', async () => {
+      const store = await loadAllowlist(TEST_TUCK_DIR);
+      expect(store.entries).toEqual([]);
+    });
+
+    it('never writes the raw secret value to disk', async () => {
+      await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, { reason: 'example from docs' });
+      const raw = readFileSync(getAllowlistPath(TEST_TUCK_DIR), 'utf-8');
+      expect(raw).not.toContain(SECRET);
+      expect(raw).toContain(computeFingerprint(SECRET));
+    });
+
+    it('throws on a corrupt allowlist rather than silently disabling scanning', async () => {
+      vol.writeFileSync(getAllowlistPath(TEST_TUCK_DIR), '{ not valid json');
+      await expect(loadAllowlist(TEST_TUCK_DIR)).rejects.toThrow(/Failed to load secret allowlist/);
+    });
+  });
+
+  describe('add/remove/list', () => {
+    it('adds an entry and lists it', async () => {
+      const entry = await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, {
+        reason: 'test placeholder',
+        pattern: 'aws-access-key-id',
+        path: '~/.config/app',
+        addedBy: 'tester',
+      });
+      expect(entry.fingerprint).toBe(computeFingerprint(SECRET));
+      expect(entry.addedBy).toBe('tester');
+
+      const entries = await listAllowlistEntries(TEST_TUCK_DIR);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].reason).toBe('test placeholder');
+    });
+
+    it('deduplicates by fingerprint+pattern+path (refresh, not append)', async () => {
+      await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, {
+        reason: 'first',
+        pattern: 'aws-access-key-id',
+        path: '~/.config/app',
+      });
+      await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, {
+        reason: 'second',
+        pattern: 'aws-access-key-id',
+        path: '~/.config/app',
+      });
+      const entries = await listAllowlistEntries(TEST_TUCK_DIR);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].reason).toBe('second');
+    });
+
+    it('keeps entries with different scopes separate', async () => {
+      await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, { reason: 'global' });
+      await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, {
+        reason: 'scoped',
+        path: '~/.config/app',
+      });
+      expect(await listAllowlistEntries(TEST_TUCK_DIR)).toHaveLength(2);
+    });
+
+    it('removes entries by fingerprint prefix', async () => {
+      const entry = await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, { reason: 'x' });
+      const removed = await removeAllowlistEntries(TEST_TUCK_DIR, entry.fingerprint.slice(0, 8));
+      expect(removed).toHaveLength(1);
+      expect(await listAllowlistEntries(TEST_TUCK_DIR)).toHaveLength(0);
+    });
+
+    it('returns empty when no entry matches the removal prefix', async () => {
+      await addAllowlistEntryForValue(TEST_TUCK_DIR, SECRET, { reason: 'x' });
+      const removed = await removeAllowlistEntries(TEST_TUCK_DIR, 'deadbeef');
+      expect(removed).toHaveLength(0);
+      expect(await listAllowlistEntries(TEST_TUCK_DIR)).toHaveLength(1);
+    });
+  });
+
+  describe('isMatchAllowed', () => {
+    it('matches a global (unscoped) entry anywhere', () => {
+      const entries = [
+        { fingerprint: computeFingerprint(SECRET), reason: 'r', addedAt: 'now' },
+      ];
+      expect(isMatchAllowed(makeMatch(), '~/anywhere', entries)).toBe(true);
+    });
+
+    it('respects a pattern scope', () => {
+      const entries = [
+        {
+          fingerprint: computeFingerprint(SECRET),
+          reason: 'r',
+          pattern: 'aws-access-key-id',
+          addedAt: 'now',
+        },
+      ];
+      expect(isMatchAllowed(makeMatch(), '~/x', entries)).toBe(true);
+      expect(isMatchAllowed(makeMatch({ patternId: 'other' }), '~/x', entries)).toBe(false);
+    });
+
+    it('respects a path scope', () => {
+      const entries = [
+        {
+          fingerprint: computeFingerprint(SECRET),
+          reason: 'r',
+          path: '~/.config/app',
+          addedAt: 'now',
+        },
+      ];
+      expect(isMatchAllowed(makeMatch(), '~/.config/app', entries)).toBe(true);
+      expect(isMatchAllowed(makeMatch(), '~/.config/other', entries)).toBe(false);
+    });
+
+    it('does not match a different value', () => {
+      const entries = [
+        { fingerprint: computeFingerprint('different'), reason: 'r', addedAt: 'now' },
+      ];
+      expect(isMatchAllowed(makeMatch(), '~/x', entries)).toBe(false);
+    });
+  });
+
+  describe('filterSummaryWithAllowlist', () => {
+    it('is a no-op with no entries', () => {
+      const summary = makeSummary([makeMatch()]);
+      expect(filterSummaryWithAllowlist(summary, [])).toBe(summary);
+    });
+
+    it('drops an allowlisted finding and recomputes counts', () => {
+      const summary = makeSummary([makeMatch()]);
+      const entries = [
+        { fingerprint: computeFingerprint(SECRET), reason: 'r', addedAt: 'now' },
+      ];
+      const filtered = filterSummaryWithAllowlist(summary, entries);
+      expect(filtered.totalSecrets).toBe(0);
+      expect(filtered.filesWithSecrets).toBe(0);
+      expect(filtered.results).toHaveLength(0);
+      expect(filtered.bySeverity.high).toBe(0);
+      // Scan-level counters are unchanged.
+      expect(filtered.scannedFiles).toBe(1);
+    });
+
+    it('keeps non-allowlisted findings in a mixed file', () => {
+      const kept = makeMatch({ value: 'REAL_SECRET_VALUE_123', line: 2 });
+      const summary = makeSummary([makeMatch(), kept]);
+      const entries = [
+        { fingerprint: computeFingerprint(SECRET), reason: 'r', addedAt: 'now' },
+      ];
+      const filtered = filterSummaryWithAllowlist(summary, entries);
+      expect(filtered.totalSecrets).toBe(1);
+      expect(filtered.filesWithSecrets).toBe(1);
+      expect(filtered.results[0].matches[0].value).toBe('REAL_SECRET_VALUE_123');
+    });
+  });
+});

--- a/tests/lib/sessionKeyCache.test.ts
+++ b/tests/lib/sessionKeyCache.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  getCachedKeystorePassphrase,
+  primeSessionKeyCache,
+  hasSessionKey,
+  setSessionKeyTtl,
+  clearSessionKeyCache,
+} from '../../src/lib/crypto/sessionKeyCache.js';
+import { enterReadOnlyMode, resetReadOnlyMode } from '../../src/lib/readOnlyMode.js';
+
+describe('sessionKeyCache', () => {
+  afterEach(() => {
+    clearSessionKeyCache();
+    resetReadOnlyMode();
+  });
+
+  it('unlocks the keystore at most once per session (one fetch for many reads)', async () => {
+    const fetch = vi.fn(async () => 'pw');
+    expect(await getCachedKeystorePassphrase(fetch)).toBe('pw');
+    expect(await getCachedKeystorePassphrase(fetch)).toBe('pw');
+    expect(await getCachedKeystorePassphrase(fetch)).toBe('pw');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a null answer too (keystore has no key) without re-fetching', async () => {
+    const fetch = vi.fn(async () => null);
+    expect(await getCachedKeystorePassphrase(fetch)).toBeNull();
+    expect(await getCachedKeystorePassphrase(fetch)).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('never fetches in read-only mode and returns null when nothing is cached', async () => {
+    enterReadOnlyMode();
+    const fetch = vi.fn(async () => 'pw');
+    expect(await getCachedKeystorePassphrase(fetch)).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(hasSessionKey()).toBe(false);
+  });
+
+  it('serves a value cached BEFORE read-only mode without touching the keystore', async () => {
+    primeSessionKeyCache('cached-pw');
+    enterReadOnlyMode();
+    const fetch = vi.fn(async () => 'fresh-pw');
+    expect(await getCachedKeystorePassphrase(fetch)).toBe('cached-pw');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('re-fetches after the TTL expires', async () => {
+    setSessionKeyTtl(0); // every entry is immediately stale
+    const fetch = vi
+      .fn<[], Promise<string | null>>()
+      .mockResolvedValueOnce('one')
+      .mockResolvedValueOnce('two');
+    expect(await getCachedKeystorePassphrase(fetch)).toBe('one');
+    // wait a tick so Date.now() advances past expiresAt
+    await new Promise((r) => setTimeout(r, 2));
+    expect(await getCachedKeystorePassphrase(fetch)).toBe('two');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearSessionKeyCache forgets the cached value', async () => {
+    primeSessionKeyCache('pw');
+    expect(hasSessionKey()).toBe(true);
+    clearSessionKeyCache();
+    expect(hasSessionKey()).toBe(false);
+  });
+});

--- a/tests/lib/stateModel-readonly.test.ts
+++ b/tests/lib/stateModel-readonly.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The read-only guarantee, end-to-end at the state-model layer.
+ *
+ * An encrypted tracked file holds ciphertext in the repo and plaintext live.
+ * Read-only commands (status/diff/list) must classify its drift WITHOUT ever
+ * unlocking the keystore. These tests prove:
+ *   1. A read-only state computation never calls the keystore, even for an
+ *      encrypted file (the keystore mock throws if touched).
+ *   2. A full (non-read-only) run warms the keyed-HMAC drift cache, after which
+ *      a read-only run accurately reports "ok" (unchanged) and "drift-local"
+ *      (after the live file is edited) — again with zero keystore access.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+
+// If a read-only path ever reaches the OS keystore, retrieve() throws and the
+// test fails loudly — this is the regression tripwire for the guarantee.
+vi.mock('../../src/lib/crypto/keystore/index.js', () => ({
+  getKeystore: async () => ({
+    retrieve: async () => {
+      throw new Error('KEYSTORE ACCESSED — read-only guarantee violated');
+    },
+    store: async () => undefined,
+    delete: async () => undefined,
+    isAvailable: async () => true,
+    getName: () => 'mock',
+  }),
+  getKeystoreName: async () => 'mock',
+  clearKeystoreCache: () => undefined,
+  TUCK_SERVICE: 'tuck-dotfiles',
+  TUCK_ACCOUNT: 'backup-encryption',
+}));
+
+import { computeFileState } from '../../src/lib/stateModel.js';
+import { encryptFileContent } from '../../src/lib/crypto/fileEncryption.js';
+import { getFileChecksum } from '../../src/lib/files.js';
+import { resetDriftKeyCache } from '../../src/lib/crypto/driftCache.js';
+import { enterReadOnlyMode, resetReadOnlyMode } from '../../src/lib/readOnlyMode.js';
+import {
+  primeSessionKeyCache,
+  clearSessionKeyCache,
+} from '../../src/lib/crypto/sessionKeyCache.js';
+import type { TrackedFileOutput } from '../../src/schemas/manifest.schema.js';
+
+const HOME = '/test-home';
+const TUCK = '/test-home/.tuck';
+const PASS = 'test-pass';
+const PLAINTEXT = 'secret file body\nline two\n';
+
+const makeEncryptedFile = (checksum: string): TrackedFileOutput => ({
+  source: '~/.secretrc',
+  destination: 'files/secretrc',
+  category: 'shell',
+  strategy: 'copy',
+  encrypted: true,
+  template: false,
+  added: '2026-01-01T00:00:00.000Z',
+  modified: '2026-01-01T00:00:00.000Z',
+  checksum,
+  bundle: 'default',
+});
+
+/** Write repo ciphertext + live plaintext; return the file entry + repo checksum. */
+const setupEncrypted = async (): Promise<{ file: TrackedFileOutput; repoChecksum: string }> => {
+  const cipher = await encryptFileContent(Buffer.from(PLAINTEXT), PASS);
+  vol.mkdirSync(`${TUCK}/files`, { recursive: true });
+  vol.writeFileSync(`${TUCK}/files/secretrc`, cipher);
+  vol.writeFileSync(`${HOME}/.secretrc`, PLAINTEXT);
+  const repoChecksum = await getFileChecksum(`${TUCK}/files/secretrc`);
+  return { file: makeEncryptedFile(repoChecksum), repoChecksum };
+};
+
+describe('stateModel read-only guarantee', () => {
+  beforeEach(() => {
+    resetDriftKeyCache();
+    clearSessionKeyCache();
+    resetReadOnlyMode();
+  });
+  afterEach(() => {
+    resetReadOnlyMode();
+    clearSessionKeyCache();
+  });
+
+  it('read-only classification of an encrypted file never touches the keystore', async () => {
+    const { file } = await setupEncrypted();
+    enterReadOnlyMode();
+    // No drift cache warmed yet → cannot know → degrades to ok, but crucially
+    // does NOT throw (the keystore mock would throw if accessed).
+    const entry = await computeFileState(TUCK, 'f1', file);
+    expect(entry.state).toBe('ok');
+  });
+
+  it('a full run warms the cache; a later read-only run stays accurate and prompt-free', async () => {
+    const { file } = await setupEncrypted();
+
+    // Full (non-read-only) run: decrypt with the primed session passphrase (so
+    // the keystore is never fetched) and record the keyed-HMAC fingerprint.
+    primeSessionKeyCache(PASS);
+    const warm = await computeFileState(TUCK, 'f1', file);
+    expect(warm.state).toBe('ok');
+
+    // Now go read-only and drop the cached passphrase entirely.
+    clearSessionKeyCache();
+    enterReadOnlyMode();
+
+    // Unchanged live file → cache says match → ok, with no keystore access.
+    const unchanged = await computeFileState(TUCK, 'f1', file);
+    expect(unchanged.state).toBe('ok');
+
+    // Edit the live file → cache says mismatch → drift-local, still no keystore.
+    vol.writeFileSync(`${HOME}/.secretrc`, 'the user edited this locally\n');
+    const edited = await computeFileState(TUCK, 'f1', file);
+    expect(edited.state).toBe('drift-local');
+  });
+  it('unknown-fingerprint branch still reports drift-repo (free repo-vs-manifest compare)', async () => {
+    const { file } = await setupEncrypted();
+    // Manifest pins a DIFFERENT checksum than the repo copy (e.g. a git pull
+    // advanced the repo file). No cache entry exists (cold cache), so the
+    // fingerprint compare is 'unknown' — the repo drift must still surface.
+    const stale = { ...file, checksum: '0'.repeat(64) };
+    enterReadOnlyMode();
+    const state = await computeFileState(TUCK, 'secretrc', stale);
+    expect(state.state).toBe('drift-repo');
+  });
+
+  it('degrades (never crashes) when the live path is a directory in read-only mode', async () => {
+    const { file } = await setupEncrypted();
+    vol.rmSync(`${HOME}/.secretrc`);
+    vol.mkdirSync(`${HOME}/.secretrc`);
+    enterReadOnlyMode();
+    // EISDIR on the live read must not escape as UNEXPECTED_ERROR.
+    const state = await computeFileState(TUCK, 'secretrc', file);
+    expect(['ok', 'drift-local', 'modified']).toContain(state.state);
+  });
+});
+

--- a/tests/lib/trackPipeline-secrets.test.ts
+++ b/tests/lib/trackPipeline-secrets.test.ts
@@ -22,6 +22,7 @@ import { SecretsDetectedError } from '../../src/errors.js';
 const AWS_SECRET = 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n';
 
 const selectMock = vi.fn();
+const textMock = vi.fn();
 
 // Minimal ui mock: strict-mode paths need only logger; the interactive 'ignore'
 // path needs a controllable prompts.select plus colour/logging stubs.
@@ -40,6 +41,7 @@ vi.mock('../../src/ui/index.js', () => {
     },
     prompts: {
       select: selectMock,
+      text: textMock,
       confirm: vi.fn().mockResolvedValue(false),
       confirmDangerous: vi.fn().mockResolvedValue(false),
     },
@@ -91,5 +93,34 @@ describe('track pipeline secret gate', () => {
     // The secret-bearing repo file must be filtered out — never returned for
     // tracking despite the identity-vs-live-path mismatch.
     expect(prepared).toHaveLength(0);
+  });
+
+  it('allowlists findings and tracks the file when the user chooses "Mark as safe"', async () => {
+    selectMock.mockResolvedValue('allow');
+    textMock.mockResolvedValue('example value from docs');
+    await initTestTuck();
+
+    const filePath = join(TEST_HOME, '.config', 'app.conf');
+    vol.mkdirSync(join(TEST_HOME, '.config'), { recursive: true });
+    vol.writeFileSync(filePath, AWS_SECRET);
+
+    const { preparePathsForTracking } = await import('../../src/lib/trackPipeline.js');
+    const { listAllowlistEntries } = await import('../../src/lib/secrets/allowlist.js');
+
+    const prepared = await preparePathsForTracking([{ path: filePath }], TEST_TUCK_DIR, {
+      secretHandling: 'interactive',
+    });
+
+    // The file is tracked (returned) because the finding is now allowlisted...
+    expect(prepared).toHaveLength(1);
+    // ...and a committed, auditable allowlist entry was recorded.
+    const entries = await listAllowlistEntries(TEST_TUCK_DIR);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries[0].reason).toBe('example value from docs');
+
+    // A subsequent scan of the same file no longer flags it.
+    const { scanForSecrets } = await import('../../src/lib/secrets/index.js');
+    const rescan = await scanForSecrets([filePath], TEST_TUCK_DIR);
+    expect(rescan.filesWithSecrets).toBe(0);
   });
 });

--- a/tests/lib/trackPipeline-secrets.test.ts
+++ b/tests/lib/trackPipeline-secrets.test.ts
@@ -95,6 +95,42 @@ describe('track pipeline secret gate', () => {
     expect(prepared).toHaveLength(0);
   });
 
+  it('does not block --key add when the subtree secret is allowlisted (strict mode)', async () => {
+    await initTestTuck();
+
+    // A JSON file whose TRACKED subtree (mcpServers) carries an AWS key, plus an
+    // untracked oauthToken alongside it.
+    const secret = 'AKIAIOSFODNN7EXAMPLE';
+    const filePath = join(TEST_HOME, '.claude.json');
+    vol.writeFileSync(
+      filePath,
+      JSON.stringify({ mcpServers: { git: { token: secret } }, oauthToken: 'x' })
+    );
+
+    const { preparePathsForTracking } = await import('../../src/lib/trackPipeline.js');
+
+    // Without an allowlist entry, strict mode blocks (the subtree scan detects it).
+    await expect(
+      preparePathsForTracking([{ path: filePath }], TEST_TUCK_DIR, {
+        jsonKey: 'mcpServers',
+        secretHandling: 'strict',
+      })
+    ).rejects.toBeInstanceOf(SecretsDetectedError);
+
+    // Allowlist the finding, then the SAME strict add must proceed — previously
+    // the raw scanContent call never consulted the allowlist, so it re-blocked
+    // forever.
+    const { addAllowlistEntryForValue } = await import('../../src/lib/secrets/allowlist.js');
+    await addAllowlistEntryForValue(TEST_TUCK_DIR, secret, { reason: 'example key from docs' });
+
+    const prepared = await preparePathsForTracking([{ path: filePath }], TEST_TUCK_DIR, {
+      jsonKey: 'mcpServers',
+      secretHandling: 'strict',
+    });
+    expect(prepared).toHaveLength(1);
+    expect(prepared[0].jsonKey).toBe('mcpServers');
+  });
+
   it('allowlists findings and tracks the file when the user chooses "Mark as safe"', async () => {
     selectMock.mockResolvedValue('allow');
     textMock.mockResolvedValue('example value from docs');

--- a/tests/lib/undoHint.test.ts
+++ b/tests/lib/undoHint.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { undoBreadcrumb, UNDO_BREADCRUMB_TITLE } from '../../src/lib/undoHint.js';
+
+describe('undoBreadcrumb', () => {
+  it('pins the breadcrumb to a specific snapshot id when provided', () => {
+    const line = undoBreadcrumb('2026-07-09-101112');
+    expect(line).toContain('tuck undo 2026-07-09-101112');
+    expect(line).toContain('tuck undo --latest');
+  });
+
+  it('falls back to --latest when no snapshot id is known', () => {
+    expect(undoBreadcrumb()).toBe('Undo this change: tuck undo --latest');
+  });
+
+  it('exposes a stable note title', () => {
+    expect(UNDO_BREADCRUMB_TITLE).toBe('Undo');
+  });
+});

--- a/tests/lib/updater.test.ts
+++ b/tests/lib/updater.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Update-check skip conditions.
+ *
+ * The update prompt uses a raw readline (waitForEnterOrCancel) that bypasses the
+ * clack interactive gate. Under any non-interactive mode — an explicit
+ * `--non-interactive`, `--json`, or a non-TTY stdin — an agent driving tuck in a
+ * PTY would otherwise block forever. `shouldSkipUpdateCheck()` must return true
+ * in every one of those cases.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldSkipUpdateCheck } from '../../src/lib/updater.js';
+import { setNonInteractive } from '../../src/lib/agentMode.js';
+import { setJsonMode } from '../../src/lib/jsonOutput.js';
+
+const originalStdinTTY = process.stdin.isTTY;
+const originalCI = process.env.CI;
+const originalNpx = process.env.npm_execpath;
+const originalNoUpdate = process.env.NO_UPDATE_CHECK;
+
+const setStdinTTY = (value: boolean): void => {
+  Object.defineProperty(process.stdin, 'isTTY', { value, writable: true, configurable: true });
+};
+
+beforeEach(() => {
+  setNonInteractive(false);
+  setJsonMode(false);
+  delete process.env.CI;
+  delete process.env.npm_execpath;
+  delete process.env.NO_UPDATE_CHECK;
+  // A real interactive terminal: without the fixes below this is the only case
+  // where the update check would proceed.
+  setStdinTTY(true);
+});
+
+afterEach(() => {
+  setNonInteractive(false);
+  setJsonMode(false);
+  setStdinTTY(originalStdinTTY as boolean);
+  if (originalCI === undefined) delete process.env.CI;
+  else process.env.CI = originalCI;
+  if (originalNpx === undefined) delete process.env.npm_execpath;
+  else process.env.npm_execpath = originalNpx;
+  if (originalNoUpdate === undefined) delete process.env.NO_UPDATE_CHECK;
+  else process.env.NO_UPDATE_CHECK = originalNoUpdate;
+});
+
+describe('shouldSkipUpdateCheck', () => {
+  it('does NOT skip on a plain interactive TTY with no suppression signal', () => {
+    expect(shouldSkipUpdateCheck()).toBe(false);
+  });
+
+  it('skips when the explicit --non-interactive flag is set, even on a TTY', () => {
+    setNonInteractive(true);
+    expect(shouldSkipUpdateCheck()).toBe(true);
+  });
+
+  it('skips in JSON mode even on a TTY (the prompt would corrupt the envelope)', () => {
+    setJsonMode(true);
+    expect(shouldSkipUpdateCheck()).toBe(true);
+  });
+
+  it('skips when stdin is not a TTY (piped / agent / CI)', () => {
+    setStdinTTY(false);
+    expect(shouldSkipUpdateCheck()).toBe(true);
+  });
+
+  it('skips in CI', () => {
+    process.env.CI = 'true';
+    expect(shouldSkipUpdateCheck()).toBe(true);
+  });
+
+  it('skips when NO_UPDATE_CHECK is set', () => {
+    process.env.NO_UPDATE_CHECK = '1';
+    expect(shouldSkipUpdateCheck()).toBe(true);
+  });
+});

--- a/tests/lib/valueEncryption.test.ts
+++ b/tests/lib/valueEncryption.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Value-level (SOPS-style) encryption unit tests.
+ *
+ * Uses real node crypto (PBKDF2/AES-256-GCM) on small payloads and the memfs
+ * fs mock from tests/setup.ts for the file-level helpers. Value counts are kept
+ * small so the 600k-iteration KDF stays well under the suite timeout.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vol } from 'memfs';
+import { join } from 'path';
+import {
+  formatValueToken,
+  parseValueToken,
+  isValueToken,
+  hasEncryptedValues,
+  countEncryptedValues,
+  findValueTokens,
+  encryptValue,
+  decryptValue,
+  encryptContentValues,
+  decryptContentValues,
+  encryptFileValues,
+  decryptFileValues,
+  fileHasEncryptedValues,
+} from '../../src/lib/secrets/valueEncryption.js';
+import { scanContent } from '../../src/lib/secrets/scanner.js';
+import type { SecretMatch } from '../../src/lib/secrets/scanner.js';
+import { TEST_HOME } from '../setup.js';
+
+const PASS = 'correct horse battery staple';
+
+/** Build a minimal SecretMatch list from raw values (only `value` matters here). */
+const matchesOf = (...values: string[]): SecretMatch[] =>
+  values.map((value, i) => ({
+    patternId: 'test',
+    patternName: 'Test',
+    severity: 'high',
+    value,
+    redactedValue: '[REDACTED]',
+    line: i + 1,
+    column: 1,
+    context: '',
+    placeholder: 'SECRET',
+  }));
+
+describe('valueEncryption', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  describe('token helpers', () => {
+    it('formats and parses a token round-trip', () => {
+      const token = formatValueToken('YWJjMTIz');
+      expect(token).toBe('ENC[tuck:v1:YWJjMTIz]');
+      expect(parseValueToken(token)).toBe('YWJjMTIz');
+      expect(isValueToken(token)).toBe(true);
+    });
+
+    it('rejects non-tokens', () => {
+      expect(parseValueToken('ENC[other:xyz]')).toBeNull();
+      expect(parseValueToken('plain value')).toBeNull();
+      expect(isValueToken('ENC[tuck:v1:]')).toBe(false); // empty payload
+      expect(isValueToken('ENC[tuck:v1:abc] trailing')).toBe(false);
+    });
+
+    it('detects, counts, and finds tokens in content', () => {
+      const content = 'A=ENC[tuck:v1:AAAA]\nB=plain\nC=ENC[tuck:v1:BBBB]';
+      expect(hasEncryptedValues(content)).toBe(true);
+      expect(countEncryptedValues(content)).toBe(2);
+      expect(findValueTokens(content)).toEqual(['ENC[tuck:v1:AAAA]', 'ENC[tuck:v1:BBBB]']);
+    });
+
+    it('reports no tokens for plain content', () => {
+      expect(hasEncryptedValues('KEY=value')).toBe(false);
+      expect(countEncryptedValues('KEY=value')).toBe(0);
+      expect(findValueTokens('KEY=value')).toEqual([]);
+    });
+  });
+
+  describe('single value encrypt/decrypt', () => {
+    it('round-trips a value', async () => {
+      const token = await encryptValue('s3cr3t-value', PASS);
+      expect(isValueToken(token)).toBe(true);
+      expect(token).not.toContain('s3cr3t-value');
+      expect(await decryptValue(token, PASS)).toBe('s3cr3t-value');
+    });
+
+    it('produces different ciphertext for the same value (fresh salt/IV)', async () => {
+      const a = await encryptValue('same', PASS);
+      const b = await encryptValue('same', PASS);
+      expect(a).not.toBe(b);
+      expect(await decryptValue(a, PASS)).toBe('same');
+      expect(await decryptValue(b, PASS)).toBe('same');
+    });
+
+    it('preserves values containing regex $-sequences verbatim', async () => {
+      const tricky = '$&$1${x}$$literal';
+      const token = await encryptValue(tricky, PASS);
+      expect(await decryptValue(token, PASS)).toBe(tricky);
+    });
+
+    it('fails to decrypt with the wrong passphrase', async () => {
+      const token = await encryptValue('value', PASS);
+      await expect(decryptValue(token, 'wrong')).rejects.toThrow();
+    });
+
+    it('rejects a tampered token', async () => {
+      const token = await encryptValue('value', PASS);
+      const payload = parseValueToken(token)!;
+      const bytes = Buffer.from(payload, 'base64');
+      bytes[bytes.length - 1] ^= 0xff; // flip a ciphertext bit
+      const tampered = formatValueToken(bytes.toString('base64'));
+      await expect(decryptValue(tampered, PASS)).rejects.toThrow();
+    });
+
+    it('rejects empty passphrases', async () => {
+      await expect(encryptValue('x', '')).rejects.toThrow();
+      await expect(decryptValue('ENC[tuck:v1:AAAA]', '')).rejects.toThrow();
+    });
+  });
+
+  describe('content-level encrypt/decrypt', () => {
+    it('encrypts only the values, keeping keys/structure/comments plaintext', async () => {
+      const content = [
+        '# my env file',
+        'AWS_KEY=AKIAIOSFODNN7EXAMPLE',
+        'DB_PASSWORD=supersecretpassword123',
+        '',
+        'PLAIN=not-a-secret',
+      ].join('\n');
+      const matches = matchesOf('AKIAIOSFODNN7EXAMPLE', 'supersecretpassword123');
+
+      const { content: enc, encrypted } = await encryptContentValues(content, matches, PASS);
+      expect(encrypted).toBe(2);
+      // Keys, comment, and blank line untouched.
+      expect(enc).toContain('# my env file');
+      expect(enc).toContain('AWS_KEY=ENC[tuck:v1:');
+      expect(enc).toContain('DB_PASSWORD=ENC[tuck:v1:');
+      expect(enc).toContain('PLAIN=not-a-secret');
+      // Secrets gone.
+      expect(enc).not.toContain('AKIAIOSFODNN7EXAMPLE');
+      expect(enc).not.toContain('supersecretpassword123');
+
+      const { content: dec, decrypted } = await decryptContentValues(enc, PASS);
+      expect(decrypted).toBe(2);
+      expect(dec).toBe(content);
+    });
+
+    it('round-trips a JSON file preserving structure', async () => {
+      const content = JSON.stringify(
+        { name: 'app', apiKey: 'sk-live-abcdef123456', nested: { token: 'ghp_secretvalue1234' } },
+        null,
+        2
+      );
+      const matches = matchesOf('sk-live-abcdef123456', 'ghp_secretvalue1234');
+
+      const { content: enc } = await encryptContentValues(content, matches, PASS);
+      // Still valid JSON with the same keys/shape.
+      const parsed = JSON.parse(enc);
+      expect(parsed.name).toBe('app');
+      expect(parsed.apiKey.startsWith('ENC[tuck:v1:')).toBe(true);
+      expect(parsed.nested.token.startsWith('ENC[tuck:v1:')).toBe(true);
+
+      const { content: dec } = await decryptContentValues(enc, PASS);
+      expect(dec).toBe(content);
+    });
+
+    it('derives one key for many values (shared salt across new tokens)', async () => {
+      const content = 'A=aaa111\nB=bbb222\nC=ccc333';
+      const matches = matchesOf('aaa111', 'bbb222', 'ccc333');
+      const { content: enc, encrypted } = await encryptContentValues(content, matches, PASS);
+      expect(encrypted).toBe(3);
+      const { content: dec } = await decryptContentValues(enc, PASS);
+      expect(dec).toBe(content);
+    });
+
+    it('replaces every occurrence of a repeated value with one token', async () => {
+      const content = 'A=dupvalue\nB=dupvalue';
+      const matches = matchesOf('dupvalue');
+      const { content: enc, encrypted } = await encryptContentValues(content, matches, PASS);
+      expect(encrypted).toBe(1);
+      const tokens = findValueTokens(enc);
+      expect(tokens).toHaveLength(2);
+      expect(tokens[0]).toBe(tokens[1]); // same token reused
+      const { content: dec } = await decryptContentValues(enc, PASS);
+      expect(dec).toBe(content);
+    });
+
+    it('is idempotent: re-encrypting already-encrypted content is a no-op', async () => {
+      const content = 'A=secretvalue1';
+      const matches = matchesOf('secretvalue1');
+      const { content: enc } = await encryptContentValues(content, matches, PASS);
+
+      // Feed the base64 payload back in as if it were a detected secret — it must
+      // NOT be re-encrypted because it only lives inside an existing token.
+      const payload = parseValueToken(findValueTokens(enc)[0])!;
+      const { content: enc2, encrypted, skipped } = await encryptContentValues(
+        enc,
+        matchesOf(payload),
+        PASS
+      );
+      expect(encrypted).toBe(0);
+      expect(skipped).toBe(1);
+      expect(enc2).toBe(enc);
+    });
+
+    it('leaves existing tokens byte-identical when encrypting a newly added value', async () => {
+      const first = 'A=alpha111';
+      const { content: encFirst } = await encryptContentValues(first, matchesOf('alpha111'), PASS);
+      const existingToken = findValueTokens(encFirst)[0];
+
+      const combined = `${encFirst}\nB=beta222`;
+      const { content: encSecond, encrypted } = await encryptContentValues(
+        combined,
+        matchesOf('beta222'),
+        PASS
+      );
+      expect(encrypted).toBe(1);
+      // The first token is untouched (clean git diff).
+      expect(encSecond).toContain(existingToken);
+      const { content: dec } = await decryptContentValues(encSecond, PASS);
+      expect(dec).toBe('A=alpha111\nB=beta222');
+    });
+
+    it('counts failures without throwing when throwOnFailure is false', async () => {
+      const { content: enc } = await encryptContentValues('A=val111', matchesOf('val111'), PASS);
+      const res = await decryptContentValues(enc, 'wrong-pass', { throwOnFailure: false });
+      expect(res.decrypted).toBe(0);
+      expect(res.failed).toBe(1);
+      expect(res.content).toBe(enc); // untouched
+    });
+
+    it('throws on the first undecryptable token by default', async () => {
+      const { content: enc } = await encryptContentValues('A=val111', matchesOf('val111'), PASS);
+      await expect(decryptContentValues(enc, 'wrong-pass')).rejects.toThrow();
+    });
+
+    it('integrates with the real scanner to locate spans', async () => {
+      const content = 'export GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd';
+      const found = scanContent(content);
+      expect(found.length).toBeGreaterThan(0);
+      const { content: enc } = await encryptContentValues(content, found, PASS);
+      // The raw secret is gone and an inline token took its place.
+      expect(enc).not.toContain('ghp_0123456789abcdefABCDEF0123456789abcd');
+      expect(hasEncryptedValues(enc)).toBe(true);
+      const { content: dec } = await decryptContentValues(enc, PASS);
+      expect(dec).toBe(content);
+    });
+  });
+
+  describe('file-level operations', () => {
+    const filepath = join(TEST_HOME, '.env');
+
+    it('encrypts and decrypts a file in place, preserving structure', async () => {
+      const original = 'HOST=localhost\nSECRET=topsecretvalue1\n';
+      vol.writeFileSync(filepath, original);
+
+      const encRes = await encryptFileValues(filepath, matchesOf('topsecretvalue1'), PASS);
+      expect(encRes.changed).toBe(true);
+      expect(encRes.encrypted).toBe(1);
+
+      const onDisk = vol.readFileSync(filepath, 'utf-8') as string;
+      expect(onDisk).toContain('HOST=localhost');
+      expect(onDisk).not.toContain('topsecretvalue1');
+      expect(await fileHasEncryptedValues(filepath)).toBe(true);
+
+      const decRes = await decryptFileValues(filepath, PASS);
+      expect(decRes.changed).toBe(true);
+      expect(decRes.decrypted).toBe(1);
+      expect(vol.readFileSync(filepath, 'utf-8')).toBe(original);
+    });
+
+    it('does not rewrite a file with nothing to encrypt', async () => {
+      vol.writeFileSync(filepath, 'HOST=localhost\n');
+      const res = await encryptFileValues(filepath, matchesOf('not-present-value'), PASS);
+      expect(res.changed).toBe(false);
+      expect(res.encrypted).toBe(0);
+    });
+
+    it('does not rewrite a file with no tokens on decrypt', async () => {
+      vol.writeFileSync(filepath, 'HOST=localhost\n');
+      const res = await decryptFileValues(filepath, PASS);
+      expect(res.changed).toBe(false);
+      expect(res.decrypted).toBe(0);
+    });
+
+    it('fileHasEncryptedValues is false for missing paths and directories', async () => {
+      expect(await fileHasEncryptedValues(join(TEST_HOME, 'nope'))).toBe(false);
+      vol.mkdirSync(join(TEST_HOME, 'adir'));
+      expect(await fileHasEncryptedValues(join(TEST_HOME, 'adir'))).toBe(false);
+    });
+  });
+});

--- a/tests/lib/valueEncryption.test.ts
+++ b/tests/lib/valueEncryption.test.ts
@@ -5,7 +5,7 @@
  * fs mock from tests/setup.ts for the file-level helpers. Value counts are kept
  * small so the 600k-iteration KDF stays well under the suite timeout.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { vol } from 'memfs';
 import { join } from 'path';
 import {
@@ -22,6 +22,7 @@ import {
   encryptFileValues,
   decryptFileValues,
   fileHasEncryptedValues,
+  keyDerivation,
 } from '../../src/lib/secrets/valueEncryption.js';
 import { scanContent } from '../../src/lib/secrets/scanner.js';
 import type { SecretMatch } from '../../src/lib/secrets/scanner.js';
@@ -207,6 +208,53 @@ describe('valueEncryption', () => {
       expect(encrypted).toBe(0);
       expect(skipped).toBe(1);
       expect(enc2).toBe(enc);
+    });
+
+    it('does not corrupt an earlier token when a later value occurs inside it', async () => {
+      // Deterministic collision: every token literally contains the fixed prefix
+      // `ENC[tuck:v1:`, so a secret value of `tuck:v1` is GUARANTEED to appear
+      // inside the first (longer) value's token. A single-pass value→token swap
+      // would splice the `tuck:v1` value's token into the middle of the first
+      // token's base64, destroying it. The two-pass replacement must not.
+      const longValue = 'AKIAIOSFODNN7EXAMPLELONGSECRET';
+      const collidingValue = 'tuck:v1';
+      const content = `LONG=${longValue}\nSHORT=${collidingValue}`;
+      const matches = matchesOf(longValue, collidingValue);
+
+      const { content: enc, encrypted } = await encryptContentValues(content, matches, PASS);
+      expect(encrypted).toBe(2);
+      // Both plaintext values are gone and two intact tokens remain.
+      expect(enc).not.toContain(longValue);
+      expect(findValueTokens(enc)).toHaveLength(2);
+
+      // The real proof: a clean round trip. Under the old single-pass code the
+      // first token is corrupted and this decrypt would fail / not restore.
+      const { content: dec, decrypted } = await decryptContentValues(enc, PASS);
+      expect(decrypted).toBe(2);
+      expect(dec).toBe(content);
+    });
+
+    it('derives the key once for many same-salt tokens (per-salt cache)', async () => {
+      // All tokens from a single encrypt call share one salt.
+      const values = Array.from({ length: 6 }, (_, i) => `secretvalue${i}xyz`);
+      const content = values.map((v, i) => `K${i}=${v}`).join('\n');
+      const { content: enc, encrypted } = await encryptContentValues(
+        content,
+        matchesOf(...values),
+        PASS
+      );
+      expect(encrypted).toBe(6);
+
+      const deriveSpy = vi.spyOn(keyDerivation, 'derive');
+      try {
+        const { content: dec, decrypted } = await decryptContentValues(enc, PASS);
+        expect(decrypted).toBe(6);
+        expect(dec).toBe(content);
+        // One derivation for all six same-salt tokens, not six.
+        expect(deriveSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        deriveSpy.mockRestore();
+      }
     });
 
     it('leaves existing tokens byte-identical when encrypting a newly added value', async () => {


### PR DESCRIPTION
## Release: second feature batch (9 features)

Everything below was implemented by Opus agents, adversarially reviewed by Fable (findings posted as PR comments), fixed, and merged only after the full CI matrix (Ubuntu/macOS/Windows × Node 18/20/22) was green. The merged tree passes typecheck, lint, build, and 2098 tests.

### Features

- **JSON-path-scoped tracking** (#109) — `tuck add <file> --key mcpServers` tracks only a JSON subtree; apply/restore write it back at the tracked path, leaving machine state/tokens untouched. Subtree-scoped secret scanning on sync, subtree-aware `tuck diff`, prototype-pollution guards.
- **Rules fan-out** (#108) — one canonical rules file materialized/symlinked to CLAUDE.md, .cursorrules, .windsurfrules, copilot-instructions.md, GEMINI.md (global or per-repo) with per-tool template overrides.
- **Read-only no-prompt guarantee** (#116) — `status`/`diff`/`list` never unlock the keystore or touch a secret backend; encrypted-file drift detection via a machine-local keyed-HMAC cache.
- **Value-level (SOPS-style) encryption** (#115) — encrypt only secret values in place; keys/structure/comments stay plaintext so git diff/merge keep working.
- **Fix-instead-of-block secret remediation** (#112) — one-keystroke redact-and-store at scan time plus a centralized, auditable allowlist (`tuck secrets allow`).
- **Structured JSON three-way smart merge** (#110) — key-level merge policies per file; conflicts surfaced on sync instead of silent overwrite; merge bases persist across aborted runs.
- **Safe first apply** (#111) — full diff summary + auto-snapshot before any write; adopt-first `tuck init`; undo breadcrumbs after every destructive flow.
- **Versioned OS settings** (#113) — capture/replay macOS `defaults` with OS-version guards plus a tracked manual-steps checklist.
- **Agent-native CLI audit** (#105) — `--non-interactive` fail-fast everywhere, ANSI suppression on non-TTY, contextual git error classification with raw output preserved in the JSON envelope (`error.git_output`).

### Review process

16 Fable reviews produced ~55 verified findings (5 blockers, ~25 majors) — including secret-loss paths, a deletion-resurrection loop, missing non-interactive confirmation gates, a false-drift HMAC race, and Windows-only path bugs — all fixed with regression tests before merge.

**Do not merge without review** — created for release sign-off; merging triggers semantic-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)